### PR TITLE
test(archive): アーカイブ機能の Frontend テスト追加（10.12.1, 10.12.2）

### DIFF
--- a/docs/TODO_FEATURE_10_ARCHIVE.md
+++ b/docs/TODO_FEATURE_10_ARCHIVE.md
@@ -92,8 +92,8 @@ DELETE /api/todos/archived (一括削除)
 - [x] 10.11.1: アーカイブ済み Todo のスタイル
 
 ### Task 10.12: Frontend テスト
-- [ ] 10.12.1: TodoService アーカイブ機能のテスト
-- [ ] 10.12.2: ArchivedTodosPage のテスト
+- [x] 10.12.1: TodoService アーカイブ機能のテスト
+- [x] 10.12.2: ArchivedTodosPage のテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
@@ -1,0 +1,100 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { of, throwError } from 'rxjs'
+import ArchivedTodosPageComponent from './archived-todos-page.component'
+import { TodoService } from '../../../../services/todo.service'
+import type { Todo } from '../../../../models/todo.interface'
+
+const mockArchivedTodos: Todo[] = [
+  {
+    id: 1,
+    userId: 1,
+    title: 'Done task',
+    description: null,
+    completed: true,
+    priority: 'medium',
+    dueDate: null,
+    sortOrder: 0,
+    archived: true,
+    archivedAt: '2026-03-01T12:00:00.000Z',
+    createdAt: '2026-03-01T10:00:00.000Z',
+    updatedAt: '2026-03-01T12:00:00.000Z',
+    Tags: [],
+  },
+]
+
+describe('ArchivedTodosPageComponent (10.12.2)', () => {
+  let component: ArchivedTodosPageComponent
+  let fixture: ComponentFixture<ArchivedTodosPageComponent>
+  let todoService: jasmine.SpyObj<TodoService>
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('TodoService', ['getArchivedTodos', 'unarchiveTodo', 'deleteArchivedTodos'])
+    await TestBed.configureTestingModule({
+      imports: [ArchivedTodosPageComponent],
+      providers: [{ provide: TodoService, useValue: spy }, provideNoopAnimations()],
+    }).compileComponents()
+
+    todoService = TestBed.inject(TodoService) as jasmine.SpyObj<TodoService>
+    todoService.getArchivedTodos.and.returnValue(of([]))
+
+    fixture = TestBed.createComponent(ArchivedTodosPageComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should call getArchivedTodos on init and set todos', () => {
+    expect(todoService.getArchivedTodos).toHaveBeenCalled()
+    expect(component.todos).toEqual([])
+  })
+
+  it('should display loaded archived todos', () => {
+    todoService.getArchivedTodos.calls.reset()
+    todoService.getArchivedTodos.and.returnValue(of(mockArchivedTodos))
+    component.loadArchived()
+    expect(component.todos).toEqual(mockArchivedTodos)
+    expect(component.loading).toBe(false)
+  })
+
+  it('should call unarchiveTodo and reload on onUnarchive', () => {
+    todoService.getArchivedTodos.and.returnValue(of([]))
+    todoService.unarchiveTodo.and.returnValue(of(mockArchivedTodos[0] as Todo))
+    component.onUnarchive(1)
+    expect(todoService.unarchiveTodo).toHaveBeenCalledWith(1)
+    expect(todoService.getArchivedTodos).toHaveBeenCalled()
+  })
+
+  it('should set error on unarchiveTodo failure', () => {
+    todoService.unarchiveTodo.and.returnValue(throwError(() => ({ message: 'server error' })))
+    component.onUnarchive(1)
+    expect(component.error).toBe('server error')
+  })
+
+  it('should call deleteArchivedTodos and reload when confirm is true', () => {
+    spyOn(window, 'confirm').and.returnValue(true)
+    todoService.deleteArchivedTodos.and.returnValue(of(undefined))
+    todoService.getArchivedTodos.and.returnValue(of([]))
+    component.onDeleteAll()
+    expect(todoService.deleteArchivedTodos).toHaveBeenCalled()
+    expect(todoService.getArchivedTodos).toHaveBeenCalled()
+  })
+
+  it('should not call deleteArchivedTodos when confirm is false', () => {
+    spyOn(window, 'confirm').and.returnValue(false)
+    component.onDeleteAll()
+    expect(todoService.deleteArchivedTodos).not.toHaveBeenCalled()
+  })
+
+  it('formatArchivedAt should return empty string for null', () => {
+    expect(component.formatArchivedAt(null)).toBe('')
+  })
+
+  it('formatArchivedAt should return ja-JP formatted date', () => {
+    const formatted = component.formatArchivedAt('2026-03-01T12:00:00.000Z')
+    expect(formatted).toMatch(/\d{4}\/\d{1,2}\/\d{1,2}/)
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
@@ -89,6 +89,13 @@ describe('ArchivedTodosPageComponent (10.12.2)', () => {
     expect(todoService.deleteArchivedTodos).not.toHaveBeenCalled()
   })
 
+  it('should set error when deleteArchivedTodos fails', () => {
+    spyOn(window, 'confirm').and.returnValue(true)
+    todoService.deleteArchivedTodos.and.returnValue(throwError(() => ({ message: 'delete error' })))
+    component.onDeleteAll()
+    expect(component.error).toBe('delete error')
+  })
+
   it('formatArchivedAt should return empty string for null', () => {
     expect(component.formatArchivedAt(null)).toBe('')
   })

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -98,7 +98,6 @@ describe('TodoService', () => {
     it('should call DELETE /todos/archived for deleteArchivedTodos', () => {
       service.deleteArchivedTodos().subscribe()
       const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/archived` && r.method === 'DELETE')
-      expect(req.request.url).toBe(`${apiUrl}/todos/archived`)
       req.flush(null)
     })
   })

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -71,4 +71,35 @@ describe('TodoService', () => {
       req.flush(null)
     })
   })
+
+  describe('archive (10.12.1)', () => {
+    it('should call PATCH /todos/:id/archive for archiveTodo', () => {
+      const id = 5
+      service.archiveTodo(id).subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${id}/archive` && r.method === 'PATCH')
+      expect(req.request.body).toEqual({})
+      req.flush({ id, archived: true })
+    })
+
+    it('should call PATCH /todos/:id/unarchive for unarchiveTodo', () => {
+      const id = 3
+      service.unarchiveTodo(id).subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${id}/unarchive` && r.method === 'PATCH')
+      expect(req.request.body).toEqual({})
+      req.flush({ id, archived: false })
+    })
+
+    it('should call GET /todos/archived for getArchivedTodos', () => {
+      service.getArchivedTodos().subscribe((list) => expect(list).toEqual([]))
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/archived` && r.method === 'GET')
+      req.flush([])
+    })
+
+    it('should call DELETE /todos/archived for deleteArchivedTodos', () => {
+      service.deleteArchivedTodos().subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/archived` && r.method === 'DELETE')
+      expect(req.request.url).toBe(`${apiUrl}/todos/archived`)
+      req.flush(null)
+    })
+  })
 })


### PR DESCRIPTION
## 概要
アーカイブ機能の Task 10.12 Frontend テストを実装し、TODO_FEATURE_10_ARCHIVE を完了させる。

## 変更内容

### 10.12.1: TodoService アーカイブ機能のテスト
- `todo.service.spec.ts` に `describe('archive (10.12.1)')` を追加
- `archiveTodo(id)`: PATCH /todos/:id/archive を検証
- `unarchiveTodo(id)`: PATCH /todos/:id/unarchive を検証
- `getArchivedTodos()`: GET /todos/archived を検証
- `deleteArchivedTodos()`: DELETE /todos/archived を検証

### 10.12.2: ArchivedTodosPage のテスト
- `archived-todos-page.component.spec.ts` を新規作成
- TodoService をモックし、getArchivedTodos / unarchiveTodo / deleteArchivedTodos の呼び出しを検証
- init 時の getArchivedTodos、loadArchived で todos/loading 更新
- onUnarchive で unarchiveTodo 呼び出しと loadArchived 再実行、エラー時は error 設定
- onDeleteAll で confirm が true のとき deleteArchivedTodos と loadArchived、false のときは呼ばない
- formatArchivedAt(null) は空文字、日付文字列は ja-JP フォーマット
- CardComponent のアニメーション用に `provideNoopAnimations()` を追加

## 確認済み
- `docker compose run --rm frontend ng build` ✅
- `docker compose run --rm frontend ng test --watch=false` ✅（41 SUCCESS）

## 関連
- `docs/TODO_FEATURE_10_ARCHIVE.md` の Task 10.12 を完了に更新

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)