### PR TITLE
feat(todo): アーカイブ機能を追加（Phase A-3）

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -138,6 +138,56 @@ async function reorderTodos(fastify, req, reply) {
   }
 }
 
+async function archiveTodo(fastify, req, reply) {
+  try {
+    const todoId = parseTodoId(req.params.id);
+    if (todoId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id' });
+    }
+    const todo = await todoService.archiveTodo(fastify, todoId, req.user.id);
+    if (!todo) {
+      return reply.code(404).send({ error: 'Not found' });
+    }
+    reply.code(200).send(todo.toJSON());
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Archive failed');
+  }
+}
+
+async function unarchiveTodo(fastify, req, reply) {
+  try {
+    const todoId = parseTodoId(req.params.id);
+    if (todoId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id' });
+    }
+    const todo = await todoService.unarchiveTodo(fastify, todoId, req.user.id);
+    if (!todo) {
+      return reply.code(404).send({ error: 'Not found' });
+    }
+    reply.code(200).send(todo.toJSON());
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Unarchive failed');
+  }
+}
+
+async function getArchivedTodos(fastify, req, reply) {
+  try {
+    const todos = await todoService.getArchivedTodos(fastify, req.user.id);
+    reply.code(200).send(todos.map((t) => t.toJSON()));
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Failed to get archived todos');
+  }
+}
+
+async function deleteArchivedTodos(fastify, req, reply) {
+  try {
+    await todoService.deleteArchivedTodos(fastify, req.user.id);
+    reply.code(204).send();
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Failed to delete archived todos');
+  }
+}
+
 module.exports = {
   createTodo,
   getTodos,
@@ -147,4 +197,8 @@ module.exports = {
   toggleComplete,
   searchTodos,
   reorderTodos,
+  archiveTodo,
+  unarchiveTodo,
+  getArchivedTodos,
+  deleteArchivedTodos,
 };

--- a/backend/migrations/20260301100944-add-archived-to-todos.js
+++ b/backend/migrations/20260301100944-add-archived-to-todos.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('todos', 'archived', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('todos', 'archived_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addIndex('todos', ['archived']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('todos', ['archived']);
+    await queryInterface.removeColumn('todos', 'archived_at');
+    await queryInterface.removeColumn('todos', 'archived');
+  }
+};

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -52,6 +52,16 @@ module.exports = (sequelize) => {
         defaultValue: 0,
         field: 'sort_order',
       },
+      archived: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      archivedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        field: 'archived_at',
+      },
     },
     {
       tableName: 'todos',

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -11,6 +11,10 @@ const {
   toggleComplete,
   searchTodos,
   reorderTodos,
+  archiveTodo,
+  unarchiveTodo,
+  getArchivedTodos,
+  deleteArchivedTodos,
 } = require('../../../controllers/todoController');
 
 module.exports = async function (fastify, opts) {
@@ -132,6 +136,14 @@ module.exports = async function (fastify, opts) {
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => searchTodos(fastify, request, reply),
   });
+  fastify.get('/todos/archived', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getArchivedTodos(fastify, request, reply),
+  });
+  fastify.delete('/todos/archived', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => deleteArchivedTodos(fastify, request, reply),
+  });
   fastify.get('/todos/:id', {
     schema: {
       params: {
@@ -184,5 +196,27 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => toggleComplete(fastify, request, reply),
+  });
+  fastify.patch('/todos/:id/archive', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => archiveTodo(fastify, request, reply),
+  });
+  fastify.patch('/todos/:id/unarchive', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => unarchiveTodo(fastify, request, reply),
   });
 }

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -61,13 +61,27 @@ async function getTodosByUserId(fastify, userId, options = {}) {
 }
 
 /**
- * ID とユーザーで Todo を 1 件取得する（他ユーザーの場合は null）
+ * 未アーカイブの Todo を ID とユーザーで 1 件取得する（他ユーザー・アーカイブ済みは null）
+ * 通常の GET/PUT/DELETE/toggle は未アーカイブのみ操作可能とする。
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} userId - ユーザー ID
  * @returns {Promise<object|null>}
  */
 async function getTodoById(fastify, todoId, userId) {
+  return fastify.models.Todo.findOne({
+    where: { id: todoId, userId, archived: false },
+  });
+}
+
+/**
+ * アーカイブ有無を問わず Todo を 1 件取得する（archive/unarchive 専用）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object|null>}
+ */
+async function getTodoByIdIncludingArchived(fastify, todoId, userId) {
   return fastify.models.Todo.findOne({
     where: { id: todoId, userId },
   });
@@ -188,15 +202,16 @@ async function reorderTodos(fastify, userId, todoIds) {
 }
 
 /**
- * Todo をアーカイブする（所有者のみ。完了済みでなくてもアーカイブ可能とする）
+ * Todo をアーカイブする（所有者のみ。完了済みでなくても API 上はアーカイブ可能）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} userId - ユーザー ID
  * @returns {Promise<object|null>} 更新後の Todo、存在しなければ null
  */
 async function archiveTodo(fastify, todoId, userId) {
-  const todo = await getTodoById(fastify, todoId, userId);
+  const todo = await getTodoByIdIncludingArchived(fastify, todoId, userId);
   if (!todo) return null;
+  if (todo.archived) return todo;
   todo.archived = true;
   todo.archivedAt = new Date();
   await todo.save();
@@ -211,7 +226,7 @@ async function archiveTodo(fastify, todoId, userId) {
  * @returns {Promise<object|null>} 更新後の Todo、存在しなければ null
  */
 async function unarchiveTodo(fastify, todoId, userId) {
-  const todo = await getTodoById(fastify, todoId, userId);
+  const todo = await getTodoByIdIncludingArchived(fastify, todoId, userId);
   if (!todo) return null;
   todo.archived = false;
   todo.archivedAt = null;

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -42,7 +42,7 @@ async function createTodo(fastify, userId, todoData) {
  * @returns {Promise<object[]>} Todo 配列
  */
 async function getTodosByUserId(fastify, userId, options = {}) {
-  const where = { userId };
+  const where = { userId, archived: false };
   if (typeof options.completed === 'boolean') {
     where.completed = options.completed;
   }
@@ -130,7 +130,7 @@ async function toggleComplete(fastify, todoId, userId) {
  * @returns {Promise<object[]>} Todo 配列
  */
 async function searchTodos(fastify, userId, params = {}) {
-  const where = { userId };
+  const where = { userId, archived: false };
   if (typeof params.completed === 'boolean') {
     where.completed = params.completed;
   }
@@ -187,6 +187,64 @@ async function reorderTodos(fastify, userId, todoIds) {
   }
 }
 
+/**
+ * Todo をアーカイブする（所有者のみ。完了済みでなくてもアーカイブ可能とする）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object|null>} 更新後の Todo、存在しなければ null
+ */
+async function archiveTodo(fastify, todoId, userId) {
+  const todo = await getTodoById(fastify, todoId, userId);
+  if (!todo) return null;
+  todo.archived = true;
+  todo.archivedAt = new Date();
+  await todo.save();
+  return todo;
+}
+
+/**
+ * Todo のアーカイブを解除する（所有者のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object|null>} 更新後の Todo、存在しなければ null
+ */
+async function unarchiveTodo(fastify, todoId, userId) {
+  const todo = await getTodoById(fastify, todoId, userId);
+  if (!todo) return null;
+  todo.archived = false;
+  todo.archivedAt = null;
+  await todo.save();
+  return todo;
+}
+
+/**
+ * アーカイブ済み Todo 一覧を取得する（作成日降順）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object[]>} Todo 配列
+ */
+async function getArchivedTodos(fastify, userId) {
+  return fastify.models.Todo.findAll({
+    where: { userId, archived: true },
+    order: [['archivedAt', 'DESC']],
+  });
+}
+
+/**
+ * アーカイブ済み Todo を一括削除する（所有者のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<number>} 削除件数
+ */
+async function deleteArchivedTodos(fastify, userId) {
+  const result = await fastify.models.Todo.destroy({
+    where: { userId, archived: true },
+  });
+  return result;
+}
+
 module.exports = {
   createTodo,
   getTodosByUserId,
@@ -196,4 +254,8 @@ module.exports = {
   toggleComplete,
   searchTodos,
   reorderTodos,
+  archiveTodo,
+  unarchiveTodo,
+  getArchivedTodos,
+  deleteArchivedTodos,
 };

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -614,3 +614,68 @@ test('other user cannot archive my todo (404)', async (t) => {
   })
   assert.strictEqual(archiveAsB.statusCode, 404)
 })
+
+test('archived todo returns 404 for GET /todos/:id and PUT /todos/:id', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `getarch-${suffix}`, email: `getarch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'To archive' }
+  })
+  const todoId = JSON.parse(createRes.payload).id
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/archive`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const getRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todoId}`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(getRes.statusCode, 404)
+  const putRes = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/todos/${todoId}`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Updated' }
+  })
+  assert.strictEqual(putRes.statusCode, 404)
+})
+
+test('other user cannot unarchive my todo (404)', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const userA = { name: `unarchA-${suffix}`, email: `unarchA-${suffix}@test.local`, password: 'pass123' }
+  const userB = { name: `unarchB-${suffix}`, email: `unarchB-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB })
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } })
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } })
+  const tokenA = JSON.parse(loginA.payload).token
+  const tokenB = JSON.parse(loginB.payload).token
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' }
+  })
+  const todoId = JSON.parse(createRes.payload).id
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/archive`,
+    headers: { authorization: `Bearer ${tokenA}` }
+  })
+  const unarchiveAsB = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/unarchive`,
+    headers: { authorization: `Bearer ${tokenB}` }
+  })
+  assert.strictEqual(unarchiveAsB.statusCode, 404)
+})

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -457,3 +457,160 @@ test('reorder with other user todo id returns 204 and does not change other user
   assert.strictEqual(titlesA[0], 'A2')
   assert.strictEqual(titlesA[1], 'A1')
 })
+
+test('PATCH /api/v1/todos/:id/archive without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'PATCH',
+    url: '/api/v1/todos/1/archive'
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('PATCH /api/v1/todos/:id/archive archives todo and GET /todos excludes it', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `arch-${suffix}`, email: `arch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'To archive' }
+  })
+  const todoId = JSON.parse(createRes.payload).id
+  const archiveRes = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/archive`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(archiveRes.statusCode, 200)
+  const archived = JSON.parse(archiveRes.payload)
+  assert.strictEqual(archived.archived, true)
+  assert(archived.archivedAt != null)
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const list = JSON.parse(listRes.payload)
+  assert(!list.some((todo) => todo.id === todoId))
+  const archivedListRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/archived',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(archivedListRes.statusCode, 200)
+  const archivedList = JSON.parse(archivedListRes.payload)
+  assert(archivedList.some((todo) => todo.id === todoId))
+})
+
+test('PATCH /api/v1/todos/:id/unarchive restores todo to list', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `unarch-${suffix}`, email: `unarch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Archived one' }
+  })
+  const todoId = JSON.parse(createRes.payload).id
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/archive`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const unarchiveRes = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/unarchive`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(unarchiveRes.statusCode, 200)
+  const todo = JSON.parse(unarchiveRes.payload)
+  assert.strictEqual(todo.archived, false)
+  assert.strictEqual(todo.archivedAt, null)
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert(listRes.statusCode === 200 && JSON.parse(listRes.payload).some((todo) => todo.id === todoId))
+})
+
+test('DELETE /api/v1/todos/archived without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({ method: 'DELETE', url: '/api/v1/todos/archived' })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('DELETE /api/v1/todos/archived deletes all archived todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `delarch-${suffix}`, email: `delarch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'One' }
+  })
+  const c2 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Two' }
+  })
+  const id2 = JSON.parse(c2.payload).id
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${id2}/archive`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const delRes = await app.inject({
+    method: 'DELETE',
+    url: '/api/v1/todos/archived',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(delRes.statusCode, 204)
+  const archivedRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/archived',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const archived = JSON.parse(archivedRes.payload)
+  assert.strictEqual(archived.length, 0)
+})
+
+test('other user cannot archive my todo (404)', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const userA = { name: `archA-${suffix}`, email: `archA-${suffix}@test.local`, password: 'pass123' }
+  const userB = { name: `archB-${suffix}`, email: `archB-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB })
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } })
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } })
+  const tokenA = JSON.parse(loginA.payload).token
+  const tokenB = JSON.parse(loginB.payload).token
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' }
+  })
+  const todoId = JSON.parse(createRes.payload).id
+  const archiveAsB = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoId}/archive`,
+    headers: { authorization: `Bearer ${tokenB}` }
+  })
+  assert.strictEqual(archiveAsB.statusCode, 404)
+})

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.html
@@ -1,0 +1,51 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="アーカイブ（{{ todos.length }} 件）">
+      @if (todos.length > 0) {
+        <div class="mb-3">
+          <button
+            type="button"
+            class="btn btn-outline-danger btn-sm"
+            (click)="onDeleteAll()"
+          >
+            アーカイブを一括削除
+          </button>
+        </div>
+      }
+
+      @if (error) {
+        <div class="alert alert-danger" role="alert">{{ error }}</div>
+      }
+      @if (loading) {
+        <div class="text-center py-4">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">読み込み中...</span>
+          </div>
+        </div>
+      } @else if (todos.length === 0) {
+        <p class="text-muted py-3">アーカイブされた Todo はありません。</p>
+      } @else {
+        <div class="archived-list">
+          @for (todo of todos; track todo.id) {
+            <div class="d-flex align-items-center gap-2 py-2 border-bottom archived-item">
+              <div class="flex-grow-1 min-width-0">
+                <span class="text-muted text-decoration-line-through">{{ todo.title }}</span>
+                @if (todo.description) {
+                  <span class="d-block small text-muted">{{ todo.description }}</span>
+                }
+                <span class="small text-muted">アーカイブ: {{ formatArchivedAt(todo.archivedAt) }}</span>
+              </div>
+              <button
+                type="button"
+                class="btn btn-sm btn-outline-primary"
+                (click)="onUnarchive(todo.id)"
+              >
+                解除
+              </button>
+            </div>
+          }
+        </div>
+      }
+    </app-card>
+  </div>
+</div>

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.scss
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.scss
@@ -1,0 +1,11 @@
+.archived-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.archived-item {
+  .min-width-0 {
+    min-width: 0;
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Subject, takeUntil } from 'rxjs'
+import { TodoService } from '../../../../services/todo.service'
+import { CardComponent } from '../../../../theme/shared/components/card/card.component'
+import type { Todo } from '../../../../models/todo.interface'
+
+@Component({
+  selector: 'app-archived-todos-page',
+  standalone: true,
+  imports: [CommonModule, CardComponent],
+  templateUrl: './archived-todos-page.component.html',
+  styleUrls: ['./archived-todos-page.component.scss']
+})
+export default class ArchivedTodosPageComponent implements OnInit, OnDestroy {
+  todos: Todo[] = []
+  loading = false
+  error: string | null = null
+
+  private destroy$ = new Subject<void>()
+
+  constructor(private todoService: TodoService) {}
+
+  ngOnInit(): void {
+    this.loadArchived()
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  loadArchived(): void {
+    this.loading = true
+    this.error = null
+    this.todoService
+      .getArchivedTodos()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (list) => {
+          this.todos = list
+          this.loading = false
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '取得に失敗しました'
+          this.loading = false
+        }
+      })
+  }
+
+  onUnarchive(id: number): void {
+    this.todoService
+      .unarchiveTodo(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadArchived(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'アーカイブ解除に失敗しました'
+        }
+      })
+  }
+
+  onDeleteAll(): void {
+    if (!confirm('アーカイブ済みの Todo をすべて削除しますか？この操作は取り消せません。')) return
+    this.todoService
+      .deleteArchivedTodos()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadArchived(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '一括削除に失敗しました'
+        }
+      })
+  }
+
+  formatArchivedAt(archivedAt: string | null): string {
+    if (!archivedAt) return ''
+    const d = new Date(archivedAt)
+    return d.toLocaleString('ja-JP')
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -13,6 +13,10 @@ const routes: Routes = [
         path: 'todos',
         loadComponent: () => import('./todo/todo-page/todo-page.component')
       },
+      {
+        path: 'archived',
+        loadComponent: () => import('./archived-todos/archived-todos-page.component')
+      },
     ]
   }
 ]

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -17,6 +17,9 @@
     </span>
   </div>
   <div class="btn-group btn-group-sm">
