### PR TITLE
test(tags): Tag API 正常系テストを追加（1.11.4）

### DIFF
--- a/backend/test/routes/tags.test.js
+++ b/backend/test/routes/tags.test.js
@@ -283,3 +283,137 @@ test('other user cannot remove tag from my todo (DELETE /todos/:id/tags/:tagId r
   });
   assert.strictEqual(res.statusCode, 404);
 });
+
+test('GET /api/v1/tags/:id returns tag (normal)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tagget-${suffix}`, email: `tagget-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'get-me', color: '#123456' },
+  });
+  assert.strictEqual(createRes.statusCode, 201);
+  const tag = JSON.parse(createRes.payload);
+  const getRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(getRes.statusCode, 200);
+  const got = JSON.parse(getRes.payload);
+  assert.strictEqual(got.id, tag.id);
+  assert.strictEqual(got.name, 'get-me');
+  assert.strictEqual(got.color, '#123456');
+});
+
+test('GET /api/v1/tags/:id without auth returns 401', async (t) => {
+  const app = await build(t);
+  const res = await app.inject({ method: 'GET', url: '/api/v1/tags/1' });
+  assert.strictEqual(res.statusCode, 401);
+});
+
+test('PUT /api/v1/tags/:id updates tag (normal)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tagput-${suffix}`, email: `tagput-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'before', color: '#111111' },
+  });
+  assert.strictEqual(createRes.statusCode, 201);
+  const tag = JSON.parse(createRes.payload);
+  const putRes = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'after', color: '#222222' },
+  });
+  assert.strictEqual(putRes.statusCode, 200);
+  const updated = JSON.parse(putRes.payload);
+  assert.strictEqual(updated.id, tag.id);
+  assert.strictEqual(updated.name, 'after');
+  assert.strictEqual(updated.color, '#222222');
+});
+
+test('DELETE /api/v1/tags/:id deletes tag (normal)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `tagdel-${suffix}`, email: `tagdel-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'to-delete', color: '#333333' },
+  });
+  assert.strictEqual(createRes.statusCode, 201);
+  const tag = JSON.parse(createRes.payload);
+  const delRes = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(delRes.statusCode, 204);
+  const getRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(getRes.statusCode, 404);
+});
+
+test('DELETE /api/v1/todos/:todoId/tags/:tagId removes tag from todo (normal)', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `todtagrm-${suffix}`, email: `todtagrm-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'to-remove', color: '#444444' },
+  });
+  const tag = JSON.parse(tagRes.payload);
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Todo with tag' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tagId: tag.id },
+  });
+  const delRes = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/todos/${todo.id}/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(delRes.statusCode, 204);
+  const getRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(getRes.statusCode, 200);
+  const todoAfter = JSON.parse(getRes.payload);
+  assert(Array.isArray(todoAfter.Tags));
+  assert(!todoAfter.Tags.some((x) => x.id === tag.id));
+});

--- a/backend/test/routes/tags.test.js
+++ b/backend/test/routes/tags.test.js
@@ -387,6 +387,7 @@ test('DELETE /api/v1/todos/:todoId/tags/:tagId removes tag from todo (normal)', 
     headers: { authorization: `Bearer ${token}` },
     payload: { name: 'to-remove', color: '#444444' },
   });
+  assert.strictEqual(tagRes.statusCode, 201);
   const tag = JSON.parse(tagRes.payload);
   const todoRes = await app.inject({
     method: 'POST',
@@ -394,6 +395,7 @@ test('DELETE /api/v1/todos/:todoId/tags/:tagId removes tag from todo (normal)', 
     headers: { authorization: `Bearer ${token}` },
     payload: { title: 'Todo with tag' },
   });
+  assert.strictEqual(todoRes.statusCode, 201);
   const todo = JSON.parse(todoRes.payload);
   await app.inject({
     method: 'POST',

--- a/docs/TODO_FEATURE_01_TAGS.md
+++ b/docs/TODO_FEATURE_01_TAGS.md
@@ -149,7 +149,7 @@ GET /api/todos?tags=1,2,3  # タグでフィルタ
 - [x] 1.11.1: `backend/test/services/TagService.test.js` 作成
 - [x] 1.11.2: TagService 各メソッドのテスト実装
 - [x] 1.11.3: `backend/test/routes/tags.test.js` 作成
-- [ ] 1.11.4: Tag API 各エンドポイントのテスト実装（GET/PUT/DELETE /tags/:id 正常系・DELETE /todos/:id/tags/:tagId 正常系は未実装）
+- [x] 1.11.4: Tag API 各エンドポイントのテスト実装（GET/PUT/DELETE /tags/:id 正常系・DELETE /todos/:id/tags/:tagId 正常系）
 - [x] 1.11.5: Todo-Tag 関連 API のテスト実装
 
 ---


### PR DESCRIPTION
## 概要
PR#9 レビューで未対応だった「Tag API 正常系テスト欠落」を解消する PR。TODO 1.11.4 を完了。

## 変更内容
- `backend/test/routes/tags.test.js`
  - GET /api/v1/tags/:id 正常系（200）・未認証 401
  - PUT /api/v1/tags/:id 正常系（200）
  - DELETE /api/v1/tags/:id 正常系（204、削除後 404）
  - DELETE /api/v1/todos/:todoId/tags/:tagId 正常系（204、Todo からタグ削除確認）
- `docs/TODO_FEATURE_01_TAGS.md`: 1.11.4 をチェック済みに更新

## 確認
- `docker compose run --rm backend node --test test/routes/tags.test.js` で 15 件すべてパス

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)