### PR TITLE
feat(todo): 一括操作を追加（Phase A-4）

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -188,6 +188,45 @@ async function deleteArchivedTodos(fastify, req, reply) {
   }
 }
 
+async function bulkComplete(fastify, req, reply) {
+  try {
+    const todoIds = req.body.todoIds;
+    if (!Array.isArray(todoIds) || todoIds.length === 0) {
+      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
+    }
+    const updated = await todoService.bulkComplete(fastify, todoIds, req.user.id);
+    reply.code(200).send({ updated });
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Bulk complete failed');
+  }
+}
+
+async function bulkDelete(fastify, req, reply) {
+  try {
+    const todoIds = req.body.todoIds;
+    if (!Array.isArray(todoIds) || todoIds.length === 0) {
+      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
+    }
+    const deleted = await todoService.bulkDelete(fastify, todoIds, req.user.id);
+    reply.code(200).send({ deleted });
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Bulk delete failed');
+  }
+}
+
+async function bulkArchive(fastify, req, reply) {
+  try {
+    const todoIds = req.body.todoIds;
+    if (!Array.isArray(todoIds) || todoIds.length === 0) {
+      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
+    }
+    const updated = await todoService.bulkArchive(fastify, todoIds, req.user.id);
+    reply.code(200).send({ updated });
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Bulk archive failed');
+  }
+}
+
 module.exports = {
   createTodo,
   getTodos,
@@ -201,4 +240,7 @@ module.exports = {
   unarchiveTodo,
   getArchivedTodos,
   deleteArchivedTodos,
+  bulkComplete,
+  bulkDelete,
+  bulkArchive,
 };

--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -191,9 +191,6 @@ async function deleteArchivedTodos(fastify, req, reply) {
 async function bulkComplete(fastify, req, reply) {
   try {
     const todoIds = req.body.todoIds;
-    if (!Array.isArray(todoIds) || todoIds.length === 0) {
-      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
-    }
     const updated = await todoService.bulkComplete(fastify, todoIds, req.user.id);
     reply.code(200).send({ updated });
   } catch (error) {
@@ -204,9 +201,6 @@ async function bulkComplete(fastify, req, reply) {
 async function bulkDelete(fastify, req, reply) {
   try {
     const todoIds = req.body.todoIds;
-    if (!Array.isArray(todoIds) || todoIds.length === 0) {
-      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
-    }
     const deleted = await todoService.bulkDelete(fastify, todoIds, req.user.id);
     reply.code(200).send({ deleted });
   } catch (error) {
@@ -217,9 +211,6 @@ async function bulkDelete(fastify, req, reply) {
 async function bulkArchive(fastify, req, reply) {
   try {
     const todoIds = req.body.todoIds;
-    if (!Array.isArray(todoIds) || todoIds.length === 0) {
-      return reply.code(400).send({ error: 'todoIds array is required and must be non-empty' });
-    }
     const updated = await todoService.bulkArchive(fastify, todoIds, req.user.id);
     reply.code(200).send({ updated });
   } catch (error) {

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -15,6 +15,9 @@ const {
   unarchiveTodo,
   getArchivedTodos,
   deleteArchivedTodos,
+  bulkComplete,
+  bulkDelete,
+  bulkArchive,
 } = require('../../../controllers/todoController');
 
 module.exports = async function (fastify, opts) {
@@ -143,6 +146,32 @@ module.exports = async function (fastify, opts) {
   fastify.delete('/todos/archived', {
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => deleteArchivedTodos(fastify, request, reply),
+  });
+  const bulkBodySchema = {
+    type: 'object',
+    required: ['todoIds'],
+    properties: {
+      todoIds: {
+        type: 'array',
+        items: { type: 'integer' },
+        minItems: 1,
+      },
+    },
+  };
+  fastify.post('/todos/bulk-complete', {
+    schema: { body: bulkBodySchema },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => bulkComplete(fastify, request, reply),
+  });
+  fastify.post('/todos/bulk-delete', {
+    schema: { body: bulkBodySchema },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => bulkDelete(fastify, request, reply),
+  });
+  fastify.post('/todos/bulk-archive', {
+    schema: { body: bulkBodySchema },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => bulkArchive(fastify, request, reply),
   });
   fastify.get('/todos/:id', {
     schema: {

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -155,6 +155,7 @@ module.exports = async function (fastify, opts) {
         type: 'array',
         items: { type: 'integer' },
         minItems: 1,
+        maxItems: 100,
       },
     },
   };

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -290,7 +290,7 @@ async function bulkDelete(fastify, todoIds, userId) {
   const safeIds = todoIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0);
   if (safeIds.length === 0) return 0;
   return fastify.models.Todo.destroy({
-    where: { id: { [Op.in]: safeIds }, userId },
+    where: { id: { [Op.in]: safeIds }, userId, archived: false },
   });
 }
 

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -260,6 +260,59 @@ async function deleteArchivedTodos(fastify, userId) {
   return result;
 }
 
+/**
+ * 指定 ID の Todo を一括で完了にする（所有者のもののみ更新）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number[]} todoIds - Todo ID 配列
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<number>} 更新件数
+ */
+async function bulkComplete(fastify, todoIds, userId) {
+  if (!Array.isArray(todoIds) || todoIds.length === 0) return 0;
+  const safeIds = todoIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0);
+  if (safeIds.length === 0) return 0;
+  const [count] = await fastify.models.Todo.update(
+    { completed: true },
+    { where: { id: { [Op.in]: safeIds }, userId, archived: false } }
+  );
+  return count;
+}
+
+/**
+ * 指定 ID の Todo を一括削除する（所有者のもののみ削除）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number[]} todoIds - Todo ID 配列
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<number>} 削除件数
+ */
+async function bulkDelete(fastify, todoIds, userId) {
+  if (!Array.isArray(todoIds) || todoIds.length === 0) return 0;
+  const safeIds = todoIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0);
+  if (safeIds.length === 0) return 0;
+  return fastify.models.Todo.destroy({
+    where: { id: { [Op.in]: safeIds }, userId },
+  });
+}
+
+/**
+ * 指定 ID の Todo を一括アーカイブする（所有者の未アーカイブのみ更新）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number[]} todoIds - Todo ID 配列
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<number>} 更新件数
+ */
+async function bulkArchive(fastify, todoIds, userId) {
+  if (!Array.isArray(todoIds) || todoIds.length === 0) return 0;
+  const safeIds = todoIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0);
+  if (safeIds.length === 0) return 0;
+  const now = new Date();
+  const [count] = await fastify.models.Todo.update(
+    { archived: true, archivedAt: now },
+    { where: { id: { [Op.in]: safeIds }, userId, archived: false } }
+  );
+  return count;
+}
+
 module.exports = {
   createTodo,
   getTodosByUserId,
@@ -273,4 +326,7 @@ module.exports = {
   unarchiveTodo,
   getArchivedTodos,
   deleteArchivedTodos,
+  bulkComplete,
+  bulkDelete,
+  bulkArchive,
 };

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -679,3 +679,131 @@ test('other user cannot unarchive my todo (404)', async (t) => {
   })
   assert.strictEqual(unarchiveAsB.statusCode, 404)
 })
+
+test('POST /api/v1/todos/bulk-complete without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-complete',
+    payload: { todoIds: [1, 2] }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('POST /api/v1/todos/bulk-complete with empty todoIds returns 400', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulk-${suffix}`, email: `bulk-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-complete',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [] }
+  })
+  assert.strictEqual(res.statusCode, 400)
+})
+
+test('POST /api/v1/todos/bulk-complete marks selected todos completed', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulkc-${suffix}`, email: `bulkc-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const c1 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'One' }
+  })
+  const c2 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Two' }
+  })
+  const id1 = JSON.parse(c1.payload).id
+  const id2 = JSON.parse(c2.payload).id
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-complete',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [id1, id2] }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.updated, 2)
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const list = JSON.parse(listRes.payload)
+  assert(list.every((todo) => todo.completed))
+})
+
+test('POST /api/v1/todos/bulk-delete deletes selected todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulkd-${suffix}`, email: `bulkd-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const c1 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'One' }
+  })
+  const id1 = JSON.parse(c1.payload).id
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-delete',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [id1] }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.deleted, 1)
+  const getRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${id1}`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(getRes.statusCode, 404)
+})
+
+test('POST /api/v1/todos/bulk-archive archives selected todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulka-${suffix}`, email: `bulka-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const c1 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'One' }
+  })
+  const id1 = JSON.parse(c1.payload).id
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-archive',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [id1] }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.updated, 1)
+  const archivedRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/archived',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const archived = JSON.parse(archivedRes.payload)
+  assert(archived.some((todo) => todo.id === id1))
+})

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -690,6 +690,26 @@ test('POST /api/v1/todos/bulk-complete without auth returns 401', async (t) => {
   assert.strictEqual(res.statusCode, 401)
 })
 
+test('POST /api/v1/todos/bulk-delete without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-delete',
+    payload: { todoIds: [1, 2] }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('POST /api/v1/todos/bulk-archive without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-archive',
+    payload: { todoIds: [1, 2] }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
 test('POST /api/v1/todos/bulk-complete with empty todoIds returns 400', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()
@@ -702,6 +722,55 @@ test('POST /api/v1/todos/bulk-complete with empty todoIds returns 400', async (t
     url: '/api/v1/todos/bulk-complete',
     headers: { authorization: `Bearer ${token}` },
     payload: { todoIds: [] }
+  })
+  assert.strictEqual(res.statusCode, 400)
+})
+
+test('POST /api/v1/todos/bulk-delete with empty todoIds returns 400', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulkdel-${suffix}`, email: `bulkdel-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-delete',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [] }
+  })
+  assert.strictEqual(res.statusCode, 400)
+})
+
+test('POST /api/v1/todos/bulk-archive with empty todoIds returns 400', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulkarch-${suffix}`, email: `bulkarch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-archive',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: [] }
+  })
+  assert.strictEqual(res.statusCode, 400)
+})
+
+test('POST /api/v1/todos/bulk-complete with todoIds exceeding maxItems returns 400', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `bulkmax-${suffix}`, email: `bulkmax-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const tooMany = Array.from({ length: 101 }, (_, i) => i + 1)
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-complete',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { todoIds: tooMany }
   })
   assert.strictEqual(res.statusCode, 400)
 })
