### PR TITLE
feat(todo): ソート機能を追加（Phase A-2）

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -25,11 +25,13 @@ async function createTodo(fastify, req, reply) {
 async function getTodos(fastify, req, reply) {
   try {
     const userId = req.user.id;
-    const filters = {
+    const options = {
       completed: req.query.completed === 'true' ? true : req.query.completed === 'false' ? false : undefined,
       priority: req.query.priority,
+      sortBy: req.query.sortBy,
+      sortOrder: req.query.sortOrder,
     };
-    const todos = await todoService.getTodosByUserId(fastify, userId, filters);
+    const todos = await todoService.getTodosByUserId(fastify, userId, options);
     reply.code(200).send(todos.map((t) => t.toJSON()));
   } catch (error) {
     handleTodoError(fastify, reply, error, 'Failed to get todos');
@@ -112,11 +114,27 @@ async function searchTodos(fastify, req, reply) {
       priority: req.query.priority,
       completed:
         req.query.completed === 'true' ? true : req.query.completed === 'false' ? false : undefined,
+      sortBy: req.query.sortBy,
+      sortOrder: req.query.sortOrder,
     };
     const todos = await todoService.searchTodos(fastify, userId, params);
     reply.code(200).send(todos.map((t) => t.toJSON()));
   } catch (error) {
     handleTodoError(fastify, reply, error, 'Search failed');
+  }
+}
+
+async function reorderTodos(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const todoIds = req.body.todoIds;
+    if (!Array.isArray(todoIds) || todoIds.length === 0) {
+      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
+    }
+    await todoService.reorderTodos(fastify, userId, todoIds);
+    reply.code(204).send();
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Reorder failed');
   }
 }
 
@@ -128,4 +146,5 @@ module.exports = {
   deleteTodo,
   toggleComplete,
   searchTodos,
+  reorderTodos,
 };

--- a/backend/migrations/20260301093644-add-sort-order-to-todos.js
+++ b/backend/migrations/20260301093644-add-sort-order-to-todos.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('todos', 'sort_order', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    });
+    await queryInterface.addIndex('todos', ['sort_order']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('todos', ['sort_order']);
+    await queryInterface.removeColumn('todos', 'sort_order');
+  }
+};

--- a/backend/migrations/20260301093644-add-sort-order-to-todos.js
+++ b/backend/migrations/20260301093644-add-sort-order-to-todos.js
@@ -9,6 +9,15 @@ module.exports = {
       defaultValue: 0,
     });
     await queryInterface.addIndex('todos', ['sort_order']);
+    // 既存行を createdAt 順で連番化（sort_order 同値での未定義順を防ぐ）
+    await queryInterface.sequelize.query(`
+      UPDATE todos t
+      INNER JOIN (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at) - 1 AS rn
+        FROM todos
+      ) s ON t.id = s.id
+      SET t.sort_order = s.rn
+    `);
   },
 
   async down(queryInterface) {

--- a/backend/migrations/20260301120000-backfill-sort-order-by-created-at.js
+++ b/backend/migrations/20260301120000-backfill-sort-order-by-created-at.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // 既存行を createdAt 順で連番化（初回マイグレーション適用後の環境向け）
+    await queryInterface.sequelize.query(`
+      UPDATE todos t
+      INNER JOIN (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at) - 1 AS rn
+        FROM todos
+      ) s ON t.id = s.id
+      SET t.sort_order = s.rn
+    `);
+  },
+
+  async down() {
+    // データロールバックは行わない（sort_order を 0 に戻すだけの価値は低い）
+  }
+};

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -46,6 +46,12 @@ module.exports = (sequelize) => {
         allowNull: true,
         field: 'due_date',
       },
