### PR TITLE
test(tags): タグ機能の Frontend テスト追加（1.26.1〜1.26.4）

### DIFF
--- a/docs/TODO_FEATURE_01_TAGS.md
+++ b/docs/TODO_FEATURE_01_TAGS.md
@@ -258,10 +258,10 @@ GET /api/todos?tags=1,2,3  # タグでフィルタ
 
 ### Task 1.26: Frontend テスト
 
-- [ ] 1.26.1: TagService ユニットテスト
-- [ ] 1.26.2: TagList コンポーネントテスト
-- [ ] 1.26.3: TagForm コンポーネントテスト
-- [ ] 1.26.4: TagChip コンポーネントテスト
+- [x] 1.26.1: TagService ユニットテスト
+- [x] 1.26.2: TagList コンポーネントテスト
+- [x] 1.26.3: TagForm コンポーネントテスト
+- [x] 1.26.4: TagChip コンポーネントテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/tags/tags-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/tags/tags-page.component.spec.ts
@@ -94,4 +94,9 @@ describe('TagsPageComponent (1.26.2, 1.26.3)', () => {
   it('isLight should return false for dark hex', () => {
     expect(component.isLight('#000000')).toBe(false)
   })
+
+  it('isLight should return false for invalid hex', () => {
+    expect(component.isLight('')).toBe(false)
+    expect(component.isLight('red')).toBe(false)
+  })
 })