@@ -806,4 +875,111 @@ test('POST /api/v1/todos/bulk-archive archives selected todos', async (t) => {
   })
   const archived = JSON.parse(archivedRes.payload)
   assert(archived.some((todo) => todo.id === id1))
+})
+
+test('bulk-complete with other user todo ids returns updated 0 and does not change other user todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const userA = { name: `bulkA-${suffix}`, email: `bulkA-${suffix}@test.local`, password: 'pass123' }
+  const userB = { name: `bulkB-${suffix}`, email: `bulkB-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB })
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } })
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } })
+  const tokenA = JSON.parse(loginA.payload).token
+  const tokenB = JSON.parse(loginB.payload).token
+  const createA = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' }
+  })
+  const idA = JSON.parse(createA.payload).id
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-complete',
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { todoIds: [idA] }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.updated, 0)
+  const getA = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${idA}`,
+    headers: { authorization: `Bearer ${tokenA}` }
+  })
+  assert.strictEqual(getA.statusCode, 200)
+  assert.strictEqual(JSON.parse(getA.payload).completed, false)
+})
+
+test('bulk-delete with other user todo ids returns deleted 0 and does not delete other user todo', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const userA = { name: `bulkdelA-${suffix}`, email: `bulkdelA-${suffix}@test.local`, password: 'pass123' }
+  const userB = { name: `bulkdelB-${suffix}`, email: `bulkdelB-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB })
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } })
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } })
+  const tokenA = JSON.parse(loginA.payload).token
+  const tokenB = JSON.parse(loginB.payload).token
+  const createA = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' }
+  })
+  const idA = JSON.parse(createA.payload).id
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-delete',
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { todoIds: [idA] }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.deleted, 0)
+  const getA = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${idA}`,
+    headers: { authorization: `Bearer ${tokenA}` }
+  })
+  assert.strictEqual(getA.statusCode, 200)
+})
+
+test('bulk-archive with other user todo ids returns updated 0 and does not archive other user todo', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const userA = { name: `bulkarchA-${suffix}`, email: `bulkarchA-${suffix}@test.local`, password: 'pass123' }
+  const userB = { name: `bulkarchB-${suffix}`, email: `bulkarchB-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB })
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } })
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } })
+  const tokenA = JSON.parse(loginA.payload).token
+  const tokenB = JSON.parse(loginB.payload).token
+  const createA = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' }
+  })
+  const idA = JSON.parse(createA.payload).id
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/bulk-archive',
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { todoIds: [idA] }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.updated, 0)
+  const getA = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${idA}`,
+    headers: { authorization: `Bearer ${tokenA}` }
+  })
+  assert.strictEqual(getA.statusCode, 200)
+  assert.strictEqual(JSON.parse(getA.payload).archived, false)
 })