+      sortOrder: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+        field: 'sort_order',
+      },
     },
     {
       tableName: 'todos',

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -10,6 +10,7 @@ const {
   deleteTodo,
   toggleComplete,
   searchTodos,
+  reorderTodos,
 } = require('../../../controllers/todoController');
 
 module.exports = async function (fastify, opts) {
@@ -90,11 +91,30 @@ module.exports = async function (fastify, opts) {
         properties: {
           completed: { type: 'string', enum: ['true', 'false'] },
           priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+          sortBy: { type: 'string', enum: ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'] },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'] },
         },
       },
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getTodos(fastify, request, reply),
+  });
+  fastify.put('/todos/reorder', {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['todoIds'],
+        properties: {
+          todoIds: {
+            type: 'array',
+            items: { type: 'integer' },
+            minItems: 1,
+          },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => reorderTodos(fastify, request, reply),
   });
   fastify.get('/todos/search', {
     schema: {
@@ -104,6 +124,8 @@ module.exports = async function (fastify, opts) {
           q: { type: 'string', maxLength: 255 },
           completed: { type: 'string', enum: ['true', 'false'] },
           priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+          sortBy: { type: 'string', enum: ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'] },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'] },
         },
       },
     },

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -13,7 +13,7 @@ function buildOrder(sequelize, sortBy, sortOrder) {
   if (SORT_BY_ALLOWED.includes(sortBy)) {
     return [[sortBy, dir]];
   }
-  return [['createdAt', 'ASC']];
+  return [['createdAt', dir]];
 }
 
 /**
@@ -165,16 +165,21 @@ async function searchTodos(fastify, userId, params = {}) {
  */
 async function reorderTodos(fastify, userId, todoIds) {
   if (!Array.isArray(todoIds) || todoIds.length === 0) return;
+  const safeIds = todoIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0);
+  if (safeIds.length === 0) return;
   const transaction = await fastify.sequelize.transaction();
   try {
-    for (let i = 0; i < todoIds.length; i++) {
-      const id = Number(todoIds[i]);
-      if (!Number.isInteger(id)) continue;
-      await fastify.models.Todo.update(
-        { sortOrder: i },
-        { where: { id, userId }, transaction }
-      );
-    }
+    const sequelize = fastify.sequelize;
+    const caseWhen = safeIds.map((_, i) => `WHEN id = :id${i} THEN ${i}`).join(' ');
+    const inList = safeIds.map((_, i) => `:id${i}`).join(', ');
+    const replacements = { userId };
+    safeIds.forEach((id, i) => {
+      replacements[`id${i}`] = id;
+    });
+    await sequelize.query(
+      `UPDATE todos SET sort_order = CASE ${caseWhen} END, updated_at = NOW() WHERE user_id = :userId AND id IN (${inList})`,
+      { replacements, transaction }
+    );
     await transaction.commit();
   } catch (err) {
     await transaction.rollback();

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -2,6 +2,20 @@
 
 const { Op } = require('sequelize');
 
+const SORT_BY_ALLOWED = ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'];
+const SORT_ORDER_ALLOWED = ['asc', 'desc'];
+
+function buildOrder(sequelize, sortBy, sortOrder) {
+  const dir = SORT_ORDER_ALLOWED.includes(sortOrder) ? sortOrder : 'asc';
+  if (sortBy === 'priority') {
+    return [[sequelize.literal("FIELD(priority, 'high', 'medium', 'low')"), dir]];
+  }
+  if (SORT_BY_ALLOWED.includes(sortBy)) {
+    return [[sortBy, dir]];
+  }
+  return [['createdAt', 'ASC']];
+}
+
 /**
  * 指定ユーザーの Todo を作成する
  * @param {object} fastify - Fastify インスタンス
@@ -21,23 +35,28 @@ async function createTodo(fastify, userId, todoData) {
 }
 
 /**
- * ユーザーの Todo 一覧をフィルタ付きで取得する
+ * ユーザーの Todo 一覧をフィルタ・ソート付きで取得する
  * @param {object} fastify - Fastify インスタンス
  * @param {number} userId - ユーザー ID
- * @param {object} filters - { completed?: boolean, priority?: string }
+ * @param {object} options - { completed?, priority?, sortBy?, sortOrder? }
  * @returns {Promise<object[]>} Todo 配列
  */
-async function getTodosByUserId(fastify, userId, filters = {}) {
+async function getTodosByUserId(fastify, userId, options = {}) {
   const where = { userId };
-  if (typeof filters.completed === 'boolean') {
-    where.completed = filters.completed;
+  if (typeof options.completed === 'boolean') {
+    where.completed = options.completed;
   }
-  if (filters.priority && ['low', 'medium', 'high'].includes(filters.priority)) {
-    where.priority = filters.priority;
+  if (options.priority && ['low', 'medium', 'high'].includes(options.priority)) {
+    where.priority = options.priority;
   }
+  const order = buildOrder(
+    fastify.sequelize,
+    options.sortBy,
+    options.sortOrder
+  );
   return fastify.models.Todo.findAll({
     where,
-    order: [['createdAt', 'ASC']],
+    order,
   });
 }
 
@@ -104,10 +123,10 @@ async function toggleComplete(fastify, todoId, userId) {
 }
 
 /**
- * タイトル・説明文で検索（キーワード + 優先度・完了のフィルタ）
+ * タイトル・説明文で検索（キーワード + 優先度・完了のフィルタ + ソート）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} userId - ユーザー ID
- * @param {object} params - { query, priority?, completed? }
+ * @param {object} params - { query, priority?, completed?, sortBy?, sortOrder? }
  * @returns {Promise<object[]>} Todo 配列
  */
 async function searchTodos(fastify, userId, params = {}) {
@@ -126,10 +145,41 @@ async function searchTodos(fastify, userId, params = {}) {
       { [Op.or]: [{ title: { [Op.like]: pattern } }, { description: { [Op.like]: pattern } }] },
     ];
   }
+  const order = buildOrder(
+    fastify.sequelize,
+    params.sortBy,
+    params.sortOrder
+  );
   return fastify.models.Todo.findAll({
     where,
-    order: [['createdAt', 'ASC']],
+    order,
   });
+}
+
+/**
+ * 並び順を一括更新する（カスタムソート用）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @param {number[]} todoIds - 新しい順序の Todo ID 配列
+ * @returns {Promise<void>}
+ */
+async function reorderTodos(fastify, userId, todoIds) {
+  if (!Array.isArray(todoIds) || todoIds.length === 0) return;
+  const transaction = await fastify.sequelize.transaction();
+  try {
+    for (let i = 0; i < todoIds.length; i++) {
+      const id = Number(todoIds[i]);
+      if (!Number.isInteger(id)) continue;
+      await fastify.models.Todo.update(
+        { sortOrder: i },
+        { where: { id, userId }, transaction }
+      );
+    }
+    await transaction.commit();
+  } catch (err) {
+    await transaction.rollback();
+    throw err;
+  }
 }
 
 module.exports = {
@@ -140,4 +190,5 @@ module.exports = {
   deleteTodo,
   toggleComplete,
   searchTodos,
+  reorderTodos,
 };

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -279,3 +279,112 @@ test('other user cannot delete todo (DELETE) - 404', async (t) => {
   })
   assert.strictEqual(delAsB.statusCode, 404)
 })
+
+test('GET /api/v1/todos with sortBy and sortOrder returns sorted list', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `sort-${suffix}`, email: `sort-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'First' }
+  })
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Second' }
+  })
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    query: { sortBy: 'createdAt', sortOrder: 'desc' }
+  })
+  assert.strictEqual(listRes.statusCode, 200)
+  const todos = JSON.parse(listRes.payload)
+  assert(Array.isArray(todos) && todos.length >= 2)
+  const created = todos.map((todo) => new Date(todo.createdAt).getTime())
+  for (let i = 1; i < created.length; i++) {
+    assert(created[i] <= created[i - 1], 'desc order: newer first')
+  }
+})
+
+test('PUT /api/v1/todos/reorder without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'PUT',
+    url: '/api/v1/todos/reorder',
+    payload: { todoIds: [1, 2, 3] }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('PUT /api/v1/todos/reorder with empty todoIds returns 400', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `reorder-${suffix}`, email: `reorder-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const res = await app.inject({
+    method: 'PUT',
+    url: '/api/v1/todos/reorder',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [] }
+  })
+  assert.strictEqual(res.statusCode, 400)
+})
+
+test('PUT /api/v1/todos/reorder updates order and GET sortBy=sortOrder returns new order', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `reorder2-${suffix}`, email: `reorder2-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const c1 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'A' }
+  })
+  const c2 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'B' }
+  })
+  const c3 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'C' }
+  })
+  const idA = JSON.parse(c1.payload).id
+  const idB = JSON.parse(c2.payload).id
+  const idC = JSON.parse(c3.payload).id
+  const reorderRes = await app.inject({
+    method: 'PUT',
+    url: '/api/v1/todos/reorder',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [idC, idA, idB] }
+  })
+  assert.strictEqual(reorderRes.statusCode, 204)
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    query: { sortBy: 'sortOrder', sortOrder: 'asc' }
+  })
+  assert.strictEqual(listRes.statusCode, 200)
+  const todos = JSON.parse(listRes.payload)
+  const titles = todos.map((todo) => todo.title)
+  assert.strictEqual(titles[0], 'C')
+  assert.strictEqual(titles[1], 'A')
+  assert.strictEqual(titles[2], 'B')
+})

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -388,3 +388,72 @@ test('PUT /api/v1/todos/reorder updates order and GET sortBy=sortOrder returns n
   assert.strictEqual(titles[1], 'A')
   assert.strictEqual(titles[2], 'B')
 })
+
+test('reorder with other user todo id returns 204 and does not change other user todo sort_order', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const userA = { name: `reorderA-${suffix}`, email: `reorderA-${suffix}@test.local`, password: 'pass123' }
+  const userB = { name: `reorderB-${suffix}`, email: `reorderB-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB })
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } })
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } })
+  const tokenA = JSON.parse(loginA.payload).token
+  const tokenB = JSON.parse(loginB.payload).token
+  const createA1 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A1' }
+  })
+  const createA2 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A2' }
+  })
+  const createB = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { title: 'B1' }
+  })
+  const idA1 = JSON.parse(createA1.payload).id
+  const idA2 = JSON.parse(createA2.payload).id
+  const idB = JSON.parse(createB.payload).id
+  const listBBefore = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenB}` },
+    query: { sortBy: 'sortOrder', sortOrder: 'asc' }
+  })
+  const todoBBefore = JSON.parse(listBBefore.payload).find((todo) => todo.id === idB)
+  assert(todoBBefore != null)
+  const sortOrderBBefore = todoBBefore.sortOrder
+  const reorderRes = await app.inject({
+    method: 'PUT',
+    url: '/api/v1/todos/reorder',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { todoIds: [idA2, idB, idA1] }
+  })
+  assert.strictEqual(reorderRes.statusCode, 204)
+  const listBAfter = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenB}` },
+    query: { sortBy: 'sortOrder', sortOrder: 'asc' }
+  })
+  const todoBAfter = JSON.parse(listBAfter.payload).find((todo) => todo.id === idB)
+  assert(todoBAfter != null)
+  assert.strictEqual(todoBAfter.sortOrder, sortOrderBBefore, 'other user todo sort_order must be unchanged')
+  const listA = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    query: { sortBy: 'sortOrder', sortOrder: 'asc' }
+  })
+  const todosA = JSON.parse(listA.payload)
+  const titlesA = todosA.map((todo) => todo.title)
+  assert.strictEqual(titlesA[0], 'A2')
+  assert.strictEqual(titlesA[1], 'A1')
+})

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.html
@@ -1,0 +1,21 @@
+<div class="d-flex align-items-center gap-2 flex-wrap">
+  <label class="form-label mb-0">並び順</label>
+  <select
+    class="form-select form-select-sm"
+    style="width: auto;"
+    [ngModel]="sortBy"
+    (ngModelChange)="onSortByChange($event)"
+  >
+    @for (opt of sortByOptions; track opt.value) {
+      <option [value]="opt.value">{{ opt.label }}</option>
+    }
+  </select>
+  <button
+    type="button"
+    class="btn btn-sm btn-outline-secondary"
+    (click)="toggleSortOrder()"
+    [attr.title]="sortOrder === 'asc' ? '昇順 → 降順に切り替え' : '降順 → 昇順に切り替え'"
+  >
+    {{ sortOrder === 'asc' ? '↑ 昇順' : '↓ 降順' }}
+  </button>
+</div>

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.html
@@ -4,7 +4,7 @@
     class="form-select form-select-sm"
     style="width: auto;"
     [value]="sortBy"
