### PR TITLE
feat(search): タグ名での検索を実装（2.2.4）

### DIFF
--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -166,8 +166,6 @@ async function searchTodos(fastify, userId, params = {}) {
     where.priority = params.priority;
   }
   const q = typeof params.query === 'string' ? params.query.trim() : '';
-  const escaped = q.length > 0 ? q.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_') : '';
-  const pattern = q.length > 0 ? `%${escaped}%` : '';
 
   const order = buildOrder(
     fastify.sequelize,
@@ -181,6 +179,8 @@ async function searchTodos(fastify, userId, params = {}) {
 
   let todoIds = [];
   if (q.length > 0) {
+    const escaped = q.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+    const pattern = `%${escaped}%`;
     // タイトル・説明での検索
     const whereText = { ...where, [Op.and]: [{ [Op.or]: [{ title: { [Op.like]: pattern } }, { description: { [Op.like]: pattern } }] }] };
     const byText = await fastify.models.Todo.findAll({

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -166,13 +166,9 @@ async function searchTodos(fastify, userId, params = {}) {
     where.priority = params.priority;
   }
   const q = typeof params.query === 'string' ? params.query.trim() : '';
-  if (q.length > 0) {
-    const escaped = q.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
-    const pattern = `%${escaped}%`;
-    where[Op.and] = [
-      { [Op.or]: [{ title: { [Op.like]: pattern } }, { description: { [Op.like]: pattern } }] },
-    ];
-  }
+  const escaped = q.length > 0 ? q.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_') : '';
+  const pattern = q.length > 0 ? `%${escaped}%` : '';
+
   const order = buildOrder(
     fastify.sequelize,
     params.sortBy,
@@ -182,6 +178,31 @@ async function searchTodos(fastify, userId, params = {}) {
     ? params.tagIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0)
     : [];
   const include = [{ model: fastify.models.Tag, as: 'Tags', through: { attributes: [] }, required: false }];
+
+  let todoIds = [];
+  if (q.length > 0) {
+    // タイトル・説明での検索
+    const whereText = { ...where, [Op.and]: [{ [Op.or]: [{ title: { [Op.like]: pattern } }, { description: { [Op.like]: pattern } }] }] };
+    const byText = await fastify.models.Todo.findAll({
+      where: whereText,
+      attributes: ['id'],
+    });
+    todoIds = byText.map((t) => t.id);
+    // タグ名での検索（Tag モデル JOIN）
+    const includeTagName = [{ model: fastify.models.Tag, as: 'Tags', where: { userId, name: { [Op.like]: pattern } }, required: true, through: { attributes: [] } }];
+    const byTagName = await fastify.models.Todo.findAll({
+      where,
+      include: includeTagName,
+      attributes: ['id'],
+    });
+    const tagNameIds = byTagName.map((t) => t.id);
+    todoIds = [...new Set([...todoIds, ...tagNameIds])];
+    if (todoIds.length === 0) {
+      return [];
+    }
+    where.id = { [Op.in]: todoIds };
+  }
+
   let todos = await fastify.models.Todo.findAll({
     where,
     include,

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -226,6 +226,163 @@ test('GET /api/v1/todos/search by tag name returns todos with that tag', async (
   assert(todos.some((t) => t.id === todo.id), 'search by tag name must return todo that has that tag')
 })
 
+test('GET /api/v1/todos/search title and tag name both hit returns deduplicated', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `dedup-${suffix}`, email: `dedup-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'work-keyword', color: '#0000ff' }
+  })
+  assert.strictEqual(tagRes.statusCode, 201)
+  const tag = JSON.parse(tagRes.payload)
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'work-keyword in title', description: 'desc' }
+  })
+  assert.strictEqual(todoRes.statusCode, 201)
+  const todo = JSON.parse(todoRes.payload)
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tag.id }
+  })
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'work-keyword' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert.strictEqual(todos.length, 1, 'title and tag name both hit must be deduplicated to one')
+  assert.strictEqual(todos[0].id, todo.id)
+})
+
+test('GET /api/v1/todos/search title only hit (no tag name match) returns todo', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `titleonly-${suffix}`, email: `titleonly-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'other-tag', color: '#00ff00' }
+  })
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'only-in-title', description: 'no match' }
+  })
+  assert.strictEqual(todoRes.statusCode, 201)
+  const todo = JSON.parse(todoRes.payload)
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'only-in-title' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert(todos.some((t) => t.id === todo.id), 'title-only match must return todo')
+})
+
+test('GET /api/v1/todos/search with q and tagIds combined filters correctly', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `combo-${suffix}`, email: `combo-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const tagARes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'tagA', color: '#ff0000' }
+  })
+  const tagBRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'tagB', color: '#00ff00' }
+  })
+  const tagA = JSON.parse(tagARes.payload)
+  const tagB = JSON.parse(tagBRes.payload)
+  const todo1Res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'keyword', description: 'desc' }
+  })
+  const todo1 = JSON.parse(todo1Res.payload)
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo1.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tagA.id }
+  })
+  const todo2Res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'keyword', description: 'desc' }
+  })
+  const todo2 = JSON.parse(todo2Res.payload)
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo2.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tagB.id }
+  })
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'keyword', tags: tagA.id }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert.strictEqual(todos.length, 1)
+  assert.strictEqual(todos[0].id, todo1.id)
+})
+
+test('GET /api/v1/todos/search no match returns empty array', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `nomatch-${suffix}`, email: `nomatch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'some todo', description: 'desc' }
+  })
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'xyznonexistent' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert(Array.isArray(todos))
+  assert.strictEqual(todos.length, 0)
+})
+
 test('other user cannot access todo (GET) - 404', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -185,6 +185,47 @@ test('search returns only own todos (other user todos not included)', async (t) 
   assert(todosB.every((todo) => todo.userId === todosB[0].userId))
 })
 