--- a/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.html
@@ -1,0 +1,17 @@
+@if (selectedCount > 0) {
+  <div class="bulk-action-bar d-flex align-items-center gap-2 flex-wrap py-2 px-3 bg-light rounded">
+    <span class="fw-medium">{{ selectedCount }} 件選択</span>
+    <button type="button" class="btn btn-sm btn-outline-success" (click)="bulkComplete.emit()">
+      一括完了
+    </button>
+    <button type="button" class="btn btn-sm btn-outline-secondary" (click)="bulkArchive.emit()">
+      一括アーカイブ
+    </button>
+    <button type="button" class="btn btn-sm btn-outline-danger" (click)="bulkDelete.emit()">
+      一括削除
+    </button>
+    <button type="button" class="btn btn-sm btn-link p-0" (click)="clearSelection.emit()">
+      選択解除
+    </button>
+  </div>
+}

--- a/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.ts
@@ -1,10 +1,9 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
-import { CommonModule } from '@angular/common'
 
 @Component({
   selector: 'app-bulk-action-bar',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './bulk-action-bar.component.html',
   styleUrls: ['./bulk-action-bar.component.scss']
 })

--- a/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/bulk-action-bar/bulk-action-bar.component.ts
@@ -1,0 +1,17 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { CommonModule } from '@angular/common'
+
+@Component({
+  selector: 'app-bulk-action-bar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './bulk-action-bar.component.html',
+  styleUrls: ['./bulk-action-bar.component.scss']
+})
+export class BulkActionBarComponent {
+  @Input() selectedCount = 0
+  @Output() bulkComplete = new EventEmitter<void>()
+  @Output() bulkDelete = new EventEmitter<void>()
+  @Output() bulkArchive = new EventEmitter<void>()
+  @Output() clearSelection = new EventEmitter<void>()
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -17,7 +17,15 @@
     (cdkDropListDropped)="onDrop($event)"
   >
     @for (todo of todos; track todo.id) {
-      <div cdkDrag [cdkDragDisabled]="dragDisabled">
+      <div class="d-flex align-items-center gap-2 todo-row" cdkDrag [cdkDragDisabled]="dragDisabled">
+        <input
+          type="checkbox"
+          class="form-check-input flex-shrink-0"
+          [checked]="selectedIds.includes(todo.id)"
+          (change)="toggleSelection(todo.id)"
+          [attr.aria-label]="'選択: ' + todo.title"
+        />
+        <div class="flex-grow-1 min-width-0">
         <app-todo-item
           [todo]="todo"
           (toggle)="toggle.emit($event)"
@@ -25,7 +33,14 @@
           (delete)="delete.emit($event)"
           (archive)="archive.emit($event)"
         />
+        </div>
       </div>
     }
   </div>
+  @if (selectedIds.length > 0) {
+    <div class="mt-2 small">
+      <button type="button" class="btn btn-link btn-sm p-0 me-2" (click)="onSelectAll()">全選択</button>
+      <button type="button" class="btn btn-link btn-sm p-0" (click)="selectionChange.emit([])">選択解除</button>
+    </div>
+  }
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -37,10 +37,8 @@
       </div>
     }
   </div>
