### PR TITLE
feat(todo): タグ機能を追加（Phase B）

### DIFF
--- a/backend/controllers/tagController.js
+++ b/backend/controllers/tagController.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const tagService = require('../services/tagService');
+
+function handleTagError(fastify, reply, error, clientMessage, statusCode = 500) {
+  fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, clientMessage);
+  reply.code(statusCode).send({ error: clientMessage });
+}
+
+function parseTagId(paramId) {
+  const id = parseInt(paramId, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+async function createTag(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const tag = await tagService.createTag(fastify, userId, req.body);
+    if (!tag) {
+      const empty = !req.body.name || String(req.body.name).trim() === '';
+      return reply.code(empty ? 400 : 409).send({ error: empty ? 'Tag name is required' : 'Tag with this name already exists' });
+    }
+    reply.code(201).send(tag.toJSON());
+  } catch (error) {
+    handleTagError(fastify, reply, error, 'Tag creation failed');
+  }
+}
+
+async function getTags(fastify, req, reply) {
+  try {
+    const tags = await tagService.getTagsByUserId(fastify, req.user.id);
+    reply.code(200).send(tags.map((t) => t.toJSON()));
+  } catch (error) {
+    handleTagError(fastify, reply, error, 'Failed to get tags');
+  }
+}
+
+async function getTagById(fastify, req, reply) {
+  try {
+    const tagId = parseTagId(req.params.id);
+    if (tagId === null) return reply.code(400).send({ error: 'Invalid tag id' });
+    const tag = await tagService.getTagById(fastify, tagId, req.user.id);
+    if (!tag) return reply.code(404).send({ error: 'Not found' });
+    reply.code(200).send(tag.toJSON());
+  } catch (error) {
+    handleTagError(fastify, reply, error, 'Failed to get tag');
+  }
+}
+
+async function updateTag(fastify, req, reply) {
+  try {
+    const tagId = parseTagId(req.params.id);
+    if (tagId === null) return reply.code(400).send({ error: 'Invalid tag id' });
+    const tag = await tagService.updateTag(fastify, tagId, req.user.id, req.body);
+    if (!tag) {
+      const existing = await tagService.getTagById(fastify, tagId, req.user.id);
+      return reply.code(existing ? 409 : 404).send({ error: existing ? 'Tag with this name already exists' : 'Not found' });
+    }
+    reply.code(200).send(tag.toJSON());
+  } catch (error) {
+    handleTagError(fastify, reply, error, 'Tag update failed');
+  }
+}
+
+async function deleteTag(fastify, req, reply) {
+  try {
+    const tagId = parseTagId(req.params.id);
+    if (tagId === null) return reply.code(400).send({ error: 'Invalid tag id' });
+    const deleted = await tagService.deleteTag(fastify, tagId, req.user.id);
+    if (!deleted) return reply.code(404).send({ error: 'Not found' });
+    reply.code(204).send();
+  } catch (error) {
+    handleTagError(fastify, reply, error, 'Tag delete failed');
+  }
+}
+
+module.exports = {
+  createTag,
+  getTags,
+  getTagById,
+  updateTag,
+  deleteTag,
+};

--- a/backend/controllers/tagController.js
+++ b/backend/controllers/tagController.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const tagService = require('../services/tagService');
+const { UniqueConstraintError } = require('sequelize');
 
 function handleTagError(fastify, reply, error, clientMessage, statusCode = 500) {
   fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, clientMessage);
@@ -22,6 +23,9 @@ async function createTag(fastify, req, reply) {
     }
     reply.code(201).send(tag.toJSON());
   } catch (error) {
+    if (error instanceof UniqueConstraintError) {
+      return reply.code(409).send({ error: 'Tag with this name already exists' });
+    }
     handleTagError(fastify, reply, error, 'Tag creation failed');
   }
 }
@@ -51,12 +55,10 @@ async function updateTag(fastify, req, reply) {
   try {
     const tagId = parseTagId(req.params.id);
     if (tagId === null) return reply.code(400).send({ error: 'Invalid tag id' });
-    const tag = await tagService.updateTag(fastify, tagId, req.user.id, req.body);
-    if (!tag) {
-      const existing = await tagService.getTagById(fastify, tagId, req.user.id);
-      return reply.code(existing ? 409 : 404).send({ error: existing ? 'Tag with this name already exists' : 'Not found' });
-    }
-    reply.code(200).send(tag.toJSON());
+    const result = await tagService.updateTag(fastify, tagId, req.user.id, req.body);
+    if (result.duplicate) return reply.code(409).send({ error: 'Tag with this name already exists' });
+    if (!result.updated) return reply.code(404).send({ error: 'Not found' });
+    reply.code(200).send(result.updated.toJSON());
   } catch (error) {
     handleTagError(fastify, reply, error, 'Tag update failed');
   }

--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -22,6 +22,12 @@ async function createTodo(fastify, req, reply) {
   }
 }
 
