### PR TITLE
feat(search): AdvancedSearchDialog 追加と Todo ページに詳細検索ボタン（2.9, 2.10.2）

### DIFF
--- a/docs/TODO_FEATURE_02_SEARCH.md
+++ b/docs/TODO_FEATURE_02_SEARCH.md
@@ -91,16 +91,16 @@ GET /api/todos/search?q=買い物&priority=high&completed=false&tags=1,2
 
 ### Task 2.9: AdvancedSearchDialog コンポーネント作成
 
-- [ ] 2.9.1: `ng generate component components/advanced-search-dialog` 実行
-- [ ] 2.9.2: Angular Material Dialog 使用
-- [ ] 2.9.3: 詳細検索フォーム実装（優先度、完了状態、タグ）
-- [ ] 2.9.4: Reactive Forms 実装
-- [ ] 2.9.5: @Output() searchParams: EventEmitter<SearchParams> 実装
+- [x] 2.9.1: `ng generate component components/advanced-search-dialog` 実行
+- [x] 2.9.2: Angular Material Dialog 使用
+- [x] 2.9.3: 詳細検索フォーム実装（優先度、完了状態、タグ）
+- [x] 2.9.4: Reactive Forms 実装
+- [x] 2.9.5: @Output() searchParams: EventEmitter<SearchParams> 実装（MatDialog close で SearchParams 返却）
 
 ### Task 2.10: TodoPage に検索機能統合
 
 - [x] 2.10.1: SearchBar コンポーネント追加
-- [ ] 2.10.2: 詳細検索ボタン追加（AdvancedSearchDialog はオプションのため未実装）
+- [x] 2.10.2: 詳細検索ボタン追加（AdvancedSearchDialog 連携）
 - [x] 2.10.3: 検索実行処理実装（検索時は search、空時は list）
 - [x] 2.10.4: 検索結果表示（既存 TodoList で表示）
 - [x] 2.10.5: 検索中のローディング表示（既存 loading で対応）

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -6,6 +6,7 @@ import { BrowserModule } from '@angular/platform-browser'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { SharedModule } from './theme/shared/shared.module'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { MatDialogModule } from '@angular/material/dialog'
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap'
 import { NavigationItem } from './theme/layout/admin/navigation/navigation'
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
@@ -19,6 +20,7 @@ export const appConfig: ApplicationConfig = {
       ReactiveFormsModule,
       SharedModule,
       BrowserAnimationsModule,
+      MatDialogModule,
       NgbModule
     ),
     NavigationItem,

