### PR TITLE
test(sort): ソート機能の Frontend テスト追加（3.13.1〜3.13.3）

### DIFF
--- a/docs/TODO_FEATURE_03_SORT.md
+++ b/docs/TODO_FEATURE_03_SORT.md
@@ -119,9 +119,9 @@ PUT /api/todos/reorder
 
 ### Task 3.13: Frontend テスト
 
-- [ ] 3.13.1: TodoService ソート機能のテスト
-- [ ] 3.13.2: SortSelector コンポーネントテスト
-- [ ] 3.13.3: ドラッグ&ドロップのテスト
+- [x] 3.13.1: TodoService ソート機能のテスト
+- [x] 3.13.2: SortSelector コンポーネントテスト
+- [x] 3.13.3: ドラッグ&ドロップのテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/sort-selector/sort-selector.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SortSelectorComponent } from './sort-selector.component'
+import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
+
+describe('SortSelectorComponent (3.13.2)', () => {
+  let component: SortSelectorComponent
+  let fixture: ComponentFixture<SortSelectorComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SortSelectorComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(SortSelectorComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should have default sortBy createdAt and sortOrder asc', () => {
+    expect(component.sortBy).toBe('createdAt')
+    expect(component.sortOrder).toBe('asc')
+  })
+
+  it('should display 5 sort options', () => {
+    expect(component.sortByOptions.length).toBe(5)
+    const values = component.sortByOptions.map((o) => o.value)
+    expect(values).toContain('createdAt')
+    expect(values).toContain('updatedAt')
+    expect(values).toContain('dueDate')
+    expect(values).toContain('priority')
+    expect(values).toContain('sortOrder')
+  })
+
+  it('should emit sortChanged with new sortBy when select value changes', () => {
+    component.sortBy = 'createdAt'
+    component.sortOrder = 'asc'
+    let emitted: { sortBy: SortBy; sortOrder: SortOrder } | null = null
+    component.sortChanged.subscribe((v) => (emitted = v))
+
+    const select = fixture.nativeElement.querySelector('select')
+    select.value = 'dueDate'
+    select.dispatchEvent(new Event('change'))
+    fixture.detectChanges()
+
+    expect(emitted).toEqual({ sortBy: 'dueDate', sortOrder: 'asc' })
+  })
+
+  it('should emit sortChanged with toggled sortOrder when toggle button is clicked', () => {
+    component.sortBy = 'priority'
+    component.sortOrder = 'asc'
+    let emitted: { sortBy: SortBy; sortOrder: SortOrder } | null = null
+    component.sortChanged.subscribe((v) => (emitted = v))
+
+    const btn = fixture.nativeElement.querySelector('button')
+    btn.click()
+    fixture.detectChanges()
+
+    expect(emitted).toEqual({ sortBy: 'priority', sortOrder: 'desc' })
+  })
+
+  it('should emit asc when toggle from desc', () => {
+    component.sortBy = 'updatedAt'
+    component.sortOrder = 'desc'
+    let emitted: { sortBy: SortBy; sortOrder: SortOrder } | null = null
+    component.sortChanged.subscribe((v) => (emitted = v))
+
+    fixture.nativeElement.querySelector('button').click()
+    fixture.detectChanges()
+
+    expect(emitted).toEqual({ sortBy: 'updatedAt', sortOrder: 'asc' })
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { CdkDragDrop } from '@angular/cdk/drag-drop'
+import { TodoListComponent } from './todo-list.component'
+import { TodoItemComponent } from '../todo-item/todo-item.component'
+import type { Todo } from '../../../../../models/todo.interface'
+import type { Tag } from '../../../../../models/tag.interface'
+
+const mockTodos: Todo[] = [
+  { id: 1, userId: 1, title: 'A', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 0, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 2, userId: 1, title: 'B', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 1, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 3, userId: 1, title: 'C', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 2, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+]
+
+describe('TodoListComponent (3.13.3)', () => {
+  let component: TodoListComponent
+  let fixture: ComponentFixture<TodoListComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TodoListComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(TodoListComponent)
+    component = fixture.componentInstance
+    component.todos = [...mockTodos]
+    component.allTags = []
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  describe('drag and drop', () => {
+    it('should emit reorder with reordered ids when drop from index 0 to 2', () => {
+      component.dragDisabled = false
+      let emitted: number[] | null = null
+      component.reorder.subscribe((ids) => (emitted = ids))
+
+      const event = {
+        previousIndex: 0,
+        currentIndex: 2,
+        container: { data: component.todos },
+        previousContainer: { data: component.todos },
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 },
+        event: new MouseEvent('drop'),
+      } as unknown as CdkDragDrop<Todo[]>
+
+      component.onDrop(event)
+
+      expect(emitted).toEqual([2, 3, 1])
+    })
+
+    it('should not emit reorder when previousIndex === currentIndex', () => {
+      component.dragDisabled = false
+      let emitted = false
+      component.reorder.subscribe(() => (emitted = true))
+
+      const event = {
+        previousIndex: 1,
+        currentIndex: 1,
+        container: { data: component.todos },
+        previousContainer: { data: component.todos },
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 },
+        event: new MouseEvent('drop'),
+      } as unknown as CdkDragDrop<Todo[]>
+
+      component.onDrop(event)
+
+      expect(emitted).toBe(false)
+    })
+
+    it('should not emit reorder when dragDisabled is true', () => {
+      component.dragDisabled = true
+      let emitted = false
+      component.reorder.subscribe(() => (emitted = true))
+
+      const event = {
+        previousIndex: 0,
+        currentIndex: 1,
+        container: { data: component.todos },
+        previousContainer: { data: component.todos },
+        isPointerOverContainer: true,
+        distance: { x: 0, y: 0 },
+        dropPoint: { x: 0, y: 0 },
+        event: new MouseEvent('drop'),
+      } as unknown as CdkDragDrop<Todo[]>
+
+      component.onDrop(event)
+
+      expect(emitted).toBe(false)
+    })
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { CdkDragDrop } from '@angular/cdk/drag-drop'
 import { TodoListComponent } from './todo-list.component'
-import { TodoItemComponent } from '../todo-item/todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { TodoService } from './todo.service'
+import type { SortOptions } from '../models/sort-options.interface'
+
+describe('TodoService', () => {
+  let service: TodoService
+  let httpMock: HttpTestingController
+  const apiUrl = 'http://localhost:3999/api/v1'
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [TodoService],
+    })
+    service = TestBed.inject(TodoService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  describe('list with sort (3.13.1)', () => {
+    it('should call GET /todos with sortBy and sortOrder params when sort is provided', () => {
+      const sort: SortOptions = { sortBy: 'dueDate', sortOrder: 'desc' }
+      service.list(undefined, sort).subscribe()
+
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos` && r.method === 'GET')
+      expect(req.request.params.get('sortBy')).toBe('dueDate')
+      expect(req.request.params.get('sortOrder')).toBe('desc')
+      req.flush([])
+    })
+
+    it('should call GET /todos without sort params when sort is not provided', () => {
+      service.list().subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos` && r.method === 'GET')
+      expect(req.request.params.has('sortBy')).toBe(false)
+      expect(req.request.params.has('sortOrder')).toBe(false)
+      req.flush([])
+    })
+
+    it('should pass sortOrder asc when sort is sortOrder asc', () => {
+      service.list(undefined, { sortBy: 'priority', sortOrder: 'asc' }).subscribe()
+      const req = httpMock.expectOne((r) => r.url.startsWith(`${apiUrl}/todos`) && r.method === 'GET')
+      expect(req.request.params.get('sortBy')).toBe('priority')
+      expect(req.request.params.get('sortOrder')).toBe('asc')
+      req.flush([])
+    })
+  })
+
+  describe('reorderTodos (3.13.1)', () => {
+    it('should call PUT /todos/reorder with todoIds in body', () => {
+      const todoIds = [3, 1, 2]
+      service.reorderTodos(todoIds).subscribe()
+
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/reorder` && r.method === 'PUT')
+      expect(req.request.body).toEqual({ todoIds })
+      req.flush(null)
+    })
+
+    it('should call PUT /todos/reorder with empty array', () => {
+      service.reorderTodos([]).subscribe()
+      const req = httpMock.expectOne(`${apiUrl}/todos/reorder`)
+      expect(req.request.body).toEqual({ todoIds: [] })
+      req.flush(null)
+    })
+  })
+})

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -1,12 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
 import { TodoService } from './todo.service'
 import type { SortOptions } from '../models/sort-options.interface'
 
 describe('TodoService', () => {
   let service: TodoService
   let httpMock: HttpTestingController
-  const apiUrl = 'http://localhost:3999/api/v1'
+  const apiUrl = environment.apiUrl
 
   beforeEach(() => {
     TestBed.configureTestingModule({


### PR DESCRIPTION
## 概要
ソート機能の Task 3.13 Frontend テストを実装し、TODO_FEATURE_03_SORT を完了させる。

## 変更内容

### 3.13.1: TodoService ソート機能のテスト
- `frontend/src/app/services/todo.service.spec.ts` を新規作成
- `list(undefined, sort)` で sortBy/sortOrder がクエリに含まれること、未指定時は含まれないことを検証
- `reorderTodos(todoIds)` で PUT /todos/reorder に `{ todoIds }` が送られることを検証
- HttpClientTestingModule 使用

### 3.13.2: SortSelector コンポーネントテスト
- `sort-selector.component.spec.ts` を新規作成
- デフォルト sortBy/sortOrder、5 種類のソートオプション表示
- セレクト変更で sortChanged に新しい sortBy が emit されること
- 昇順/降順トグルで sortChanged に切り替えた sortOrder が emit されることを検証

### 3.13.3: ドラッグ&ドロップのテスト
- `todo-list.component.spec.ts` を新規作成
- `onDrop` で index 入れ替え後に `reorder` に正しい id 配列が emit されること
- previousIndex === currentIndex のとき emit されないこと
- `dragDisabled === true` のとき emit されないことを検証

## 確認済み
- `docker compose run --rm frontend ng build` ✅
- `docker compose run --rm frontend ng test --watch=false` ✅（28 SUCCESS）

## 関連
- `docs/TODO_FEATURE_03_SORT.md` の Task 3.13 を完了に更新

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)