-  @if (selectedIds.length > 0) {
-    <div class="mt-2 small">
-      <button type="button" class="btn btn-link btn-sm p-0 me-2" (click)="onSelectAll()">全選択</button>
-      <button type="button" class="btn btn-link btn-sm p-0" (click)="selectionChange.emit([])">選択解除</button>
-    </div>
-  }
+  <div class="mt-2 small">
+    <button type="button" class="btn btn-link btn-sm p-0 me-2" (click)="onSelectAll()">全選択</button>
+    <button type="button" class="btn btn-link btn-sm p-0" (click)="selectionChange.emit([])">選択解除</button>
+  </div>
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -17,11 +17,24 @@ export class TodoListComponent {
   @Input() error: string | null = null
   /** true のときドラッグ無効（ソートが「手動」以外のとき） */
   @Input() dragDisabled = true
+  @Input() selectedIds: number[] = []
+  @Output() selectionChange = new EventEmitter<number[]>()
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
   @Output() reorder = new EventEmitter<number[]>()
+
+  toggleSelection(id: number): void {
+    const next = this.selectedIds.includes(id)
+      ? this.selectedIds.filter((x) => x !== id)
+      : [...this.selectedIds, id]
+    this.selectionChange.emit(next)
+  }
+
+  onSelectAll(): void {
+    this.selectionChange.emit(this.todos.map((t) => t.id))
+  }
 
   onDrop(event: CdkDragDrop<Todo[]>): void {
     if (this.dragDisabled || event.previousIndex === event.currentIndex) return

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -55,11 +55,21 @@
 
       <hr class="my-3" />
 
+      <app-bulk-action-bar
+        [selectedCount]="selectedIds.length"
+        (bulkComplete)="onBulkComplete()"
+        (bulkDelete)="onBulkDelete()"
+        (bulkArchive)="onBulkArchive()"
+        (clearSelection)="selectedIds = []"
+      />
+
       <app-todo-list
         [todos]="todos"
         [loading]="loading"
         [error]="error"
         [dragDisabled]="sortBy !== 'sortOrder'"
+        [selectedIds]="selectedIds"
+        (selectionChange)="onSelectionChange($event)"
         (toggle)="onToggle($event)"
         (edit)="onEdit($event)"
         (delete)="onDelete($event)"

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -6,6 +6,7 @@ import { TodoListComponent } from '../todo-list/todo-list.component'
 import { TodoFormComponent } from '../todo-form/todo-form.component'
 import { SearchBarComponent } from '../search-bar/search-bar.component'
 import { SortSelectorComponent } from '../sort-selector/sort-selector.component'
+import { BulkActionBarComponent } from '../bulk-action-bar/bulk-action-bar.component'
 import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models/todo.interface'
 import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
@@ -19,6 +20,7 @@ import type { SortBy, SortOrder } from '../../../../../models/sort-options.inter
     TodoFormComponent,
     SearchBarComponent,
     SortSelectorComponent,
+    BulkActionBarComponent,
     CardComponent
   ],
   templateUrl: './todo-page.component.html',
@@ -35,6 +37,7 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
   searchQuery = ''
   sortBy: SortBy = 'createdAt'
   sortOrder: SortOrder = 'asc'
+  selectedIds: number[] = []
 
   private destroy$ = new Subject<void>()
 
@@ -121,6 +124,59 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
         next: () => this.loadTodos(),
         error: (err) => {
           this.error = err?.error?.message ?? err?.message ?? '並び替えに失敗しました'
+        }
+      })
+  }
+
+  onSelectionChange(ids: number[]): void {
+    this.selectedIds = ids
+  }
+
+  onBulkComplete(): void {
+    if (this.selectedIds.length === 0) return
+    this.todoService
+      .bulkComplete(this.selectedIds)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.selectedIds = []
+          this.loadTodos()
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '一括完了に失敗しました'
+        }
+      })
+  }
+
+  onBulkDelete(): void {
+    if (this.selectedIds.length === 0) return
+    if (!confirm(`選択した ${this.selectedIds.length} 件の Todo を削除しますか？`)) return
+    this.todoService
+      .bulkDelete(this.selectedIds)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.selectedIds = []
+          this.loadTodos()
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '一括削除に失敗しました'
+        }
+      })
+  }
+
+  onBulkArchive(): void {
+    if (this.selectedIds.length === 0) return
+    this.todoService
+      .bulkArchive(this.selectedIds)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.selectedIds = []
+          this.loadTodos()
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '一括アーカイブに失敗しました'
         }
       })
   }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -80,10 +80,12 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
 
   onSearch(term: string): void {
     this.searchQuery = term
+    this.selectedIds = []
     this.loadTodos()
   }
 
   onFiltersChange(): void {
+    this.selectedIds = []
     this.loadTodos()
   }
 