+test('GET /api/v1/todos/search by tag name returns todos with that tag', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `tagsearch-${suffix}`, email: `tagsearch-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'urgent-work', color: '#ff0000' }
+  })
+  assert.strictEqual(tagRes.statusCode, 201)
+  const tag = JSON.parse(tagRes.payload)
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Todo with tag only', description: 'no keyword' }
+  })
+  assert.strictEqual(todoRes.statusCode, 201)
+  const todo = JSON.parse(todoRes.payload)
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tag.id }
+  })
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'urgent' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert(Array.isArray(todos))
+  assert(todos.some((t) => t.id === todo.id), 'search by tag name must return todo that has that tag')
+})
+
 test('other user cannot access todo (GET) - 404', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()

--- a/docs/TODO_FEATURE_02_SEARCH.md
+++ b/docs/TODO_FEATURE_02_SEARCH.md
@@ -45,7 +45,7 @@ GET /api/todos/search?q=買い物&priority=high&completed=false&tags=1,2
 - [x] 2.2.1: `searchTodos(userId, {query, priority, completed, tags})` 実装（tags は未実装のため省略）
 - [x] 2.2.2: Sequelize の `Op.like` 使用
 - [x] 2.2.3: タイトル・説明文での検索実装
-- [ ] 2.2.4: タグ名での検索実装（Tag モデル JOIN）※タグ機能実装後に対応
+- [x] 2.2.4: タグ名での検索実装（Tag モデル JOIN）※タグ機能実装後に対応
 - [x] 2.2.5: 複数条件の AND 結合実装
 - [x] 2.2.6: 検索結果にタグを include※タグ機能実装後に対応
 


### PR DESCRIPTION
## 概要
REVIEW.md / TODO に従い、検索機能の 2.2.4「タグ名での検索実装」を対応しました。

## 変更内容
- `backend/services/todoService.js`: `searchTodos` でタイトル・説明に加え、タグ名 LIKE 検索を追加（Tag モデル JOIN）
- `backend/test/routes/todos.test.js`: タグ名検索のテストを追加
- `docs/TODO_FEATURE_02_SEARCH.md`: 2.2.4 をチェック済みに更新

## 確認
- `docker compose run --rm backend node --test test/routes/todos.test.js` で 38 件すべてパス

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)