+function parseTagIdsQuery(q) {
+  if (q == null || q === '') return undefined;
+  const ids = String(q).split(',').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isInteger(n) && n > 0);
+  return ids.length > 0 ? ids : undefined;
+}
+
 async function getTodos(fastify, req, reply) {
   try {
     const userId = req.user.id;
@@ -30,6 +36,7 @@ async function getTodos(fastify, req, reply) {
       priority: req.query.priority,
       sortBy: req.query.sortBy,
       sortOrder: req.query.sortOrder,
+      tagIds: parseTagIdsQuery(req.query.tags),
     };
     const todos = await todoService.getTodosByUserId(fastify, userId, options);
     reply.code(200).send(todos.map((t) => t.toJSON()));
@@ -116,6 +123,7 @@ async function searchTodos(fastify, req, reply) {
         req.query.completed === 'true' ? true : req.query.completed === 'false' ? false : undefined,
       sortBy: req.query.sortBy,
       sortOrder: req.query.sortOrder,
+      tagIds: parseTagIdsQuery(req.query.tags),
     };
     const todos = await todoService.searchTodos(fastify, userId, params);
     reply.code(200).send(todos.map((t) => t.toJSON()));
@@ -218,6 +226,36 @@ async function bulkArchive(fastify, req, reply) {
   }
 }
 
+async function addTagToTodo(fastify, req, reply) {
+  try {
+    const todoId = parseTodoId(req.params.todoId);
+    const tagId = parseTodoId(req.body?.tagId);
+    if (todoId === null || tagId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id or tag id' });
+    }
+    const ok = await todoService.addTagToTodo(fastify, todoId, tagId, req.user.id);
+    if (!ok) return reply.code(404).send({ error: 'Not found' });
+    reply.code(204).send();
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Add tag to todo failed');
+  }
+}
+
+async function removeTagFromTodo(fastify, req, reply) {
+  try {
+    const todoId = parseTodoId(req.params.todoId);
+    const tagId = parseTodoId(req.params.tagId);
+    if (todoId === null || tagId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id or tag id' });
+    }
+    const ok = await todoService.removeTagFromTodo(fastify, todoId, tagId, req.user.id);
+    if (!ok) return reply.code(404).send({ error: 'Not found' });
+    reply.code(204).send();
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Remove tag from todo failed');
+  }
+}
+
 module.exports = {
   createTodo,
   getTodos,
@@ -234,4 +272,6 @@ module.exports = {
   bulkComplete,
   bulkDelete,
   bulkArchive,
+  addTagToTodo,
+  removeTagFromTodo,
 };

--- a/backend/migrations/20260301140000-create-tags.js
+++ b/backend/migrations/20260301140000-create-tags.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('tags', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      name: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+      },
+      color: {
+        type: Sequelize.STRING(7),
+        allowNull: false,
+        defaultValue: '#808080',
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+    await queryInterface.addIndex('tags', ['user_id']);
+    await queryInterface.addIndex('tags', ['user_id', 'name'], { unique: true });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('tags');
+  },
+};

--- a/backend/migrations/20260301140001-create-todo-tags.js
+++ b/backend/migrations/20260301140001-create-todo-tags.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('todo_tags', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      todo_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      tag_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'tags', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+    await queryInterface.addIndex('todo_tags', ['todo_id']);
+    await queryInterface.addIndex('todo_tags', ['tag_id']);
+    await queryInterface.addIndex('todo_tags', ['todo_id', 'tag_id'], { unique: true });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('todo_tags');
+  },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,6 +3,8 @@
 const fp = require('fastify-plugin')
 const User = require('./user')
 const Todo = require('./todo')
+const Tag = require('./tag')
+const TodoTag = require('./todoTag')
 
 module.exports = fp(async function (fastify, opts) {
   const sequelize = fastify.sequelize
@@ -10,6 +12,8 @@ module.exports = fp(async function (fastify, opts) {
   const models = {
     User: User(sequelize),
     Todo: Todo(sequelize),
+    Tag: Tag(sequelize),
+    TodoTag: TodoTag(sequelize),
   }
 
   Object.keys(models).forEach((name) => {

--- a/backend/models/tag.js
+++ b/backend/models/tag.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { DataTypes } = require('sequelize');
+
+const HEX_COLOR = /^#[0-9A-Fa-f]{6}$/;
+
+module.exports = (sequelize) => {
+  const Tag = sequelize.define(
+    'Tag',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'user_id',
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      name: {
+        type: DataTypes.STRING(50),
+        allowNull: false,
+      },
+      color: {
+        type: DataTypes.STRING(7),
+        allowNull: false,
+        defaultValue: '#808080',
+      },
+    },
+    {
+      tableName: 'tags',
+      timestamps: true,
+      underscored: true,
+      validate: {
+        colorFormat() {
+          if (this.color && !HEX_COLOR.test(this.color)) {
+            throw new Error('color must be a valid hex (e.g. #808080)');
+          }
+        },
+      },
+    }
+  );
+
+  Tag.associate = function (models) {
+    Tag.belongsTo(models.User, { foreignKey: 'userId' });
+    Tag.belongsToMany(models.Todo, { through: models.TodoTag, foreignKey: 'tagId', otherKey: 'todoId' });
+  };
+
+  return Tag;
+};

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -72,6 +72,7 @@ module.exports = (sequelize) => {
 
   Todo.associate = function (models) {
     Todo.belongsTo(models.User, { foreignKey: 'userId' });
+    Todo.belongsToMany(models.Tag, { through: models.TodoTag, foreignKey: 'todoId', otherKey: 'tagId' });
   };
 
   return Todo;

--- a/backend/models/todoTag.js
+++ b/backend/models/todoTag.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const TodoTag = sequelize.define(
+    'TodoTag',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      todoId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'todo_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      tagId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'tag_id',
+        references: { model: 'tags', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+    },
+    {
+      tableName: 'todo_tags',
+      timestamps: true,
+      updatedAt: false,
+      underscored: true,
+    }
+  );
+
+  TodoTag.associate = function (models) {
+    TodoTag.belongsTo(models.Todo, { foreignKey: 'todoId' });
+    TodoTag.belongsTo(models.Tag, { foreignKey: 'tagId' });
+  };
+
+  return TodoTag;
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -28,6 +28,7 @@ module.exports = (sequelize) => {
 
   User.associate = function (models) {
     User.hasMany(models.Todo, { foreignKey: 'userId' });
+    User.hasMany(models.Tag, { foreignKey: 'userId' });
   };
 
   return User;

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -18,7 +18,16 @@ const {
   bulkComplete,
   bulkDelete,
   bulkArchive,
+  addTagToTodo,
+  removeTagFromTodo,
 } = require('../../../controllers/todoController');
+const {
+  createTag,
+  getTags,
+  getTagById,
+  updateTag,
+  deleteTag,
+} = require('../../../controllers/tagController');
 
 module.exports = async function (fastify, opts) {
   /**
@@ -73,6 +82,68 @@ module.exports = async function (fastify, opts) {
   fastify.delete('/users/:id', { preHandler: [fastify.authenticate] }, async (request, reply)=> deleteUser(fastify, request, reply));
 
   /**
+   * tags CRUD API routes (JWT 必須)
+   */
+  fastify.post('/tags', {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string', maxLength: 50 },
+          color: { type: 'string', maxLength: 7 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => createTag(fastify, request, reply),
+  });
+  fastify.get('/tags', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getTags(fastify, request, reply),
+  });
+  fastify.get('/tags/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getTagById(fastify, request, reply),
+  });
+  fastify.put('/tags/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', maxLength: 50 },
+          color: { type: 'string', maxLength: 7 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => updateTag(fastify, request, reply),
+  });
+  fastify.delete('/tags/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => deleteTag(fastify, request, reply),
+  });
+
+  /**
    * todos CRUD API routes (JWT 必須)
    */
   fastify.post('/todos', {
@@ -100,6 +171,7 @@ module.exports = async function (fastify, opts) {
           priority: { type: 'string', enum: ['low', 'medium', 'high'] },
           sortBy: { type: 'string', enum: ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'] },
           sortOrder: { type: 'string', enum: ['asc', 'desc'] },
+          tags: { type: 'string' },
         },
       },
     },
@@ -133,6 +205,7 @@ module.exports = async function (fastify, opts) {
           priority: { type: 'string', enum: ['low', 'medium', 'high'] },
           sortBy: { type: 'string', enum: ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'] },
           sortOrder: { type: 'string', enum: ['asc', 'desc'] },
+          tags: { type: 'string' },
         },
       },
     },
@@ -173,6 +246,36 @@ module.exports = async function (fastify, opts) {
     schema: { body: bulkBodySchema },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => bulkArchive(fastify, request, reply),
+  });
+  fastify.post('/todos/:todoId/tags', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['todoId'],
+        properties: { todoId: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        required: ['tagId'],
+        properties: { tagId: { type: 'integer' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => addTagToTodo(fastify, request, reply),
+  });
+  fastify.delete('/todos/:todoId/tags/:tagId', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['todoId', 'tagId'],
+        properties: {
+          todoId: { type: 'string', pattern: '^[0-9]+$' },
+          tagId: { type: 'string', pattern: '^[0-9]+$' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => removeTagFromTodo(fastify, request, reply),
   });
   fastify.get('/todos/:id', {
     schema: {

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -90,7 +90,7 @@ module.exports = async function (fastify, opts) {
         type: 'object',
         required: ['name'],
         properties: {
-          name: { type: 'string', maxLength: 50 },
+          name: { type: 'string', minLength: 1, maxLength: 50 },
           color: { type: 'string', maxLength: 7 },
         },
       },
@@ -123,7 +123,7 @@ module.exports = async function (fastify, opts) {
       body: {
         type: 'object',
         properties: {
-          name: { type: 'string', maxLength: 50 },
+          name: { type: 'string', minLength: 1, maxLength: 50 },
           color: { type: 'string', maxLength: 7 },
         },
       },

--- a/backend/services/tagService.js
+++ b/backend/services/tagService.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Op } = require('sequelize');
+const { UniqueConstraintError } = require('sequelize');
 
 const HEX_COLOR = /^#[0-9A-Fa-f]{6}$/;
 
@@ -11,21 +12,21 @@ function normalizeColor(color) {
 }
 
 /**
- * タグを作成する（同一ユーザー内で name 重複時は null、呼び出し側で 409 用）
+ * タグを作成する（findOrCreate で race condition を避け、重複時は null → コントローラで 409）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} userId - ユーザー ID
  * @param {object} data - { name, color? }
- * @returns {Promise<object|null>} 作成された Tag、重複時は null
+ * @returns {Promise<object|null>} 新規作成された Tag のみ返す。既存同名なら null
  */
 async function createTag(fastify, userId, data) {
   const name = typeof data.name === 'string' ? data.name.trim() : '';
   if (!name) return null;
   const color = normalizeColor(data.color);
-  const existing = await fastify.models.Tag.findOne({
+  const [tag, created] = await fastify.models.Tag.findOrCreate({
     where: { userId, name },
+    defaults: { userId, name, color },
   });
-  if (existing) return null;
-  return fastify.models.Tag.create({ userId, name, color });
+  return created ? tag : null;
 }
 
 /**
@@ -55,27 +56,32 @@ async function getTagById(fastify, tagId, userId) {
 }
 
 /**
- * タグを更新する（同一ユーザー内で name 重複時は null）
+ * タグを更新する。UNIQUE 違反時は 409 用に duplicate を返す。
  * @param {object} fastify - Fastify インスタンス
  * @param {number} tagId - タグ ID
  * @param {number} userId - ユーザー ID
  * @param {object} data - { name?, color? }
- * @returns {Promise<object|null>} 更新後の Tag、未存在または重複時は null
+ * @returns {Promise<{ updated: object|null, duplicate: boolean }>}
  */
 async function updateTag(fastify, tagId, userId, data) {
   const tag = await getTagById(fastify, tagId, userId);
-  if (!tag) return null;
+  if (!tag) return { updated: null, duplicate: false };
   const name = data.name != null ? String(data.name).trim() : null;
   if (name !== null) {
     const existing = await fastify.models.Tag.findOne({
       where: { userId, name, id: { [Op.ne]: tagId } },
     });
-    if (existing) return null;
+    if (existing) return { updated: null, duplicate: true };
     tag.name = name;
   }
   if (data.color !== undefined) tag.color = normalizeColor(data.color);
-  await tag.save();
-  return tag;
+  try {
+    await tag.save();
+    return { updated: tag, duplicate: false };
+  } catch (err) {
+    if (err instanceof UniqueConstraintError) return { updated: null, duplicate: true };
+    throw err;
+  }
 }
 
 /**

--- a/backend/services/tagService.js
+++ b/backend/services/tagService.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const { Op } = require('sequelize');
+
+const HEX_COLOR = /^#[0-9A-Fa-f]{6}$/;
+
+function normalizeColor(color) {
+  if (color == null || color === '') return '#808080';
+  const s = String(color).trim();
+  return HEX_COLOR.test(s) ? s : '#808080';
+}
+
+/**
+ * タグを作成する（同一ユーザー内で name 重複時は null、呼び出し側で 409 用）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @param {object} data - { name, color? }
+ * @returns {Promise<object|null>} 作成された Tag、重複時は null
+ */
+async function createTag(fastify, userId, data) {
+  const name = typeof data.name === 'string' ? data.name.trim() : '';
+  if (!name) return null;
+  const color = normalizeColor(data.color);
+  const existing = await fastify.models.Tag.findOne({
+    where: { userId, name },
+  });
+  if (existing) return null;
+  return fastify.models.Tag.create({ userId, name, color });
+}
+
+/**
+ * ユーザーのタグ一覧を取得する
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object[]>} Tag 配列
+ */
+async function getTagsByUserId(fastify, userId) {
+  return fastify.models.Tag.findAll({
+    where: { userId },
+    order: [['name', 'ASC']],
+  });
+}
+
+/**
+ * タグを 1 件取得する（所有者のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} tagId - タグ ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object|null>}
+ */
+async function getTagById(fastify, tagId, userId) {
+  return fastify.models.Tag.findOne({
+    where: { id: tagId, userId },
+  });
+}
+
+/**
+ * タグを更新する（同一ユーザー内で name 重複時は null）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} tagId - タグ ID
+ * @param {number} userId - ユーザー ID
+ * @param {object} data - { name?, color? }
+ * @returns {Promise<object|null>} 更新後の Tag、未存在または重複時は null
+ */
+async function updateTag(fastify, tagId, userId, data) {
+  const tag = await getTagById(fastify, tagId, userId);
+  if (!tag) return null;
+  const name = data.name != null ? String(data.name).trim() : null;
+  if (name !== null) {
+    const existing = await fastify.models.Tag.findOne({
+      where: { userId, name, id: { [Op.ne]: tagId } },
+    });
+    if (existing) return null;
+    tag.name = name;
+  }
+  if (data.color !== undefined) tag.color = normalizeColor(data.color);
+  await tag.save();
+  return tag;
+}
+
+/**
+ * タグを削除する（使用中でも削除可、todo_tags は CASCADE で削除）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} tagId - タグ ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<boolean>} 削除した場合 true、存在しなければ false
+ */
+async function deleteTag(fastify, tagId, userId) {
+  const tag = await getTagById(fastify, tagId, userId);
+  if (!tag) return false;
+  await tag.destroy();
+  return true;
+}
+
+module.exports = {
+  createTag,
+  getTagsByUserId,
+  getTagById,
+  updateTag,
+  deleteTag,
+};

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Op } = require('sequelize');
+const tagService = require('./tagService');
 
 const SORT_BY_ALLOWED = ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'];
 const SORT_ORDER_ALLOWED = ['asc', 'desc'];
@@ -206,7 +207,6 @@ async function searchTodos(fastify, userId, params = {}) {
 async function addTagToTodo(fastify, todoId, tagId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
-  const tagService = require('./tagService');
   const tag = await tagService.getTagById(fastify, tagId, userId);
   if (!tag) return false;
   const [todoTag] = await fastify.models.TodoTag.findOrCreate({
@@ -227,7 +227,6 @@ async function addTagToTodo(fastify, todoId, tagId, userId) {
 async function removeTagFromTodo(fastify, todoId, tagId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
-  const tagService = require('./tagService');
   const tag = await tagService.getTagById(fastify, tagId, userId);
   if (!tag) return false;
   const result = await fastify.models.TodoTag.destroy({

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -35,11 +35,11 @@ async function createTodo(fastify, userId, todoData) {
 }
 
 /**
- * ユーザーの Todo 一覧をフィルタ・ソート付きで取得する
+ * ユーザーの Todo 一覧をフィルタ・ソート付きで取得する（タグ付き）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} userId - ユーザー ID
- * @param {object} options - { completed?, priority?, sortBy?, sortOrder? }
- * @returns {Promise<object[]>} Todo 配列
+ * @param {object} options - { completed?, priority?, sortBy?, sortOrder?, tagIds? }
+ * @returns {Promise<object[]>} Todo 配列（Tags を含む）
  */
 async function getTodosByUserId(fastify, userId, options = {}) {
   const where = { userId, archived: false };
@@ -54,10 +54,22 @@ async function getTodosByUserId(fastify, userId, options = {}) {
     options.sortBy,
     options.sortOrder
   );
-  return fastify.models.Todo.findAll({
+  const tagIds = Array.isArray(options.tagIds)
+    ? options.tagIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0)
+    : [];
+  const include = [{ model: fastify.models.Tag, as: 'Tags', through: { attributes: [] }, required: false }];
+  let todos = await fastify.models.Todo.findAll({
     where,
+    include,
     order,
   });
+  if (tagIds.length > 0) {
+    todos = todos.filter((t) => {
+      const todoTagIds = (t.Tags || []).map((tag) => tag.id);
+      return tagIds.every((id) => todoTagIds.includes(id));
+    });
+  }
+  return todos;
 }
 
 /**
@@ -71,6 +83,7 @@ async function getTodosByUserId(fastify, userId, options = {}) {
 async function getTodoById(fastify, todoId, userId) {
   return fastify.models.Todo.findOne({
     where: { id: todoId, userId, archived: false },
+    include: [{ model: fastify.models.Tag, as: 'Tags', through: { attributes: [] }, required: false }],
   });
 }
 
@@ -164,10 +177,63 @@ async function searchTodos(fastify, userId, params = {}) {
     params.sortBy,
     params.sortOrder
   );
-  return fastify.models.Todo.findAll({
+  const tagIds = Array.isArray(params.tagIds)
+    ? params.tagIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0)
+    : [];
+  const include = [{ model: fastify.models.Tag, as: 'Tags', through: { attributes: [] }, required: false }];
+  let todos = await fastify.models.Todo.findAll({
     where,
+    include,
     order,
   });
+  if (tagIds.length > 0) {
+    todos = todos.filter((t) => {
+      const todoTagIds = (t.Tags || []).map((tag) => tag.id);
+      return tagIds.every((id) => todoTagIds.includes(id));
+    });
+  }
+  return todos;
+}
+
+/**
+ * Todo にタグを付与する（所有者の Todo と Tag のみ、冪等）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} tagId - タグ ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<boolean>} 付与した場合 true、既に付与済みまたは存在しなければ false
+ */
+async function addTagToTodo(fastify, todoId, tagId, userId) {
+  const todo = await getTodoById(fastify, todoId, userId);
+  if (!todo) return false;
+  const tagService = require('./tagService');
+  const tag = await tagService.getTagById(fastify, tagId, userId);
+  if (!tag) return false;
+  const [todoTag] = await fastify.models.TodoTag.findOrCreate({
+    where: { todoId, tagId },
+    defaults: { todoId, tagId },
+  });
+  return !!todoTag;
+}
+
+/**
+ * Todo からタグを外す（所有者のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} tagId - タグ ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<boolean>} 削除した場合 true、存在しなければ false
+ */
+async function removeTagFromTodo(fastify, todoId, tagId, userId) {
+  const todo = await getTodoById(fastify, todoId, userId);
+  if (!todo) return false;
+  const tagService = require('./tagService');
+  const tag = await tagService.getTagById(fastify, tagId, userId);
+  if (!tag) return false;
+  const result = await fastify.models.TodoTag.destroy({
+    where: { todoId, tagId },
+  });
+  return result > 0;
 }
 
 /**
@@ -329,4 +395,6 @@ module.exports = {
   bulkComplete,
   bulkDelete,
   bulkArchive,
+  addTagToTodo,
+  removeTagFromTodo,
 };

--- a/backend/test/routes/tags.test.js
+++ b/backend/test/routes/tags.test.js
@@ -157,3 +157,129 @@ test('GET /api/v1/todos?tags= filters by tag', async (t) => {
   assert(list.length >= 1);
   assert(list.every((todo) => (todo.Tags || []).some((t) => t.id === tag.id)));
 });
+
+test('other user cannot update tag (PUT /tags/:id returns 404)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const userA = { name: `tagA-${suffix}`, email: `tagA-${suffix}@test.local`, password: 'pass123' };
+  const userB = { name: `tagB-${suffix}`, email: `tagB-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA });
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB });
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } });
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } });
+  const tokenA = JSON.parse(loginA.payload).token;
+  const tokenB = JSON.parse(loginB.payload).token;
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { name: 'A tag' },
+  });
+  const tag = JSON.parse(createRes.payload);
+  const res = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { name: 'hacked' },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('other user cannot delete tag (DELETE /tags/:id returns 404)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const userA = { name: `tagdelA-${suffix}`, email: `tagdelA-${suffix}@test.local`, password: 'pass123' };
+  const userB = { name: `tagdelB-${suffix}`, email: `tagdelB-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA });
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB });
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } });
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } });
+  const tokenA = JSON.parse(loginA.payload).token;
+  const tokenB = JSON.parse(loginB.payload).token;
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { name: 'A tag' },
+  });
+  const tag = JSON.parse(createRes.payload);
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${tokenB}` },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('other user cannot add tag to my todo (POST /todos/:id/tags returns 404)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const userA = { name: `todtagA-${suffix}`, email: `todtagA-${suffix}@test.local`, password: 'pass123' };
+  const userB = { name: `todtagB-${suffix}`, email: `todtagB-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA });
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB });
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } });
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } });
+  const tokenA = JSON.parse(loginA.payload).token;
+  const tokenB = JSON.parse(loginB.payload).token;
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { name: 'B tag' },
+  });
+  const tag = JSON.parse(tagRes.payload);
+  const res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${tokenB}` },
+    payload: { tagId: tag.id },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('other user cannot remove tag from my todo (DELETE /todos/:id/tags/:tagId returns 404)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const userA = { name: `todtagdelA-${suffix}`, email: `todtagdelA-${suffix}@test.local`, password: 'pass123' };
+  const userB = { name: `todtagdelB-${suffix}`, email: `todtagdelB-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userA });
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: userB });
+  const loginA = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userA.email, password: userA.password } });
+  const loginB = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: userB.email, password: userB.password } });
+  const tokenA = JSON.parse(loginA.payload).token;
+  const tokenB = JSON.parse(loginB.payload).token;
+  const tagARes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { name: 'A tag' },
+  });
+  const tagA = JSON.parse(tagARes.payload);
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { title: 'A todo' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${tokenA}` },
+    payload: { tagId: tagA.id },
+  });
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/todos/${todo.id}/tags/${tagA.id}`,
+    headers: { authorization: `Bearer ${tokenB}` },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});

--- a/backend/test/routes/tags.test.js
+++ b/backend/test/routes/tags.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { build } = require('../helper');
+
+function uniqueSuffix() {
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+test('GET /api/v1/tags without auth returns 401', async (t) => {
+  const app = await build(t);
+  const res = await app.inject({ method: 'GET', url: '/api/v1/tags' });
+  assert.strictEqual(res.statusCode, 401);
+});
+
+test('POST /api/v1/tags without auth returns 401', async (t) => {
+  const app = await build(t);
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    payload: { name: 'work' },
+  });
+  assert.strictEqual(res.statusCode, 401);
+});
+
+test('POST /api/v1/tags creates tag and GET /tags returns it', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tag-${suffix}`, email: `tag-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'work', color: '#ff0000' },
+  });
+  assert.strictEqual(createRes.statusCode, 201);
+  const tag = JSON.parse(createRes.payload);
+  assert.strictEqual(tag.name, 'work');
+  assert.strictEqual(tag.color, '#ff0000');
+  assert(tag.id != null);
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(listRes.statusCode, 200);
+  const list = JSON.parse(listRes.payload);
+  assert(list.some((t) => t.id === tag.id && t.name === 'work'));
+});
+
+test('POST /api/v1/tags duplicate name returns 409', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tagd-${suffix}`, email: `tagd-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'same' },
+  });
+  const res2 = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'same' },
+  });
+  assert.strictEqual(res2.statusCode, 409);
+});
+
+test('POST /api/v1/todos/:todoId/tags adds tag and GET /todos/:id includes tags', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tagt-${suffix}`, email: `tagt-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'urgent', color: '#00ff00' },
+  });
+  const tag = JSON.parse(tagRes.payload);
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'With tag' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  const addRes = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tag.id },
+  });
+  assert.strictEqual(addRes.statusCode, 204);
+  const getRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(getRes.statusCode, 200);
+  const todoWithTags = JSON.parse(getRes.payload);
+  assert(Array.isArray(todoWithTags.Tags));
+  assert(todoWithTags.Tags.some((t) => t.id === tag.id));
+});
+
+test('GET /api/v1/todos?tags= filters by tag', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tagf-${suffix}`, email: `tagf-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'filter-tag' },
+  });
+  const tag = JSON.parse(tagRes.payload);
+  const todo1Res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Has tag' },
+  });
+  const todo1 = JSON.parse(todo1Res.payload);
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'No tag' },
+  });
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo1.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tag.id },
+  });
+  const listRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos?tags=${tag.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(listRes.statusCode, 200);
+  const list = JSON.parse(listRes.payload);
+  assert(list.length >= 1);
+  assert(list.every((todo) => (todo.Tags || []).some((t) => t.id === tag.id)));
+});

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -17,6 +17,10 @@ const routes: Routes = [
         path: 'archived',
         loadComponent: () => import('./archived-todos/archived-todos-page.component')
       },
+      {
+        path: 'tags',
+        loadComponent: () => import('./tags/tags-page.component')
+      },
     ]
   }
 ]

--- a/frontend/src/app/components/pages/dashboard/tags/tags-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/tags/tags-page.component.html
@@ -1,0 +1,59 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="タグ管理">
+      @if (error) {
+        <div class="alert alert-danger" role="alert">{{ error }}</div>
+      }
+      <div class="mb-4">
+        <form class="row g-2 align-items-end" (ngSubmit)="onSubmit()">
+          <div class="col-auto">
+            <label class="form-label mb-0">名前</label>
+            <input
+              type="text"
+              class="form-control form-control-sm"
+              [(ngModel)]="newName"
+              name="newName"
+              maxlength="50"
+              placeholder="タグ名"
+            />
+          </div>
+          <div class="col-auto">
+            <label class="form-label mb-0">色</label>
+            <input
+              type="color"
+              class="form-control form-control-color form-control-sm"
+              [(ngModel)]="newColor"
+              name="newColor"
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary btn-sm">追加</button>
+          </div>
+        </form>
+      </div>
+      @if (loading) {
+        <div class="text-center py-4">
+          <div class="spinner-border text-primary" role="status"></div>
+        </div>
+      } @else if (tags.length === 0) {
+        <p class="text-muted">タグがありません。上で作成してください。</p>
+      } @else {
+        <ul class="list-group list-group-flush">
+          @for (tag of tags; track tag.id) {
+            <li class="list-group-item d-flex align-items-center justify-content-between">
+              <span
+                class="badge rounded-pill"
+                [style.background-color]="tag.color"
+                [class.text-dark]="isLight(tag.color)"
+                [class.text-white]="!isLight(tag.color)"
+              >
+                {{ tag.name }}
+              </span>
+              <button type="button" class="btn btn-sm btn-outline-danger" (click)="onDelete(tag)">削除</button>
+            </li>
+          }
+        </ul>
+      }
+    </app-card>
+  </div>
+</div>

--- a/frontend/src/app/components/pages/dashboard/tags/tags-page.component.scss
+++ b/frontend/src/app/components/pages/dashboard/tags/tags-page.component.scss
@@ -1,0 +1,5 @@
+.form-control-color {
+  width: 2.5rem;
+  height: 1.875rem;
+  padding: 0.125rem;
+}

--- a/frontend/src/app/components/pages/dashboard/tags/tags-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/tags/tags-page.component.ts
@@ -1,0 +1,83 @@
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import { Subject, takeUntil } from 'rxjs'
+import { TagService } from '../../../../services/tag.service'
+import { CardComponent } from '../../../../theme/shared/components/card/card.component'
+import type { Tag, CreateTagDto } from '../../../../models/tag.interface'
+
+@Component({
+  selector: 'app-tags-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule, CardComponent],
+  templateUrl: './tags-page.component.html',
+  styleUrls: ['./tags-page.component.scss']
+})
+export default class TagsPageComponent implements OnInit, OnDestroy {
+  tags: Tag[] = []
+  loading = false
+  error: string | null = null
+  newName = ''
+  newColor = '#808080'
+  private destroy$ = new Subject<void>()
+
+  constructor(private tagService: TagService) {}
+
+  ngOnInit(): void {
+    this.loadTags()
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  loadTags(): void {
+    this.loading = true
+    this.error = null
+    this.tagService.getTags().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (list) => {
+        this.tags = list
+        this.loading = false
+      },
+      error: (err) => {
+        this.error = err?.error?.message ?? err?.message ?? '取得に失敗しました'
+        this.loading = false
+      }
+    })
+  }
+
+  onSubmit(): void {
+    const name = this.newName.trim()
+    if (!name) return
+    const body: CreateTagDto = { name, color: this.newColor }
+    this.tagService.create(body).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => {
+        this.newName = ''
+        this.newColor = '#808080'
+        this.loadTags()
+      },
+      error: (err) => {
+        this.error = err?.error?.message ?? err?.message ?? '作成に失敗しました'
+      }
+    })
+  }
+
+  onDelete(tag: Tag): void {
+    if (!confirm(`タグ「${tag.name}」を削除しますか？`)) return
+    this.tagService.delete(tag.id).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => this.loadTags(),
+      error: (err) => {
+        this.error = err?.error?.message ?? err?.message ?? '削除に失敗しました'
+      }
+    })
+  }
+
+  isLight(hex: string): boolean {
+    if (!hex || !hex.startsWith('#')) return false
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.html
@@ -1,0 +1,18 @@
+<span
+  class="tag-chip badge rounded-pill me-1"
+  [style.background-color]="tag.color"
+  [class.text-dark]="isLight(tag.color)"
+  [class.text-white]="!isLight(tag.color)"
+>
+  {{ tag.name }}
+  @if (removable) {
+    <button
+      type="button"
+      class="ms-1"
+      [class.btn-close]="true"
+      [class.btn-close-white]="!isLight(tag.color)"
+      (click)="onRemove(); $event.preventDefault()"
+      [attr.aria-label]="'タグ ' + tag.name + ' を削除'"
+    ></button>
+  }
+</span>

--- a/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.scss
@@ -1,0 +1,7 @@
+.tag-chip {
+  font-size: 0.75rem;
+  .btn-close {
+    font-size: 0.5rem;
+    padding: 0;
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.ts
@@ -1,0 +1,29 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import type { Tag } from '../../../../../models/tag.interface'
+
+@Component({
+  selector: 'app-tag-chip',
+  standalone: true,
+  imports: [],
+  templateUrl: './tag-chip.component.html',
+  styleUrls: ['./tag-chip.component.scss']
+})
+export class TagChipComponent {
+  @Input({ required: true }) tag!: Tag
+  @Input() removable = false
+  @Output() removed = new EventEmitter<Tag>()
+
+  onRemove(): void {
+    this.removed.emit(this.tag)
+  }
+
+  /** 背景色が明るい場合は true（ダークテキスト用） */
+  isLight(hex: string): boolean {
+    if (!hex || !hex.startsWith('#')) return false
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+    return luminance > 0.6
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -15,6 +15,23 @@
     <span *ngIf="todo.dueDate" class="ms-2 small" [ngClass]="dueDateClass(todo.dueDate)">
       {{ todo.dueDate }}
     </span>
+    <div class="mt-1 d-flex flex-wrap align-items-center gap-1">
+      @for (tag of tags; track tag.id) {
+        <app-tag-chip [tag]="tag" [removable]="true" (removed)="onTagRemoved(tag)" />
+      }
+      @if (availableTagsToAdd.length > 0) {
+        <div ngbDropdown class="d-inline-block">
+          <button type="button" class="btn btn-sm btn-link p-0 small" ngbDropdownToggle>+ タグ</button>
+          <ul ngbDropdownMenu class="dropdown-menu">
+            @for (tag of availableTagsToAdd; track tag.id) {
+              <li>
+                <a class="dropdown-item" href="javascript:" (click)="onAddTag(tag.id)">{{ tag.name }}</a>
+              </li>
+            }
+          </ul>
+        </div>
+      }
+    </div>
   </div>
   <div class="btn-group btn-group-sm">
     @if (todo.completed) {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -1,20 +1,26 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap'
 import type { Todo } from '../../../../../models/todo.interface'
+import type { Tag } from '../../../../../models/tag.interface'
+import { TagChipComponent } from '../tag-chip/tag-chip.component'
 
 @Component({
   selector: 'app-todo-item',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, TagChipComponent],
   templateUrl: './todo-item.component.html',
   styleUrls: ['./todo-item.component.scss']
 })
 export class TodoItemComponent {
   @Input({ required: true }) todo!: Todo
+  @Input() allTags: Tag[] = []
   @Output() toggle = new EventEmitter<number>()
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
+  @Output() tagRemoved = new EventEmitter<{ todoId: number; tag: Tag }>()
+  @Output() tagAdded = new EventEmitter<{ todoId: number; tagId: number }>()
 
   onToggle(): void {
     this.toggle.emit(this.todo.id)
@@ -30,6 +36,23 @@ export class TodoItemComponent {
 
   onArchive(): void {
     this.archive.emit(this.todo.id)
+  }
+
+  onTagRemoved(tag: Tag): void {
+    this.tagRemoved.emit({ todoId: this.todo.id, tag })
+  }
+
+  onAddTag(tagId: number): void {
+    this.tagAdded.emit({ todoId: this.todo.id, tagId })
+  }
+
+  get tags(): Tag[] {
+    return this.todo.Tags ?? []
+  }
+
+  get availableTagsToAdd(): Tag[] {
+    const onTodo = new Set((this.todo.Tags ?? []).map((t) => t.id))
+    return this.allTags.filter((t) => !onTodo.has(t.id))
   }
 
   /** 優先度バッジの Bootstrap クラス */

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -28,10 +28,13 @@
         <div class="flex-grow-1 min-width-0">
         <app-todo-item
           [todo]="todo"
+          [allTags]="allTags"
           (toggle)="toggle.emit($event)"
           (edit)="edit.emit($event)"
           (delete)="delete.emit($event)"
           (archive)="archive.emit($event)"
+          (tagRemoved)="tagRemoved.emit($event)"
+          (tagAdded)="tagAdded.emit($event)"
         />
         </div>
       </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common'
 import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop'
 import { TodoItemComponent } from '../todo-item/todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
+import type { Tag } from '../../../../../models/tag.interface'
 
 @Component({
   selector: 'app-todo-list',
@@ -13,6 +14,7 @@ import type { Todo } from '../../../../../models/todo.interface'
 })
 export class TodoListComponent {
   @Input() todos: Todo[] = []
+  @Input() allTags: Tag[] = []
   @Input() loading = false
   @Input() error: string | null = null
   /** true のときドラッグ無効（ソートが「手動」以外のとき） */
@@ -24,6 +26,8 @@ export class TodoListComponent {
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
   @Output() reorder = new EventEmitter<number[]>()
+  @Output() tagRemoved = new EventEmitter<{ todoId: number; tag: Tag }>()
+  @Output() tagAdded = new EventEmitter<{ todoId: number; tagId: number }>()
 
   toggleSelection(id: number): void {
     const next = this.selectedIds.includes(id)

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -38,6 +38,23 @@
               (sortChanged)="onSortChange($event)"
             />
           </div>
+          @if (allTags.length > 0) {
+            <div class="col-12 col-md-auto mt-1 mt-md-0">
+              <span class="me-1 small text-muted">タグ:</span>
+              @for (tag of allTags; track tag.id) {
+                <button
+                  type="button"
+                  class="badge rounded-pill me-1 mb-1"
+                  [style.background-color]="filterTagIds.includes(tag.id) ? tag.color : '#e9ecef'"
+                  [class.text-dark]="filterTagIds.includes(tag.id) ? isLight(tag.color) : true"
+                  [class.text-white]="filterTagIds.includes(tag.id) && !isLight(tag.color)"
+                  (click)="toggleTagFilter(tag.id)"
+                >
+                  {{ tag.name }}
+                </button>
+              }
+            </div>
+          }
         </div>
       </div>
 
@@ -65,6 +82,7 @@
 
       <app-todo-list
         [todos]="todos"
+        [allTags]="allTags"
         [loading]="loading"
         [error]="error"
         [dragDisabled]="sortBy !== 'sortOrder'"
@@ -75,6 +93,8 @@
         (delete)="onDelete($event)"
         (archive)="onArchived($event)"
         (reorder)="onReorder($event)"
+        (tagRemoved)="onTagRemoved($event)"
+        (tagAdded)="onTagAdded($event)"
       />
     </app-card>
   </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { Subject, takeUntil } from 'rxjs'
 import { TodoService } from '../../../../../services/todo.service'
+import { TagService } from '../../../../../services/tag.service'
 import { TodoListComponent } from '../todo-list/todo-list.component'
 import { TodoFormComponent } from '../todo-form/todo-form.component'
 import { SearchBarComponent } from '../search-bar/search-bar.component'
@@ -9,6 +10,7 @@ import { SortSelectorComponent } from '../sort-selector/sort-selector.component'
 import { BulkActionBarComponent } from '../bulk-action-bar/bulk-action-bar.component'
 import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models/todo.interface'
+import type { Tag } from '../../../../../models/tag.interface'
 import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
 
 @Component({
@@ -34,17 +36,30 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
 
   filterCompleted: boolean | null = null
   filterPriority: TodoPriority | null = null
+  filterTagIds: number[] = []
   searchQuery = ''
   sortBy: SortBy = 'createdAt'
   sortOrder: SortOrder = 'asc'
   selectedIds: number[] = []
+  allTags: Tag[] = []
 
   private destroy$ = new Subject<void>()
 
-  constructor(private todoService: TodoService) {}
+  constructor(
+    private todoService: TodoService,
+    private tagService: TagService
+  ) {}
 
   ngOnInit(): void {
+    this.loadTags()
     this.loadTodos()
+  }
+
+  loadTags(): void {
+    this.tagService.getTags().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (tags) => { this.allTags = tags },
+      error: () => { this.allTags = [] }
+    })
   }
 
   ngOnDestroy(): void {
@@ -55,13 +70,14 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
   loadTodos(): void {
     this.loading = true
     this.error = null
-    const filters: { completed?: boolean; priority?: TodoPriority } = {}
+    const filters: { completed?: boolean; priority?: TodoPriority; tagIds?: number[] } = {}
     if (this.filterCompleted !== null) filters.completed = this.filterCompleted
     if (this.filterPriority !== null) filters.priority = this.filterPriority
+    if (this.filterTagIds.length > 0) filters.tagIds = this.filterTagIds
     const sort = { sortBy: this.sortBy, sortOrder: this.sortOrder }
 
     const q = this.searchQuery.trim()
-    const searchParams = q ? { q, ...filters } : null
+    const searchParams = q ? { q, ...filters, tagIds: filters.tagIds } : null
     const req = searchParams
       ? this.todoService.search(searchParams, sort)
       : this.todoService.list(filters, sort)
@@ -117,6 +133,36 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     this.sortOrder = sort.sortOrder
     this.selectedIds = []
     this.loadTodos()
+  }
+
+  toggleTagFilter(tagId: number): void {
+    this.filterTagIds = this.filterTagIds.includes(tagId)
+      ? this.filterTagIds.filter((id) => id !== tagId)
+      : [...this.filterTagIds, tagId]
+    this.selectedIds = []
+    this.loadTodos()
+  }
+
+  isLight(hex: string): boolean {
+    if (!hex || !hex.startsWith('#')) return false
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6
+  }
+
+  onTagRemoved(event: { todoId: number; tag: Tag }): void {
+    this.todoService.removeTagFromTodo(event.todoId, event.tag.id).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => { this.loadTodos(); this.loadTags() },
+      error: (err) => { this.error = err?.error?.message ?? err?.message ?? 'タグの削除に失敗しました' }
+    })
+  }
+
+  onTagAdded(event: { todoId: number; tagId: number }): void {
+    this.todoService.addTagToTodo(event.todoId, event.tagId).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => { this.loadTodos() },
+      error: (err) => { this.error = err?.error?.message ?? err?.message ?? 'タグの追加に失敗しました' }
+    })
   }
 
   onReorder(todoIds: number[]): void {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -77,7 +77,7 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     const sort = { sortBy: this.sortBy, sortOrder: this.sortOrder }
 
     const q = this.searchQuery.trim()
-    const searchParams = q ? { q, ...filters, tagIds: filters.tagIds } : null
+    const searchParams = q ? { q, ...filters } : null
     const req = searchParams
       ? this.todoService.search(searchParams, sort)
       : this.todoService.list(filters, sort)
@@ -153,7 +153,7 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
 
   onTagRemoved(event: { todoId: number; tag: Tag }): void {
     this.todoService.removeTagFromTodo(event.todoId, event.tag.id).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => { this.loadTodos(); this.loadTags() },
+      next: () => this.loadTodos(),
       error: (err) => { this.error = err?.error?.message ?? err?.message ?? 'タグの削除に失敗しました' }
     })
   }

--- a/frontend/src/app/models/search-params.interface.ts
+++ b/frontend/src/app/models/search-params.interface.ts
@@ -7,4 +7,5 @@ export interface SearchParams {
   q: string
   completed?: boolean
   priority?: TodoPriority
+  tagIds?: number[]
 }

--- a/frontend/src/app/models/tag.interface.ts
+++ b/frontend/src/app/models/tag.interface.ts
@@ -1,0 +1,21 @@
+/**
+ * API から返却される Tag 型
+ */
+export interface Tag {
+  id: number
+  userId: number
+  name: string
+  color: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateTagDto {
+  name: string
+  color?: string
+}
+
+export interface UpdateTagDto {
+  name?: string
+  color?: string
+}

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -1,10 +1,12 @@
+import type { Tag } from './tag.interface'
+
 /**
  * Todo 優先度
  */
 export type TodoPriority = 'low' | 'medium' | 'high'
 
 /**
- * API から返却される Todo 型
+ * API から返却される Todo 型（タグ付き）
  */
 export interface Todo {
   id: number
@@ -19,6 +21,7 @@ export interface Todo {
   archivedAt: string | null
   createdAt: string
   updatedAt: string
+  Tags?: Tag[]
 }
 
 /**

--- a/frontend/src/app/services/tag.service.ts
+++ b/frontend/src/app/services/tag.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+import type { Tag, CreateTagDto, UpdateTagDto } from '../models/tag.interface'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TagService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  create(body: CreateTagDto): Observable<Tag> {
+    return this.http.post<Tag>(`${this.apiUrl}/tags`, body)
+  }
+
+  getTags(): Observable<Tag[]> {
+    return this.http.get<Tag[]>(`${this.apiUrl}/tags`)
+  }
+
+  getById(id: number): Observable<Tag> {
+    return this.http.get<Tag>(`${this.apiUrl}/tags/${id}`)
+  }
+
+  update(id: number, body: UpdateTagDto): Observable<Tag> {
+    return this.http.put<Tag>(`${this.apiUrl}/tags/${id}`, body)
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/tags/${id}`)
+  }
+}

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -9,6 +9,7 @@ import type { SortOptions } from '../models/sort-options.interface'
 export interface TodoListFilters {
   completed?: boolean
   priority?: TodoPriority
+  tagIds?: number[]
 }
 
 @Injectable({
@@ -27,6 +28,7 @@ export class TodoService {
     const params: Record<string, string> = {}
     if (filters?.completed !== undefined) params['completed'] = String(filters.completed)
     if (filters?.priority) params['priority'] = filters.priority
+    if (filters?.tagIds?.length) params['tags'] = filters.tagIds.join(',')
     if (sort?.sortBy) params['sortBy'] = sort.sortBy
     if (sort?.sortOrder) params['sortOrder'] = sort.sortOrder
     return this.http.get<Todo[]>(`${this.apiUrl}/todos`, { params })
@@ -55,6 +57,7 @@ export class TodoService {
     const p: Record<string, string> = { q: params.q.trim() }
     if (params.completed !== undefined) p['completed'] = String(params.completed)
     if (params.priority) p['priority'] = params.priority
+    if (params.tagIds?.length) p['tags'] = params.tagIds.join(',')
     if (sort?.sortBy) p['sortBy'] = sort.sortBy
     if (sort?.sortOrder) p['sortOrder'] = sort.sortOrder
     return this.http.get<Todo[]>(`${this.apiUrl}/todos/search`, { params: p })
@@ -93,5 +96,13 @@ export class TodoService {
 
   bulkArchive(todoIds: number[]): Observable<{ updated: number }> {
     return this.http.post<{ updated: number }>(`${this.apiUrl}/todos/bulk-archive`, { todoIds })
+  }
+
+  addTagToTodo(todoId: number, tagId: number): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/todos/${todoId}/tags`, { tagId })
+  }
+
+  removeTagFromTodo(todoId: number, tagId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/todos/${todoId}/tags/${tagId}`)
   }
 }

--- a/frontend/src/app/theme/layout/admin/navigation/navigation.ts
+++ b/frontend/src/app/theme/layout/admin/navigation/navigation.ts
@@ -51,6 +51,14 @@ const NavigationItems = [
         url: '/dashboard/archived',
         icon: 'feather icon-archive',
         classes: 'nav-item'
+      },
+      {
+        id: 'tags',
+        title: 'タグ管理',
+        type: 'item',
+        url: '/dashboard/tags',
+        icon: 'feather icon-tag',
+        classes: 'nav-item'
       }
     ]
   },


### PR DESCRIPTION
## 概要
Todo にタグを付与し、タグでフィルタ・検索できる機能を追加しました。

## Backend
- **DB**: tags（userId, name, color）, todo_tags（todoId, tagId）マイグレーション
- **API**: GET/POST/PUT/DELETE /api/v1/tags, GET /api/v1/tags/:id（JWT 必須）
- **Todo タグ**: POST /api/v1/todos/:todoId/tags（body: tagId）, DELETE /api/v1/todos/:todoId/tags/:tagId
- **フィルタ**: GET /api/v1/todos?tags=1,2, GET /api/v1/todos/search?tags=1,2（指定タグをすべて持つ Todo のみ）
- TagService: 同一ユーザー内 name 重複時 409、color は HEX デフォルト #808080
- Todo 取得時に Tags を include して返却
- タグ API のルートテスト追加（401, CRUD, 重複 409, Todo への付与・フィルタ）

## Frontend
- **タグ管理ページ**（/dashboard/tags）: タグ一覧・作成（名前・色）・削除、サイドナビに「タグ管理」追加
- **Todo 一覧**: 各 Todo にタグチップ表示、タグ削除、「+ タグ」で NgbDropdown から追加
- **タグフィルタ**: 一覧上でタグチップをクリックして絞り込み（複数タグは AND）
- TagChip: 色付きバッジ、明度で文字色切替、removable 時は削除ボタン
- TagService, TodoService（addTagToTodo, removeTagFromTodo, list/search に tagIds）

## ルール準拠
- ビルド・テストは Docker 内で実行
- 1 タスク = 1 PR（Phase B タグ機能）

Made with [Cursor](https://cursor.com)