@@ -113,6 +115,7 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
   onSortChange(sort: { sortBy: SortBy; sortOrder: SortOrder }): void {
     this.sortBy = sort.sortBy
     this.sortOrder = sort.sortOrder
+    this.selectedIds = []
     this.loadTodos()
   }
 

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -82,4 +82,16 @@ export class TodoService {
   deleteArchivedTodos(): Observable<void> {
     return this.http.delete<void>(`${this.apiUrl}/todos/archived`)
   }
+
+  bulkComplete(todoIds: number[]): Observable<{ updated: number }> {
+    return this.http.post<{ updated: number }>(`${this.apiUrl}/todos/bulk-complete`, { todoIds })
+  }
+
+  bulkDelete(todoIds: number[]): Observable<{ deleted: number }> {
+    return this.http.post<{ deleted: number }>(`${this.apiUrl}/todos/bulk-delete`, { todoIds })
+  }
+
+  bulkArchive(todoIds: number[]): Observable<{ updated: number }> {
+    return this.http.post<{ updated: number }>(`${this.apiUrl}/todos/bulk-archive`, { todoIds })
+  }
 }


### PR DESCRIPTION
## 概要
複数 Todo を選択して一括で完了・アーカイブ・削除できるようにしました。

## 変更内容

### Backend
- `bulkComplete(todoIds, userId)` / `bulkDelete` / `bulkArchive`（未アーカイブ・所有者のみ対象）
- POST /api/v1/todos/bulk-complete, POST /api/v1/todos/bulk-delete, POST /api/v1/todos/bulk-archive（body: `{ todoIds: number[] }`）
- 認証・空 todoIds・正常系のテスト追加

### Frontend
- TodoService: `bulkComplete`, `bulkDelete`, `bulkArchive`
- TodoList: 行ごとチェックボックス、`selectedIds` / `selectionChange`、全選択・選択解除リンク
- BulkActionBar: 「N 件選択」表示、一括完了・一括アーカイブ・一括削除・選択解除ボタン
- TodoPage: 選択状態の保持、一括実行後に一覧再取得・選択クリア（一括削除は確認ダイアログ）

## ルール準拠
- ビルド・テストは Docker 内で実行
- 1 タスク = 1 PR（Phase A-4 一括操作）。一括タグ付けはタグ機能実装後に追加予定。

Made with [Cursor](https://cursor.com)