--- a/frontend/src/app/components/pages/dashboard/tags/tags-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/tags/tags-page.component.spec.ts
@@ -1,0 +1,97 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { of, throwError } from 'rxjs'
+import TagsPageComponent from './tags-page.component'
+import { TagService } from '../../../../services/tag.service'
+import type { Tag } from '../../../../models/tag.interface'
+
+const mockTags: Tag[] = [
+  { id: 1, userId: 1, name: 'work', color: '#ff0000', createdAt: '', updatedAt: '' },
+  { id: 2, userId: 1, name: 'private', color: '#00ff00', createdAt: '', updatedAt: '' },
+]
+
+describe('TagsPageComponent (1.26.2, 1.26.3)', () => {
+  let component: TagsPageComponent
+  let fixture: ComponentFixture<TagsPageComponent>
+  let tagService: jasmine.SpyObj<TagService>
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('TagService', ['getTags', 'create', 'delete'])
+    await TestBed.configureTestingModule({
+      imports: [TagsPageComponent],
+      providers: [{ provide: TagService, useValue: spy }, provideNoopAnimations()],
+    }).compileComponents()
+
+    tagService = TestBed.inject(TagService) as jasmine.SpyObj<TagService>
+    tagService.getTags.and.returnValue(of([]))
+
+    fixture = TestBed.createComponent(TagsPageComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should call getTags on init', () => {
+    expect(tagService.getTags).toHaveBeenCalled()
+    expect(component.tags).toEqual([])
+  })
+
+  it('should display loaded tags', () => {
+    tagService.getTags.calls.reset()
+    tagService.getTags.and.returnValue(of(mockTags))
+    component.loadTags()
+    expect(component.tags).toEqual(mockTags)
+    expect(component.loading).toBe(false)
+  })
+
+  it('should call create and reload on submit with valid name', () => {
+    tagService.create.and.returnValue(of(mockTags[0]))
+    tagService.getTags.and.returnValue(of([]))
+    component.newName = ' newtag '
+    component.newColor = '#0000ff'
+    component.onSubmit()
+    expect(tagService.create).toHaveBeenCalledWith({ name: 'newtag', color: '#0000ff' })
+    expect(tagService.getTags).toHaveBeenCalled()
+    expect(component.newName).toBe('')
+    expect(component.newColor).toBe('#808080')
+  })
+
+  it('should not call create when name is empty', () => {
+    component.newName = '   '
+    component.onSubmit()
+    expect(tagService.create).not.toHaveBeenCalled()
+  })
+
+  it('should call delete and reload when confirm is true', () => {
+    spyOn(window, 'confirm').and.returnValue(true)
+    tagService.delete.and.returnValue(of(undefined))
+    tagService.getTags.and.returnValue(of([]))
+    component.onDelete(mockTags[0])
+    expect(tagService.delete).toHaveBeenCalledWith(1)
+    expect(tagService.getTags).toHaveBeenCalled()
+  })
+
+  it('should not call delete when confirm is false', () => {
+    spyOn(window, 'confirm').and.returnValue(false)
+    component.onDelete(mockTags[0])
+    expect(tagService.delete).not.toHaveBeenCalled()
+  })
+
+  it('should set error on create failure', () => {
+    component.newName = 'x'
+    tagService.create.and.returnValue(throwError(() => ({ message: 'create error' })))
+    component.onSubmit()
+    expect(component.error).toBe('create error')
+  })
+
+  it('isLight should return true for light hex', () => {
+    expect(component.isLight('#ffffff')).toBe(true)
+  })
+
+  it('isLight should return false for dark hex', () => {
+    expect(component.isLight('#000000')).toBe(false)
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/tag-chip/tag-chip.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { TagChipComponent } from './tag-chip.component'
+import type { Tag } from '../../../../../models/tag.interface'
+
+const mockTag: Tag = {
+  id: 1,
+  userId: 1,
+  name: 'work',
+  color: '#808080',
+  createdAt: '',
+  updatedAt: '',
+}
+
+describe('TagChipComponent (1.26.4)', () => {
+  let component: TagChipComponent
+  let fixture: ComponentFixture<TagChipComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TagChipComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(TagChipComponent)
+    component = fixture.componentInstance
+    component.tag = { ...mockTag }
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should display tag name', () => {
+    expect(fixture.nativeElement.textContent).toContain('work')
+  })
+
+  it('should apply tag color as background', () => {
+    const el = fixture.nativeElement.querySelector('.tag-chip')
+    expect(el.style.backgroundColor).toBe('rgb(128, 128, 128)')
+  })
+
+  it('should emit removed when remove button is clicked and removable is true', () => {
+    component.removable = true
+    fixture.detectChanges()
+    let emitted: Tag | null = null
+    component.removed.subscribe((t) => (emitted = t))
+    fixture.nativeElement.querySelector('button').click()
+    expect(emitted).toEqual(mockTag)
+  })
+
+  it('should not show remove button when removable is false', () => {
+    component.removable = false
+    fixture.detectChanges()
+    expect(fixture.nativeElement.querySelector('button')).toBeNull()
+  })
+
+  it('isLight should return true for light color', () => {
+    expect(component.isLight('#ffffff')).toBe(true)
+    expect(component.isLight('#eeeeee')).toBe(true)
+  })
+
+  it('isLight should return false for dark color', () => {
+    expect(component.isLight('#000000')).toBe(false)
+    expect(component.isLight('#333333')).toBe(false)
+  })
+
+  it('isLight should return false for invalid hex', () => {
+    expect(component.isLight('')).toBe(false)
+    expect(component.isLight('red')).toBe(false)
+  })
+})

--- a/frontend/src/app/services/tag.service.spec.ts
+++ b/frontend/src/app/services/tag.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
+import { TagService } from './tag.service'
+import type { CreateTagDto, UpdateTagDto } from '../models/tag.interface'
+
+describe('TagService (1.26.1)', () => {
+  let service: TagService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [TagService],
+    })
+    service = TestBed.inject(TagService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should call POST /tags with body for create', () => {
+    const body: CreateTagDto = { name: 'work', color: '#ff0000' }
+    service.create(body).subscribe((tag) => expect(tag.id).toBe(1))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/tags` && r.method === 'POST')
+    expect(req.request.body).toEqual(body)
+    req.flush({ id: 1, userId: 1, name: 'work', color: '#ff0000', createdAt: '', updatedAt: '' })
+  })
+
+  it('should call GET /tags for getTags', () => {
+    service.getTags().subscribe((list) => expect(list).toEqual([]))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/tags` && r.method === 'GET')
+    req.flush([])
+  })
+
+  it('should call GET /tags/:id for getById', () => {
+    const id = 5
+    service.getById(id).subscribe((tag) => expect(tag.id).toBe(id))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/tags/${id}` && r.method === 'GET')
+    req.flush({ id, userId: 1, name: 'x', color: '#000', createdAt: '', updatedAt: '' })
+  })
+
+  it('should call PUT /tags/:id with body for update', () => {
+    const id = 3
+    const body: UpdateTagDto = { name: 'updated' }
+    service.update(id, body).subscribe()
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/tags/${id}` && r.method === 'PUT')
+    expect(req.request.body).toEqual(body)
+    req.flush({ id, userId: 1, name: 'updated', color: '#000', createdAt: '', updatedAt: '' })
+  })
+
+  it('should call DELETE /tags/:id for delete', () => {
+    const id = 2
+    service.delete(id).subscribe()
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/tags/${id}` && r.method === 'DELETE')
+    req.flush(null)
+  })
+})

--- a/frontend/src/app/services/tag.service.spec.ts
+++ b/frontend/src/app/services/tag.service.spec.ts
@@ -50,7 +50,7 @@ describe('TagService (1.26.1)', () => {
   it('should call PUT /tags/:id with body for update', () => {
     const id = 3
     const body: UpdateTagDto = { name: 'updated' }
-    service.update(id, body).subscribe()
+    service.update(id, body).subscribe((tag) => expect(tag.name).toBe('updated'))
     const req = httpMock.expectOne((r) => r.url === `${apiUrl}/tags/${id}` && r.method === 'PUT')
     expect(req.request.body).toEqual(body)
     req.flush({ id, userId: 1, name: 'updated', color: '#000', createdAt: '', updatedAt: '' })


### PR DESCRIPTION
## 概要
タグ機能の Task 1.26 Frontend テストを実装し、TODO_FEATURE_01_TAGS を完了させる。

## 変更内容

### 1.26.1: TagService ユニットテスト
- `tag.service.spec.ts` を新規作成
- create / getTags / getById / update / delete の各 HTTP メソッドの URL・body・レスポンスを検証
- HttpClientTestingModule 使用

### 1.26.2 / 1.26.3: TagsPageComponent テスト（一覧・フォーム）
- `tags-page.component.spec.ts` を新規作成（TagList・TagForm は同一ページに統合のため一括テスト）
- init 時の getTags、loadTags で tags/loading 更新
- onSubmit: 名前 trim・create 呼び出し・成功時リセットと loadTags、空名時は create 未呼び出し
- onDelete: confirm ありで delete + loadTags、confirm なしで未呼び出し
- create 失敗時の error 設定、isLight の挙動を検証
- provideNoopAnimations で CardComponent のアニメーション対応

### 1.26.4: TagChipComponent テスト
- `tag-chip.component.spec.ts` を新規作成
- タグ名表示、背景色適用、removable 時のみ削除ボタン表示・removed emit
- isLight の明/暗/不正 hex の戻り値を検証

## 確認済み
- `docker compose run --rm frontend ng build` ✅
- `docker compose run --rm frontend ng test --watch=false` ✅（82 SUCCESS）

## 関連
- `docs/TODO_FEATURE_01_TAGS.md` の Task 1.26 を完了に更新

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)