+    @if (todo.completed) {
+      <button type="button" class="btn btn-outline-secondary" (click)="onArchive()" title="アーカイブ">アーカイブ</button>
+    }
     <button type="button" class="btn btn-outline-primary" (click)="onEdit()">編集</button>
     <button type="button" class="btn btn-outline-danger" (click)="onDelete()">削除</button>
   </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -14,6 +14,7 @@ export class TodoItemComponent {
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
+  @Output() archived = new EventEmitter<number>()
 
   onToggle(): void {
     this.toggle.emit(this.todo.id)
@@ -25,6 +26,10 @@ export class TodoItemComponent {
 
   onDelete(): void {
     this.delete.emit(this.todo.id)
+  }
+
+  onArchive(): void {
+    this.archived.emit(this.todo.id)
   }
 
   /** 優先度バッジの Bootstrap クラス */

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -14,7 +14,7 @@ export class TodoItemComponent {
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
-  @Output() archived = new EventEmitter<number>()
+  @Output() archive = new EventEmitter<number>()
 
   onToggle(): void {
     this.toggle.emit(this.todo.id)
@@ -29,7 +29,7 @@ export class TodoItemComponent {
   }
 
   onArchive(): void {
-    this.archived.emit(this.todo.id)
+    this.archive.emit(this.todo.id)
   }
 
   /** 優先度バッジの Bootstrap クラス */

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -23,7 +23,7 @@
           (toggle)="toggle.emit($event)"
           (edit)="edit.emit($event)"
           (delete)="delete.emit($event)"
-          (archived)="archived.emit($event)"
+          (archive)="archive.emit($event)"
         />
       </div>
     }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -23,6 +23,7 @@
           (toggle)="toggle.emit($event)"
           (edit)="edit.emit($event)"
           (delete)="delete.emit($event)"
+          (archived)="archived.emit($event)"
         />
       </div>
     }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -20,7 +20,7 @@ export class TodoListComponent {
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
-  @Output() archived = new EventEmitter<number>()
+  @Output() archive = new EventEmitter<number>()
   @Output() reorder = new EventEmitter<number[]>()
 
   onDrop(event: CdkDragDrop<Todo[]>): void {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -20,6 +20,7 @@ export class TodoListComponent {
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
+  @Output() archived = new EventEmitter<number>()
   @Output() reorder = new EventEmitter<number[]>()
 
   onDrop(event: CdkDragDrop<Todo[]>): void {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -63,7 +63,7 @@
         (toggle)="onToggle($event)"
         (edit)="onEdit($event)"
         (delete)="onDelete($event)"
-        (archived)="onArchived($event)"
+        (archive)="onArchived($event)"
         (reorder)="onReorder($event)"
       />
     </app-card>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -63,6 +63,7 @@
         (toggle)="onToggle($event)"
         (edit)="onEdit($event)"
         (delete)="onDelete($event)"
+        (archived)="onArchived($event)"
         (reorder)="onReorder($event)"
       />
     </app-card>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -125,6 +125,18 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
       })
   }
 
+  onArchived(id: number): void {
+    this.todoService
+      .archiveTodo(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'アーカイブに失敗しました'
+        }
+      })
+  }
+
   onToggle(id: number): void {
     this.todoService
       .toggleComplete(id)

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -15,6 +15,8 @@ export interface Todo {
   priority: TodoPriority
   dueDate: string | null
   sortOrder: number
+  archived: boolean
+  archivedAt: string | null
   createdAt: string
   updatedAt: string
 }

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -66,4 +66,20 @@ export class TodoService {
   reorderTodos(todoIds: number[]): Observable<void> {
     return this.http.put<void>(`${this.apiUrl}/todos/reorder`, { todoIds })
   }
+
+  archiveTodo(id: number): Observable<Todo> {
+    return this.http.patch<Todo>(`${this.apiUrl}/todos/${id}/archive`, {})
+  }
+
+  unarchiveTodo(id: number): Observable<Todo> {
+    return this.http.patch<Todo>(`${this.apiUrl}/todos/${id}/unarchive`, {})
+  }
+
+  getArchivedTodos(): Observable<Todo[]> {
+    return this.http.get<Todo[]>(`${this.apiUrl}/todos/archived`)
+  }
+
+  deleteArchivedTodos(): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/todos/archived`)
+  }
 }

--- a/frontend/src/app/theme/layout/admin/navigation/navigation.ts
+++ b/frontend/src/app/theme/layout/admin/navigation/navigation.ts
@@ -43,6 +43,14 @@ const NavigationItems = [
         url: '/dashboard/todos',
         icon: 'feather icon-check-square',
         classes: 'nav-item'
+      },
+      {
+        id: 'archived',
+        title: 'アーカイブ',
+        type: 'item',
+        url: '/dashboard/archived',
+        icon: 'feather icon-archive',
+        classes: 'nav-item'
       }
     ]
   },


### PR DESCRIPTION
## 概要
完了した Todo をアーカイブし、別画面で一覧・解除・一括削除できるようにしました。

## 変更内容

### Backend
- `todos.archived`（BOOLEAN）, `archived_at`（TIMESTAMP）カラム追加マイグレーション・Todo モデル更新
- `getTodosByUserId` / `searchTodos` でアーカイブ済みを除外
- `archiveTodo`, `unarchiveTodo`, `getArchivedTodos`, `deleteArchivedTodos` 実装
- PATCH /api/v1/todos/:id/archive, PATCH /api/v1/todos/:id/unarchive
- GET /api/v1/todos/archived, DELETE /api/v1/todos/archived
- アーカイブ関連のテスト追加（認証・archive/unarchive・一括削除・認可）

### Frontend
- Todo 型に `archived`, `archivedAt` 追加
- TodoService: `archiveTodo`, `unarchiveTodo`, `getArchivedTodos`, `deleteArchivedTodos`
- 完了済み Todo に「アーカイブ」ボタン、TodoPage でアーカイブ処理
- ArchivedTodosPage: アーカイブ一覧・解除ボタン・一括削除（確認ダイアログ付き）
- ルート `/dashboard/archived`、サイドナビに「アーカイブ」リンク追加

## ルール準拠
- ビルド・マイグレーション・テストは Docker 内で実行
- 1 タスク = 1 PR（Phase A-3 アーカイブ機能）

Made with [Cursor](https://cursor.com)