--- a/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.html
@@ -1,0 +1,50 @@
+<h2 mat-dialog-title>詳細検索</h2>
+<mat-dialog-content>
+  <form [formGroup]="form" class="d-flex flex-column gap-3">
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>キーワード</mat-label>
+      <input matInput formControlName="q" placeholder="タイトル・説明で検索" />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>完了状態</mat-label>
+      <mat-select formControlName="completed">
+        @for (opt of completedOptions; track opt.value) {
+          <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>優先度</mat-label>
+      <mat-select formControlName="priority">
+        @for (opt of priorityOptions; track opt.value) {
+          <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    @if (allTags.length > 0) {
+      <div class="tag-filters">
+        <span class="mat-body-2 mb-1 d-block">タグ</span>
+        <div class="d-flex flex-wrap gap-1">
+          @for (tag of allTags; track tag.id) {
+            <button
+              type="button"
+              class="badge rounded-pill"
+              [class.bg-secondary]="!tagIdsFormValue.includes(tag.id)"
+              [style.background-color]="tagIdsFormValue.includes(tag.id) ? tag.color : null"
+              [class.text-dark]="tagIdsFormValue.includes(tag.id) ? isLight(tag.color) : true"
+              [class.text-white]="tagIdsFormValue.includes(tag.id) && !isLight(tag.color)"
+              (click)="toggleTag(tag.id)"
+            >
+              {{ tag.name }}
+            </button>
+          }
+        </div>
+      </div>
+    }
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="clear()">クリア</button>
+  <button mat-button (click)="cancel()">キャンセル</button>
+  <button mat-flat-button color="primary" (click)="apply()">検索する</button>
+</mat-dialog-actions>

--- a/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common'
 import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms'
 import {
   MAT_DIALOG_DATA,
-  MatDialogModule,
   MatDialogRef,
   MatDialogTitle,
   MatDialogContent,
@@ -14,7 +13,6 @@ import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatInputModule } from '@angular/material/input'
 import { MatSelectModule } from '@angular/material/select'
 import { MatButtonModule } from '@angular/material/button'
-import { MatCheckboxModule } from '@angular/material/checkbox'
 import type { SearchParams } from '../../../../../models/search-params.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 import type { TodoPriority } from '../../../../../models/todo.interface'
@@ -34,7 +32,6 @@ export interface AdvancedSearchDialogData {
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    MatDialogModule,
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
@@ -42,8 +39,7 @@ export interface AdvancedSearchDialogData {
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
-    MatButtonModule,
-    MatCheckboxModule
+    MatButtonModule
   ],
   templateUrl: './advanced-search-dialog.component.html',
   styleUrl: './advanced-search-dialog.component.scss'

--- a/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.ts
@@ -1,0 +1,133 @@
+import { Component, Inject } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms'
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose
+} from '@angular/material/dialog'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
+import { MatSelectModule } from '@angular/material/select'
+import { MatButtonModule } from '@angular/material/button'
+import { MatCheckboxModule } from '@angular/material/checkbox'
+import type { SearchParams } from '../../../../../models/search-params.interface'
+import type { Tag } from '../../../../../models/tag.interface'
+import type { TodoPriority } from '../../../../../models/todo.interface'
+
+export interface AdvancedSearchDialogData {
+  currentParams: Partial<SearchParams> | null
+  allTags: Tag[]
+}
+
+/**
+ * 詳細検索ダイアログ。優先度・完了状態・タグ・キーワードをまとめて指定し、
+ * 適用時に SearchParams を close で返す。
+ */
+@Component({
+  selector: 'app-advanced-search-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatCheckboxModule
+  ],
+  templateUrl: './advanced-search-dialog.component.html',
+  styleUrl: './advanced-search-dialog.component.scss'
+})
+export class AdvancedSearchDialogComponent {
+  form: FormGroup
+  allTags: Tag[]
+  priorityOptions: { value: '' | TodoPriority; label: string }[] = [
+    { value: '', label: '指定しない' },
+    { value: 'low', label: 'low' },
+    { value: 'medium', label: 'medium' },
+    { value: 'high', label: 'high' }
+  ]
+  completedOptions: { value: '' | 'true' | 'false'; label: string }[] = [
+    { value: '', label: '指定しない' },
+    { value: 'false', label: '未完了' },
+    { value: 'true', label: '完了' }
+  ]
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<AdvancedSearchDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AdvancedSearchDialogData
+  ) {
+    this.allTags = data.allTags ?? []
+    const p = data.currentParams ?? {}
+    this.form = this.fb.nonNullable.group({
+      q: [p.q ?? ''],
+      completed: [p.completed === undefined ? '' : String(p.completed)],
+      priority: [p.priority ?? ''],
+      tagIds: [p.tagIds ?? [] as number[]]
+    })
+  }
+
+  get tagIdsFormValue(): number[] {
+    const v = this.form.get('tagIds')?.value
+    return Array.isArray(v) ? v : []
+  }
+
+  toggleTag(tagId: number): void {
+    const current = this.tagIdsFormValue
+    const next = current.includes(tagId)
+      ? current.filter((id) => id !== tagId)
+      : [...current, tagId]
+    this.form.patchValue({ tagIds: next })
+  }
+
+  apply(): void {
+    const raw = this.form.getRawValue()
+    const completed =
+      raw.completed === '' ? undefined : raw.completed === 'true'
+    const priority =
+      raw.priority === '' ? undefined : (raw.priority as TodoPriority)
+    const tagIds = Array.isArray(raw.tagIds) && raw.tagIds.length > 0
+      ? raw.tagIds
+      : undefined
+    const params: SearchParams = {
+      q: (raw.q ?? '').trim(),
+      ...(completed !== undefined && { completed }),
+      ...(priority !== undefined && { priority }),
+      ...(tagIds !== undefined && { tagIds })
+    }
+    this.dialogRef.close(params)
+  }
+
+  clear(): void {
+    this.form.reset({
+      q: '',
+      completed: '',
+      priority: '',
+      tagIds: []
+    })
+  }
+
+  cancel(): void {
+    this.dialogRef.close()
+  }
+
+  /** タグ色が明るい場合に true（チップの文字色切り替え用） */
+  isLight(hex: string): boolean {
+    if (!hex || !hex.startsWith('#')) return false
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -2,7 +2,12 @@
   <div class="col-12">
     <app-card cardTitle="Todo リスト（{{ todos.length }} 件）">
       <div class="mb-3">
-        <app-search-bar (searchTerm)="onSearch($event)" />
+        <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+          <app-search-bar (searchTerm)="onSearch($event)" />
+          <button type="button" class="btn btn-outline-secondary btn-sm" (click)="openAdvancedSearch()">
+            詳細検索
+          </button>
+        </div>
         <div class="row g-2 align-items-center flex-wrap">
           <div class="col-auto">
             <label class="form-label mb-0 me-1">完了</label>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { Subject, takeUntil } from 'rxjs'
+import { MatDialog } from '@angular/material/dialog'
 import { TodoService } from '../../../../../services/todo.service'
 import { TagService } from '../../../../../services/tag.service'
 import { TodoListComponent } from '../todo-list/todo-list.component'
@@ -9,9 +10,14 @@ import { SearchBarComponent } from '../search-bar/search-bar.component'
 import { SortSelectorComponent } from '../sort-selector/sort-selector.component'
 import { BulkActionBarComponent } from '../bulk-action-bar/bulk-action-bar.component'
 import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
+import {
+  AdvancedSearchDialogComponent,
+  type AdvancedSearchDialogData
+} from '../advanced-search-dialog/advanced-search-dialog.component'
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
+import type { SearchParams } from '../../../../../models/search-params.interface'
 
 @Component({
   selector: 'app-todo-page',
@@ -47,7 +53,8 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
 
   constructor(
     private todoService: TodoService,
-    private tagService: TagService
+    private tagService: TagService,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -98,6 +105,31 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     this.searchQuery = term
     this.selectedIds = []
     this.loadTodos()
+  }
+
+  openAdvancedSearch(): void {
+    const data: AdvancedSearchDialogData = {
+      currentParams: {
+        q: this.searchQuery,
+        completed: this.filterCompleted ?? undefined,
+        priority: this.filterPriority ?? undefined,
+        tagIds: this.filterTagIds.length > 0 ? [...this.filterTagIds] : undefined
+      },
+      allTags: this.allTags
+    }
+    const ref = this.dialog.open(AdvancedSearchDialogComponent, {
+      width: '400px',
+      data
+    })
+    ref.afterClosed().pipe(takeUntil(this.destroy$)).subscribe((params: SearchParams | undefined) => {
+      if (params == null) return
+      this.searchQuery = params.q ?? ''
+      this.filterCompleted = params.completed ?? null
+      this.filterPriority = (params.priority ?? null) as TodoPriority | null
+      this.filterTagIds = params.tagIds ?? []
+      this.selectedIds = []
+      this.loadTodos()
+    })
   }
 
   onFiltersChange(): void {


### PR DESCRIPTION
## 概要
検索機能の Task 2.9 と 2.10.2 を実装しました。

## 変更内容
- **Task 2.9**: AdvancedSearchDialog コンポーネント作成
  - Angular Material Dialog 使用
  - キーワード・完了状態・優先度・タグの詳細検索フォーム（Reactive Forms）
  - 適用時に `dialogRef.close(SearchParams)` で SearchParams を返却
- **Task 2.10.2**: TodoPage に「詳細検索」ボタン追加
  - クリックで AdvancedSearchDialog を開き、現在の検索条件を渡して表示
  - ダイアログで「検索する」押下時に SearchParams を反映して `loadTodos()` 実行
- `app.config.ts` に MatDialogModule 追加
- `docs/TODO_FEATURE_02_SEARCH.md` の 2.9 / 2.10.2 を完了に更新

## 確認
- `docker compose run --rm frontend ng test --watch=false` → 83 SUCCESS
- `ng build` 成功（バンドル予算の警告は既存事象）

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)