### PR TITLE
feat(ui): ダークモードを追加（Phase A-5）

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core'
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router'
 import { SharedModule } from './theme/shared/shared.module'
+import { ThemeService } from './services/theme.service'
 
 @Component({
   selector: 'app-root',
@@ -15,9 +16,13 @@ import { SharedModule } from './theme/shared/shared.module'
 export class AppComponent implements OnInit {
   title = 'Node App Frontend'
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private themeService: ThemeService
+  ) {}
 
   ngOnInit() {
+    this.themeService.init()
     this.router.events.subscribe((evt) => {
       if (!(evt instanceof NavigationEnd)) {
         return

--- a/frontend/src/app/services/theme.service.spec.ts
+++ b/frontend/src/app/services/theme.service.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing'
+import { ThemeService } from './theme.service'
+
+describe('ThemeService', () => {
+  let service: ThemeService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(ThemeService)
+    // テストごとに localStorage をクリア
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.removeItem('app-theme')
+    }
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should default to light theme', () => {
+    expect(service.currentTheme).toBe('light')
+  })
+
+  it('should set and persist dark theme', () => {
+    service.setTheme('dark')
+    expect(service.currentTheme).toBe('dark')
+    expect(window.localStorage.getItem('app-theme')).toBe('dark')
+  })
+
+  it('should set and persist light theme', () => {
+    service.setTheme('dark')
+    service.setTheme('light')
+    expect(service.currentTheme).toBe('light')
+    expect(window.localStorage.getItem('app-theme')).toBe('light')
+  })
+
+  it('should toggle from light to dark', () => {
+    service.toggle()
+    expect(service.currentTheme).toBe('dark')
+  })
+
+  it('should toggle from dark to light', () => {
+    service.setTheme('dark')
+    service.toggle()
+    expect(service.currentTheme).toBe('light')
+  })
+
+  it('should emit theme changes', (done) => {
+    service.themeChanges.subscribe((theme) => {
+      expect(theme).toBe('dark')
+      done()
+    })
+    service.setTheme('dark')
+  })
+})

--- a/frontend/src/app/services/theme.service.spec.ts
+++ b/frontend/src/app/services/theme.service.spec.ts
@@ -5,12 +5,12 @@ describe('ThemeService', () => {
   let service: ThemeService
 
   beforeEach(() => {
-    TestBed.configureTestingModule({})
-    service = TestBed.inject(ThemeService)
-    // テストごとに localStorage をクリア
+    // サービス生成前にクリア（順序依存を防ぐ）
     if (typeof window !== 'undefined' && window.localStorage) {
       window.localStorage.removeItem('app-theme')
     }
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(ThemeService)
   })
 
   it('should be created', () => {
@@ -51,5 +51,19 @@ describe('ThemeService', () => {
       done()
     })
     service.setTheme('dark')
+  })
+
+  it('init() should apply dark-mode class to body when theme is dark', () => {
+    service.setTheme('dark')
+    document.body.classList.remove('dark-mode')
+    service.init()
+    expect(document.body.classList.contains('dark-mode')).toBe(true)
+  })
+
+  it('init() should remove dark-mode class from body when theme is light', () => {
+    service.setTheme('dark')
+    service.setTheme('light')
+    service.init()
+    expect(document.body.classList.contains('dark-mode')).toBe(false)
   })
 })

--- a/frontend/src/app/services/theme.service.ts
+++ b/frontend/src/app/services/theme.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core'
+import { BehaviorSubject, Observable } from 'rxjs'
+
+export type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'app-theme'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private readonly theme$ = new BehaviorSubject<Theme>(this.getStored())
+
+  get currentTheme(): Theme {
+    return this.theme$.getValue()
+  }
+
+  get themeChanges(): Observable<Theme> {
+    return this.theme$.asObservable()
+  }
+
+  /** ローカルストレージから復元（デフォルト light） */
+  private getStored(): Theme {
+    if (typeof window === 'undefined' || !window.localStorage) return 'light'
+    const v = window.localStorage.getItem(STORAGE_KEY)
+    return v === 'dark' ? 'dark' : 'light'
+  }
+
+  /** 起動時に body にクラスを適用（AppComponent から呼ぶ） */
+  init(): void {
+    this.applyToDom(this.currentTheme)
+  }
+
+  setTheme(theme: Theme): void {
+    if (this.theme$.getValue() === theme) return
+    this.theme$.next(theme)
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, theme)
+      this.applyToDom(theme)
+    }
+  }
+
+  toggle(): void {
+    this.setTheme(this.currentTheme === 'light' ? 'dark' : 'light')
+  }
+
+  private applyToDom(theme: Theme): void {
+    if (typeof document === 'undefined') return
+    const body = document.body
+    if (theme === 'dark') {
+      body.classList.add('dark-mode')
+    } else {
+      body.classList.remove('dark-mode')
+    }
+  }
+}

