### PR TITLE
test(search): 検索 API 各条件パターンのテストを追加（2.5.2）

### DIFF
--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -383,6 +383,116 @@ test('GET /api/v1/todos/search no match returns empty array', async (t) => {
   assert.strictEqual(todos.length, 0)
 })
 
+test('GET /api/v1/todos/search with completed=true returns only completed todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `comp-${suffix}`, email: `comp-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const doneRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'done task', completed: true }
+  })
+  assert.strictEqual(doneRes.statusCode, 201)
+  const doneTodo = JSON.parse(doneRes.payload)
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${doneTodo.id}/toggle`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const openRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'open task' }
+  })
+  assert.strictEqual(openRes.statusCode, 201)
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'task', completed: 'true' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert(todos.length >= 1)
+  assert(todos.every((todo) => todo.completed === true))
+  assert(todos.some((todo) => todo.id === doneTodo.id))
+})
+
+test('GET /api/v1/todos/search with completed=false returns only incomplete todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `open-${suffix}`, email: `open-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const openRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'open only' }
+  })
+  assert.strictEqual(openRes.statusCode, 201)
+  const openTodo = JSON.parse(openRes.payload)
+  const doneRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'done only' }
+  })
+  assert.strictEqual(doneRes.statusCode, 201)
+  const doneTodo = JSON.parse(doneRes.payload)
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${doneTodo.id}/toggle`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'only', completed: 'false' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert(todos.length >= 1)
+  assert(todos.every((todo) => todo.completed === false))
+  assert(todos.some((todo) => todo.id === openTodo.id))
+})
+
+test('GET /api/v1/todos/search with q and completed and priority returns combined filter', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `combo-${suffix}`, email: `combo-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const matchRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'combo-target', priority: 'high' }
+  })
+  assert.strictEqual(matchRes.statusCode, 201)
+  const matchTodo = JSON.parse(matchRes.payload)
+  const searchRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/search',
+    headers: { authorization: `Bearer ${token}` },
+    query: { q: 'combo-target', completed: 'false', priority: 'high' }
+  })
+  assert.strictEqual(searchRes.statusCode, 200)
+  const todos = JSON.parse(searchRes.payload)
+  assert(todos.length >= 1)
+  assert.strictEqual(todos[0].id, matchTodo.id)
+  assert.strictEqual(todos[0].priority, 'high')
+  assert.strictEqual(todos[0].completed, false)
+})
+
 test('other user cannot access todo (GET) - 404', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -394,15 +394,16 @@ test('GET /api/v1/todos/search with completed=true returns only completed todos'
     method: 'POST',
     url: '/api/v1/todos',
     headers: { authorization: `Bearer ${token}` },
-    payload: { title: 'done task', completed: true }
+    payload: { title: 'done task' }
   })
   assert.strictEqual(doneRes.statusCode, 201)
   const doneTodo = JSON.parse(doneRes.payload)
-  await app.inject({
+  const toggleRes = await app.inject({
     method: 'PATCH',
     url: `/api/v1/todos/${doneTodo.id}/toggle`,
     headers: { authorization: `Bearer ${token}` }
   })
+  assert.strictEqual(toggleRes.statusCode, 200)
   const openRes = await app.inject({
     method: 'POST',
     url: '/api/v1/todos',
@@ -446,11 +447,12 @@ test('GET /api/v1/todos/search with completed=false returns only incomplete todo
   })
   assert.strictEqual(doneRes.statusCode, 201)
   const doneTodo = JSON.parse(doneRes.payload)
-  await app.inject({
+  const toggleRes = await app.inject({
     method: 'PATCH',
     url: `/api/v1/todos/${doneTodo.id}/toggle`,
     headers: { authorization: `Bearer ${token}` }
   })
+  assert.strictEqual(toggleRes.statusCode, 200)
   const searchRes = await app.inject({
     method: 'GET',
     url: '/api/v1/todos/search',
@@ -487,10 +489,10 @@ test('GET /api/v1/todos/search with q and completed and priority returns combine
   })
   assert.strictEqual(searchRes.statusCode, 200)
   const todos = JSON.parse(searchRes.payload)
-  assert(todos.length >= 1)
-  assert.strictEqual(todos[0].id, matchTodo.id)
-  assert.strictEqual(todos[0].priority, 'high')
-  assert.strictEqual(todos[0].completed, false)
+  assert(todos.some((t) => t.id === matchTodo.id))
+  const found = todos.find((t) => t.id === matchTodo.id)
+  assert.strictEqual(found.priority, 'high')
+  assert.strictEqual(found.completed, false)
 })
 
 test('other user cannot access todo (GET) - 404', async (t) => {

--- a/docs/TODO_FEATURE_02_SEARCH.md
+++ b/docs/TODO_FEATURE_02_SEARCH.md
@@ -64,7 +64,7 @@ GET /api/todos/search?q=買い物&priority=high&completed=false&tags=1,2
 ### Task 2.5: Backend テスト
 
 - [x] 2.5.1: 検索 API 認証・検索結果のテスト実装
-- [ ] 2.5.2: 検索 API のテスト実装（各条件パターン）
+- [x] 2.5.2: 検索 API のテスト実装（各条件パターン）
 
 ---
 


### PR DESCRIPTION
## 概要
TODO 2.5.2「検索 API のテスト実装（各条件パターン）」を対応。completed フィルタおよび複合条件のテストを追加。

## 変更内容
- `backend/test/routes/todos.test.js`
  - GET /api/v1/todos/search with completed=true → 完了 Todo のみ
  - GET /api/v1/todos/search with completed=false → 未完了 Todo のみ
  - GET /api/v1/todos/search with q + completed + priority → 複合条件で絞り込み
- `docs/TODO_FEATURE_02_SEARCH.md`: 2.5.2 をチェック済みに更新

## 確認
- `docker compose run --rm backend node --test test/routes/todos.test.js` で 45 件すべてパス

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)