-    (change)="onSortByChange($any($event.target).value)"
+    (change)="onSortByChange($event)"
   >
     @for (opt of sortByOptions; track opt.value) {
       <option [value]="opt.value">{{ opt.label }}</option>

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.html
@@ -3,8 +3,8 @@
   <select
     class="form-select form-select-sm"
     style="width: auto;"
-    [ngModel]="sortBy"
-    (ngModelChange)="onSortByChange($event)"
+    [value]="sortBy"
+    (change)="onSortByChange($any($event.target).value)"
   >
     @for (opt of sortByOptions; track opt.value) {
       <option [value]="opt.value">{{ opt.label }}</option>

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.ts
@@ -1,12 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { CommonModule } from '@angular/common'
-import { FormsModule } from '@angular/forms'
 import type { SortBy, SortOrder, SortOptions } from '../../../../../models/sort-options.interface'
 
 @Component({
   selector: 'app-sort-selector',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule],
   templateUrl: './sort-selector.component.html',
   styleUrls: ['./sort-selector.component.scss']
 })

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.ts
@@ -22,9 +22,9 @@ export class SortSelectorComponent {
     { value: 'sortOrder', label: '手動' },
   ]
 
-  onSortByChange(value: string): void {
-    const sortBy = value as SortBy
-    this.sortChanged.emit({ sortBy, sortOrder: this.sortOrder })
+  onSortByChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value as SortBy
+    this.sortChanged.emit({ sortBy: value, sortOrder: this.sortOrder })
   }
 
   toggleSortOrder(): void {

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import type { SortBy, SortOrder, SortOptions } from '../../../../../models/sort-options.interface'
+
+@Component({
+  selector: 'app-sort-selector',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './sort-selector.component.html',
+  styleUrls: ['./sort-selector.component.scss']
+})
+export class SortSelectorComponent {
+  @Input() sortBy: SortBy = 'createdAt'
+  @Input() sortOrder: SortOrder = 'asc'
+  @Output() sortChanged = new EventEmitter<SortOptions>()
+
+  readonly sortByOptions: { value: SortBy; label: string }[] = [
+    { value: 'createdAt', label: '作成日' },
+    { value: 'updatedAt', label: '更新日' },
+    { value: 'dueDate', label: '期限' },
+    { value: 'priority', label: '優先度' },
+    { value: 'sortOrder', label: '手動' },
+  ]
+
+  onSortByChange(value: string): void {
+    const sortBy = value as SortBy
+    this.sortChanged.emit({ sortBy, sortOrder: this.sortOrder })
+  }
+
+  toggleSortOrder(): void {
+    const sortOrder: SortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc'
+    this.sortChanged.emit({ sortBy: this.sortBy, sortOrder })
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -10,14 +10,21 @@
 } @else if (todos.length === 0) {
   <p class="text-muted py-3">Todo がありません。</p>
 } @else {
-  <div class="todo-list">
+  <div
+    class="todo-list"
+    cdkDropList
+    [cdkDropListDisabled]="dragDisabled"
+    (cdkDropListDropped)="onDrop($event)"
+  >
     @for (todo of todos; track todo.id) {
-      <app-todo-item
-        [todo]="todo"
-        (toggle)="toggle.emit($event)"
-        (edit)="edit.emit($event)"
-        (delete)="delete.emit($event)"
-      />
+      <div cdkDrag [cdkDragDisabled]="dragDisabled">
+        <app-todo-item
+          [todo]="todo"
+          (toggle)="toggle.emit($event)"
+          (edit)="edit.emit($event)"
+          (delete)="delete.emit($event)"
+        />
+      </div>
     }
   </div>
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.scss
@@ -2,4 +2,15 @@
   list-style: none;
   padding: 0;
   margin: 0;
+
+  .cdk-drag-preview {
+    opacity: 0.9;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+  .cdk-drag-placeholder {
+    opacity: 0.3;
+  }
+  .cdk-drag-animating {
+    transition: transform 200ms ease;
+  }
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -1,12 +1,13 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop'
 import { TodoItemComponent } from '../todo-item/todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
 
 @Component({
   selector: 'app-todo-list',
   standalone: true,
-  imports: [CommonModule, TodoItemComponent],
+  imports: [CommonModule, DragDropModule, TodoItemComponent],
   templateUrl: './todo-list.component.html',
   styleUrls: ['./todo-list.component.scss']
 })
@@ -14,7 +15,17 @@ export class TodoListComponent {
   @Input() todos: Todo[] = []
   @Input() loading = false
   @Input() error: string | null = null
+  /** true のときドラッグ無効（ソートが「手動」以外のとき） */
+  @Input() dragDisabled = true
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
+  @Output() reorder = new EventEmitter<number[]>()
+
+  onDrop(event: CdkDragDrop<Todo[]>): void {
+    if (this.dragDisabled || event.previousIndex === event.currentIndex) return
+    const copy = [...this.todos]
+    moveItemInArray(copy, event.previousIndex, event.currentIndex)
+    this.reorder.emit(copy.map((t) => t.id))
+  }
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -31,6 +31,13 @@
               <option value="high">high</option>
             </select>
           </div>
+          <div class="col-auto">
+            <app-sort-selector
+              [sortBy]="sortBy"
+              [sortOrder]="sortOrder"
+              (sortChanged)="onSortChange($event)"
+            />
+          </div>
         </div>
       </div>
 
@@ -52,9 +59,11 @@
         [todos]="todos"
         [loading]="loading"
         [error]="error"
+        [dragDisabled]="sortBy !== 'sortOrder'"
         (toggle)="onToggle($event)"
         (edit)="onEdit($event)"
         (delete)="onDelete($event)"
+        (reorder)="onReorder($event)"
       />
     </app-card>
   </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -5,13 +5,22 @@ import { TodoService } from '../../../../../services/todo.service'
 import { TodoListComponent } from '../todo-list/todo-list.component'
 import { TodoFormComponent } from '../todo-form/todo-form.component'
 import { SearchBarComponent } from '../search-bar/search-bar.component'
+import { SortSelectorComponent } from '../sort-selector/sort-selector.component'
 import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models/todo.interface'
+import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
 
 @Component({
   selector: 'app-todo-page',
   standalone: true,
-  imports: [CommonModule, TodoListComponent, TodoFormComponent, SearchBarComponent, CardComponent],
+  imports: [
+    CommonModule,
+    TodoListComponent,
+    TodoFormComponent,
+    SearchBarComponent,
+    SortSelectorComponent,
+    CardComponent
+  ],
   templateUrl: './todo-page.component.html',
   styleUrls: ['./todo-page.component.scss']
 })
@@ -24,6 +33,8 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
   filterCompleted: boolean | null = null
   filterPriority: TodoPriority | null = null
   searchQuery = ''
+  sortBy: SortBy = 'createdAt'
+  sortOrder: SortOrder = 'asc'
 
   private destroy$ = new Subject<void>()
 
@@ -44,12 +55,13 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     const filters: { completed?: boolean; priority?: TodoPriority } = {}
     if (this.filterCompleted !== null) filters.completed = this.filterCompleted
     if (this.filterPriority !== null) filters.priority = this.filterPriority
+    const sort = { sortBy: this.sortBy, sortOrder: this.sortOrder }
 
     const q = this.searchQuery.trim()
     const searchParams = q ? { q, ...filters } : null
     const req = searchParams
-      ? this.todoService.search(searchParams)
-      : this.todoService.list(filters)
+      ? this.todoService.search(searchParams, sort)
+      : this.todoService.list(filters, sort)
 
     req.pipe(takeUntil(this.destroy$)).subscribe({
       next: (list) => {
@@ -93,6 +105,24 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     const value = (event.target as HTMLSelectElement).value
     this.filterPriority = value === '' ? null : (value as TodoPriority)
     this.onFiltersChange()
+  }
+
+  onSortChange(sort: { sortBy: SortBy; sortOrder: SortOrder }): void {
+    this.sortBy = sort.sortBy
+    this.sortOrder = sort.sortOrder
+    this.loadTodos()
+  }
+
+  onReorder(todoIds: number[]): void {
+    this.todoService
+      .reorderTodos(todoIds)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '並び替えに失敗しました'
+        }
+      })
   }
 
   onToggle(id: number): void {

--- a/frontend/src/app/models/sort-options.interface.ts
+++ b/frontend/src/app/models/sort-options.interface.ts
@@ -1,0 +1,14 @@
+/**
+ * ソート基準（API の sortBy と一致）
+ */
+export type SortBy = 'dueDate' | 'priority' | 'createdAt' | 'updatedAt' | 'sortOrder'
+
+/**
+ * ソート順
+ */
+export type SortOrder = 'asc' | 'desc'
+
+export interface SortOptions {
+  sortBy: SortBy
+  sortOrder: SortOrder
+}

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -14,6 +14,7 @@ export interface Todo {
   completed: boolean
   priority: TodoPriority
   dueDate: string | null
+  sortOrder: number
   createdAt: string
   updatedAt: string
 }

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs'
 import { environment } from '../../environments/environment'
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../models/todo.interface'
 import type { SearchParams } from '../models/search-params.interface'
+import type { SortOptions } from '../models/sort-options.interface'
 
 export interface TodoListFilters {
   completed?: boolean
@@ -22,16 +23,13 @@ export class TodoService {
     return this.http.post<Todo>(`${this.apiUrl}/todos`, body)
   }
 
-  list(filters?: TodoListFilters): Observable<Todo[]> {
-    let params: Record<string, string> = {}
-    if (filters?.completed !== undefined) {
-      params['completed'] = String(filters.completed)
-    }
-    if (filters?.priority) {
-      params['priority'] = filters.priority
-    }
-    const options = Object.keys(params).length ? { params } : {}
-    return this.http.get<Todo[]>(`${this.apiUrl}/todos`, options)
+  list(filters?: TodoListFilters, sort?: SortOptions): Observable<Todo[]> {
+    const params: Record<string, string> = {}
+    if (filters?.completed !== undefined) params['completed'] = String(filters.completed)
+    if (filters?.priority) params['priority'] = filters.priority
+    if (sort?.sortBy) params['sortBy'] = sort.sortBy
+    if (sort?.sortOrder) params['sortOrder'] = sort.sortOrder
+    return this.http.get<Todo[]>(`${this.apiUrl}/todos`, { params })
   }
 
   getById(id: number): Observable<Todo> {
@@ -51,12 +49,21 @@ export class TodoService {
   }
 
   /**
-   * タイトル・説明で検索（q 必須。completed, priority で絞り込み可）
+   * タイトル・説明で検索（q 必須。completed, priority, sort で絞り込み・ソート可）
    */
-  search(params: SearchParams): Observable<Todo[]> {
+  search(params: SearchParams, sort?: SortOptions): Observable<Todo[]> {
     const p: Record<string, string> = { q: params.q.trim() }
     if (params.completed !== undefined) p['completed'] = String(params.completed)
     if (params.priority) p['priority'] = params.priority
+    if (sort?.sortBy) p['sortBy'] = sort.sortBy
+    if (sort?.sortOrder) p['sortOrder'] = sort.sortOrder
     return this.http.get<Todo[]>(`${this.apiUrl}/todos/search`, { params: p })
+  }
+
+  /**
+   * カスタム並び順を保存（sortBy=sortOrder のときの手動並び替え用）
+   */
+  reorderTodos(todoIds: number[]): Observable<void> {
+    return this.http.put<void>(`${this.apiUrl}/todos/reorder`, { todoIds })
   }
 }


### PR DESCRIPTION
## 概要
Todo を期限・優先度・作成日・更新日・手動でソートし、手動時はドラッグ&ドロップで並び替え可能にしました。

## 変更内容

### Backend
- `todos.sort_order` カラム追加マイグレーション・Todo モデル更新
- `getTodosByUserId` / `searchTodos` に `sortBy`, `sortOrder` 対応（priority は high > medium > low）
- `PUT /api/v1/todos/reorder` と `reorderTodos` 実装（トランザクション）
- ソート・reorder のテスト追加

### Frontend
- `SortOptions` インターフェース・`Todo.sortOrder` 追加
- TodoService: `list`/`search` にソート引数、`reorderTodos` API
- SortSelector コンポーネント（並び順・昇順/降順）
- TodoList に CDK ドラッグ&ドロップ（「手動」ソート時のみ有効）
- TodoPage でソート状態保持・reorder 時 API 呼び出し

## ルール準拠
- ビルド・テストは Docker 内で実行
- 1 タスク = 1 PR（Phase A-2 ソート機能）
- 実装後 REVIEW.md の指摘に従い修正予定

Made with [Cursor](https://cursor.com)