--- a/frontend/src/app/theme/layout/admin/nav-bar/nav-right/nav-right.component.html
+++ b/frontend/src/app/theme/layout/admin/nav-bar/nav-right/nav-right.component.html
@@ -1,4 +1,7 @@
 <ul class="navbar-nav">
+  <li class="nav-item d-flex align-items-center">
+    <app-theme-toggle></app-theme-toggle>
+  </li>
   <li>
     <div class="dropdown drp-user" ngbDropdown placement="auto">
       <a href="javascript:" ngbDropdownToggle data-toggle="dropdown" class="d-flex align-items-center">

--- a/frontend/src/app/theme/layout/admin/nav-bar/nav-right/nav-right.component.ts
+++ b/frontend/src/app/theme/layout/admin/nav-bar/nav-right/nav-right.component.ts
@@ -2,12 +2,14 @@ import { Component } from '@angular/core'
 import { Router } from '@angular/router'
 import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap'
 import { AuthService } from '../../../../../services/auth.service'
+import { ThemeToggleComponent } from '../../../../shared/components/theme-toggle/theme-toggle.component'
 
 @Component({
   selector: 'app-nav-right',
   templateUrl: './nav-right.component.html',
   standalone: true,
   imports: [
+    ThemeToggleComponent,
     NgbDropdownToggle,
     NgbDropdown,
     NgbDropdownMenu

--- a/frontend/src/app/theme/shared/components/theme-toggle/theme-toggle.component.html
+++ b/frontend/src/app/theme/shared/components/theme-toggle/theme-toggle.component.html
@@ -1,0 +1,14 @@
+<button
+  type="button"
+  class="btn btn-link theme-toggle-btn d-flex align-items-center text-decoration-none"
+  (click)="toggle()"
+  [attr.aria-label]="themeService.currentTheme === 'light' ? 'ダークモードに切り替え' : 'ライトモードに切り替え'"
+>
+  @if (themeService.currentTheme === 'light') {
+    <i class="feather icon-moon" aria-hidden="true"></i>
+    <span class="ms-1 d-none d-sm-inline">ダーク</span>
+  } @else {
+    <i class="feather icon-sun" aria-hidden="true"></i>
+    <span class="ms-1 d-none d-sm-inline">ライト</span>
+  }
+</button>

--- a/frontend/src/app/theme/shared/components/theme-toggle/theme-toggle.component.scss
+++ b/frontend/src/app/theme/shared/components/theme-toggle/theme-toggle.component.scss
@@ -1,0 +1,9 @@
+.theme-toggle-btn {
+  color: inherit;
+  padding: 0.25rem 0.5rem;
+
+  &:hover {
+    color: inherit;
+    opacity: 0.85;
+  }
+}

--- a/frontend/src/app/theme/shared/components/theme-toggle/theme-toggle.component.ts
+++ b/frontend/src/app/theme/shared/components/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core'
+import { ThemeService } from '../../../../services/theme.service'
+
+@Component({
+  selector: 'app-theme-toggle',
+  standalone: true,
+  imports: [],
+  templateUrl: './theme-toggle.component.html',
+  styleUrls: ['./theme-toggle.component.scss']
+})
+export class ThemeToggleComponent {
+  constructor(public themeService: ThemeService) {}
+
+  toggle(): void {
+    this.themeService.toggle()
+  }
+}

--- a/frontend/src/scss/_dark-mode.scss
+++ b/frontend/src/scss/_dark-mode.scss
@@ -55,7 +55,7 @@ body.dark-mode {
       color: #a9b7d0 !important;
     }
 
-    .pcoded-navbar .pcoded-inner-navbar li.active > a .pcoded-mtext {
+    .pcoded-inner-navbar li.active > a .pcoded-mtext {
       color: #04a9f5 !important;
     }
   }

--- a/frontend/src/scss/_dark-mode.scss
+++ b/frontend/src/scss/_dark-mode.scss
@@ -1,0 +1,173 @@
+// =======================================
+// ダークモード: body.dark-mode で適用
+// CSS 変数で一括定義し、必要に応じて上書き
+// =======================================
+
+:root {
+  --app-bg: #f4f7fa;
+  --app-text: #888;
+  --app-heading: #111;
+  --app-border: #eaeaea;
+  --app-card-bg: #fff;
+}
+
+body.dark-mode {
+  background: #1a1d23;
+  color: #b0b0b0;
+
+  h1, h2, h3, h4, h5, h6 {
+    color: #e8e8e8;
+  }
+
+  // メインコンテンツ
+  .pcoded-main-container,
+  .pcoded-content,
+  .pcoded-inner-content,
+  .main-body,
+  .page-wrapper {
+    background: #1a1d23;
+  }
+
+  // ヘッダー
+  .pcoded-header.navbar,
+  .pcoded-header .m-header {
+    background: #252830 !important;
+    border-color: #333;
+
+    .b-title,
+    .navbar-nav .nav-link,
+    .dropdown .dropdown-toggle {
+      color: #e0e0e0 !important;
+    }
+
+    .theme-toggle-btn {
+      color: #e0e0e0;
+    }
+  }
+
+  // サイドバー
+  .pcoded-navbar {
+    background: #252830 !important;
+
+    .pcoded-inner-navbar .pcoded-mtext,
+    .pcoded-inner-navbar .pcoded-micon,
+    .pcoded-menu-caption {
+      color: #a9b7d0 !important;
+    }
+
+    .pcoded-navbar .pcoded-inner-navbar li.active > a .pcoded-mtext {
+      color: #04a9f5 !important;
+    }
+  }
+
+  // カード
+  .card {
+    background: #252830;
+    border-color: #333;
+
+    .card-header {
+      background: #2d3139;
+      border-color: #333;
+      color: #e8e8e8;
+    }
+
+    .card-body {
+      background: #252830;
+      color: #b0b0b0;
+    }
+  }
+
+  // パンくず・テキスト
+  .breadcrumb-item,
+  .breadcrumb-item a {
+    color: #a0a0a0 !important;
+  }
+
+  .breadcrumb-item.active,
+  .page-header-title {
+    color: #e8e8e8 !important;
+  }
+
+  // フォーム
+  .form-control,
+  .form-select {
+    background: #2d3139;
+    border-color: #444;
+    color: #e0e0e0;
+
+    &::placeholder {
+      color: #888;
+    }
+  }
+
+  .form-control:focus,
+  .form-select:focus {
+    background: #2d3139;
+    border-color: #04a9f5;
+    color: #e0e0e0;
+  }
+
+  // リスト・テーブル
+  .list-group-item {
+    background: #252830;
+    border-color: #333;
+    color: #b0b0b0;
+  }
+
+  .table {
+    color: #b0b0b0;
+
+    th, td {
+      border-color: #333;
+    }
+  }
+
+  // アラート・バッジ
+  .alert {
+    background: #2d3139;
+    border-color: #444;
+    color: #b0b0b0;
+  }
+
+  // Bootstrap ドロップダウン
+  .dropdown-menu {
+    background: #252830;
+    border-color: #333;
+  }
+
+  .dropdown-item {
+    color: #b0b0b0;
+
+    &:hover {
+      background: #2d3139;
+      color: #e0e0e0;
+    }
+  }
+
+  // リンク・ボタン
+  .btn-link {
+    color: #7eb8da;
+  }
+
+  .btn-outline-secondary,
+  .btn-outline-success,
+  .btn-outline-danger {
+    border-color: #555;
+    color: #b0b0b0;
+
+    &:hover {
+      background: #2d3139;
+      color: #e0e0e0;
+    }
+  }
+
+  // Todo 一覧など
+  .todo-row,
+  .bg-light {
+    background: #2d3139 !important;
+  }
+
+  .text-muted {
+    color: #888 !important;
+  }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -18,3 +18,4 @@
 @import 'scss/plugins/plugins';
 
 @import 'scss/custom';
+@import 'scss/dark-mode';


### PR DESCRIPTION
## 概要
ライト/ダークテーマを切り替え可能にし、選択を LocalStorage に保存する機能を追加しました。

## 変更内容

### ThemeService
- `currentTheme` / `themeChanges` で現在テーマを取得・購読
- `setTheme('light'|'dark')` / `toggle()` で切り替え
- `init()`: 起動時に LocalStorage（`app-theme`）から復元し `body` に `.dark-mode` を適用

### ThemeToggleComponent
- ヘッダー右（ユーザーメニュー左）に配置
- ライト時は月アイコン＋「ダーク」、ダーク時は太陽アイコン＋「ライト」を表示
- クリックでテーマ切り替え

### スタイル
- `_dark-mode.scss`: `body.dark-mode` 配下で背景・ヘッダー・サイドバー・カード・フォーム・リスト等をダーク配色にオーバーライド
- `:root` に CSS 変数（`--app-bg` 等）を定義（今後の拡張用）

### テスト
- ThemeService のユニットテスト（デフォルト light、setTheme/toggle、永続化、themeChanges 発火）を追加

## ルール準拠
- ビルドは Docker 内で `ng build` 実行済み
- 1 タスク = 1 PR（Phase A-5 ダークモード）

Made with [Cursor](https://cursor.com)