### PR TITLE
test(search): 検索機能の Frontend テスト追加（2.13.1〜2.13.3）

### DIFF
--- a/docs/TODO_FEATURE_02_SEARCH.md
+++ b/docs/TODO_FEATURE_02_SEARCH.md
@@ -119,9 +119,9 @@ GET /api/todos/search?q=買い物&priority=high&completed=false&tags=1,2
 
 ### Task 2.13: Frontend テスト
 
-- [ ] 2.13.1: TodoService.searchTodos のテスト
-- [ ] 2.13.2: SearchBar コンポーネントテスト
-- [ ] 2.13.3: AdvancedSearchDialog コンポーネントテスト
+- [x] 2.13.1: TodoService.search のテスト
+- [x] 2.13.2: SearchBar コンポーネントテスト
+- [x] 2.13.3: AdvancedSearchDialog コンポーネントテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.spec.ts
@@ -47,13 +47,14 @@ describe('AdvancedSearchDialogComponent (2.13.3)', () => {
   })
 
   it('should init form from data.currentParams', async () => {
+    // overrideProvider は親 beforeEach で既に createComponent 済みのため使用不可。異なる MAT_DIALOG_DATA を渡すため再構成する。
     TestBed.resetTestingModule()
-    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close'])
+    const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
     await TestBed.configureTestingModule({
       imports: [AdvancedSearchDialogComponent],
       providers: [
         provideNoopAnimations(),
-        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MatDialogRef, useValue: ref },
         {
           provide: MAT_DIALOG_DATA,
           useValue: {
@@ -107,6 +108,7 @@ describe('AdvancedSearchDialogComponent (2.13.3)', () => {
   })
 
   it('should toggle tag in tagIds', async () => {
+    // overrideProvider は親 beforeEach で既に createComponent 済みのため使用不可。allTags を渡すため再構成する。
     TestBed.resetTestingModule()
     const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
     await TestBed.configureTestingModule({

--- a/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.spec.ts
@@ -1,0 +1,144 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog'
+import { AdvancedSearchDialogComponent, type AdvancedSearchDialogData } from './advanced-search-dialog.component'
+import type { Tag } from '../../../../../models/tag.interface'
+
+const mockTags: Tag[] = [
+  { id: 1, userId: 1, name: 'work', color: '#ff0000', createdAt: '', updatedAt: '' },
+  { id: 2, userId: 1, name: 'private', color: '#ffffff', createdAt: '', updatedAt: '' },
+]
+
+describe('AdvancedSearchDialogComponent (2.13.3)', () => {
+  let component: AdvancedSearchDialogComponent
+  let fixture: ComponentFixture<AdvancedSearchDialogComponent>
+  let dialogRef: jasmine.SpyObj<MatDialogRef<AdvancedSearchDialogComponent>>
+
+  const defaultData: AdvancedSearchDialogData = {
+    currentParams: null,
+    allTags: [],
+  }
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close'])
+    await TestBed.configureTestingModule({
+      imports: [AdvancedSearchDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: defaultData },
+      ],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(AdvancedSearchDialogComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should init form with empty values when data.currentParams is null', () => {
+    expect(component.form.get('q')?.value).toBe('')
+    expect(component.form.get('completed')?.value).toBe('')
+    expect(component.form.get('priority')?.value).toBe('')
+    expect(component.form.get('tagIds')?.value).toEqual([])
+  })
+
+  it('should init form from data.currentParams', async () => {
+    TestBed.resetTestingModule()
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close'])
+    await TestBed.configureTestingModule({
+      imports: [AdvancedSearchDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MatDialogRef, useValue: dialogRef },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            currentParams: { q: 'test', completed: true, priority: 'high', tagIds: [1] },
+            allTags: [],
+          },
+        },
+      ],
+    }).compileComponents()
+
+    const f = TestBed.createComponent(AdvancedSearchDialogComponent)
+    const c = f.componentInstance
+    expect(c.form.get('q')?.value).toBe('test')
+    expect(c.form.get('completed')?.value).toBe('true')
+    expect(c.form.get('priority')?.value).toBe('high')
+    expect(c.form.get('tagIds')?.value).toEqual([1])
+  })
+
+  it('should close with SearchParams when apply()', () => {
+    component.form.patchValue({ q: ' keyword ', completed: 'true', priority: 'medium', tagIds: [1, 2] })
+    component.apply()
+    expect(dialogRef.close).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        q: 'keyword',
+        completed: true,
+        priority: 'medium',
+        tagIds: [1, 2],
+      })
+    )
+  })
+
+  it('should not include optional fields when empty on apply()', () => {
+    component.form.patchValue({ q: '', completed: '', priority: '', tagIds: [] })
+    component.apply()
+    const call = (dialogRef.close as jasmine.Spy).calls.mostRecent()
+    expect(call.args[0]).toEqual({ q: '' })
+  })
+
+  it('should reset form on clear()', () => {
+    component.form.patchValue({ q: 'x', completed: 'true', priority: 'high', tagIds: [1] })
+    component.clear()
+    expect(component.form.get('q')?.value).toBe('')
+    expect(component.form.get('completed')?.value).toBe('')
+    expect(component.form.get('priority')?.value).toBe('')
+    expect(component.form.get('tagIds')?.value).toEqual([])
+  })
+
+  it('should close with no arg when cancel()', () => {
+    component.cancel()
+    expect(dialogRef.close).toHaveBeenCalledWith()
+  })
+
+  it('should toggle tag in tagIds', async () => {
+    TestBed.resetTestingModule()
+    const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
+    await TestBed.configureTestingModule({
+      imports: [AdvancedSearchDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MatDialogRef, useValue: ref },
+        { provide: MAT_DIALOG_DATA, useValue: { currentParams: null, allTags: mockTags } },
+      ],
+    }).compileComponents()
+
+    const f = TestBed.createComponent(AdvancedSearchDialogComponent)
+    const c = f.componentInstance
+    expect(c.tagIdsFormValue).toEqual([])
+    c.toggleTag(1)
+    expect(c.tagIdsFormValue).toEqual([1])
+    c.toggleTag(2)
+    expect(c.tagIdsFormValue).toEqual([1, 2])
+    c.toggleTag(1)
+    expect(c.tagIdsFormValue).toEqual([2])
+  })
+
+  it('isLight should return true for light hex', () => {
+    expect(component.isLight('#ffffff')).toBe(true)
+  })
+
+  it('isLight should return false for dark hex', () => {
+    expect(component.isLight('#000000')).toBe(false)
+  })
+
+  it('isLight should return false for invalid hex', () => {
+    expect(component.isLight('')).toBe(false)
+    expect(component.isLight('red')).toBe(false)
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/advanced-search-dialog/advanced-search-dialog.component.spec.ts
@@ -10,137 +10,149 @@ const mockTags: Tag[] = [
 ]
 
 describe('AdvancedSearchDialogComponent (2.13.3)', () => {
-  let component: AdvancedSearchDialogComponent
-  let fixture: ComponentFixture<AdvancedSearchDialogComponent>
-  let dialogRef: jasmine.SpyObj<MatDialogRef<AdvancedSearchDialogComponent>>
-
   const defaultData: AdvancedSearchDialogData = {
     currentParams: null,
     allTags: [],
   }
 
-  beforeEach(async () => {
-    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close'])
-    await TestBed.configureTestingModule({
-      imports: [AdvancedSearchDialogComponent],
-      providers: [
-        provideNoopAnimations(),
-        { provide: MatDialogRef, useValue: dialogRef },
-        { provide: MAT_DIALOG_DATA, useValue: defaultData },
-      ],
-    }).compileComponents()
+  describe('with default data (currentParams: null, allTags: [])', () => {
+    let component: AdvancedSearchDialogComponent
+    let fixture: ComponentFixture<AdvancedSearchDialogComponent>
+    let dialogRef: jasmine.SpyObj<MatDialogRef<AdvancedSearchDialogComponent>>
 
-    fixture = TestBed.createComponent(AdvancedSearchDialogComponent)
-    component = fixture.componentInstance
-    fixture.detectChanges()
+    beforeEach(async () => {
+      dialogRef = jasmine.createSpyObj('MatDialogRef', ['close'])
+      await TestBed.configureTestingModule({
+        imports: [AdvancedSearchDialogComponent],
+        providers: [
+          provideNoopAnimations(),
+          { provide: MatDialogRef, useValue: dialogRef },
+          { provide: MAT_DIALOG_DATA, useValue: defaultData },
+        ],
+      }).compileComponents()
+
+      fixture = TestBed.createComponent(AdvancedSearchDialogComponent)
+      component = fixture.componentInstance
+      fixture.detectChanges()
+    })
+
+    it('should create', () => {
+      expect(component).toBeTruthy()
+    })
+
+    it('should init form with empty values when data.currentParams is null', () => {
+      expect(component.form.get('q')?.value).toBe('')
+      expect(component.form.get('completed')?.value).toBe('')
+      expect(component.form.get('priority')?.value).toBe('')
+      expect(component.form.get('tagIds')?.value).toEqual([])
+    })
+
+    it('should close with SearchParams when apply()', () => {
+      component.form.patchValue({ q: ' keyword ', completed: 'true', priority: 'medium', tagIds: [1, 2] })
+      component.apply()
+      expect(dialogRef.close).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          q: 'keyword',
+          completed: true,
+          priority: 'medium',
+          tagIds: [1, 2],
+        })
+      )
+    })
+
+    it('should not include optional fields when empty on apply()', () => {
+      component.form.patchValue({ q: '', completed: '', priority: '', tagIds: [] })
+      component.apply()
+      const call = (dialogRef.close as jasmine.Spy).calls.mostRecent()
+      expect(call.args[0]).toEqual({ q: '' })
+    })
+
+    it('should reset form on clear()', () => {
+      component.form.patchValue({ q: 'x', completed: 'true', priority: 'high', tagIds: [1] })
+      component.clear()
+      expect(component.form.get('q')?.value).toBe('')
+      expect(component.form.get('completed')?.value).toBe('')
+      expect(component.form.get('priority')?.value).toBe('')
+      expect(component.form.get('tagIds')?.value).toEqual([])
+    })
+
+    it('should close with no arg when cancel()', () => {
+      component.cancel()
+      expect(dialogRef.close).toHaveBeenCalledWith()
+    })
+
+    it('isLight should return true for light hex', () => {
+      expect(component.isLight('#ffffff')).toBe(true)
+    })
+
+    it('isLight should return false for dark hex', () => {
+      expect(component.isLight('#000000')).toBe(false)
+    })
+
+    it('isLight should return false for invalid hex', () => {
+      expect(component.isLight('')).toBe(false)
+      expect(component.isLight('red')).toBe(false)
+    })
   })
 
-  it('should create', () => {
-    expect(component).toBeTruthy()
-  })
-
-  it('should init form with empty values when data.currentParams is null', () => {
-    expect(component.form.get('q')?.value).toBe('')
-    expect(component.form.get('completed')?.value).toBe('')
-    expect(component.form.get('priority')?.value).toBe('')
-    expect(component.form.get('tagIds')?.value).toEqual([])
-  })
-
-  it('should init form from data.currentParams', async () => {
-    // overrideProvider は親 beforeEach で既に createComponent 済みのため使用不可。異なる MAT_DIALOG_DATA を渡すため再構成する。
-    TestBed.resetTestingModule()
-    const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
-    await TestBed.configureTestingModule({
-      imports: [AdvancedSearchDialogComponent],
-      providers: [
-        provideNoopAnimations(),
-        { provide: MatDialogRef, useValue: ref },
-        {
-          provide: MAT_DIALOG_DATA,
-          useValue: {
-            currentParams: { q: 'test', completed: true, priority: 'high', tagIds: [1] },
-            allTags: [],
+  describe('when MAT_DIALOG_DATA has currentParams', () => {
+    let component: AdvancedSearchDialogComponent
+    let fixture: ComponentFixture<AdvancedSearchDialogComponent>
+    beforeEach(async () => {
+      const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
+      await TestBed.configureTestingModule({
+        imports: [AdvancedSearchDialogComponent],
+        providers: [
+          provideNoopAnimations(),
+          { provide: MatDialogRef, useValue: ref },
+          {
+            provide: MAT_DIALOG_DATA,
+            useValue: {
+              currentParams: { q: 'test', completed: true, priority: 'high', tagIds: [1] },
+              allTags: [],
+            },
           },
-        },
-      ],
-    }).compileComponents()
+        ],
+      }).compileComponents()
+      fixture = TestBed.createComponent(AdvancedSearchDialogComponent)
+      component = fixture.componentInstance
+      fixture.detectChanges()
+    })
 
-    const f = TestBed.createComponent(AdvancedSearchDialogComponent)
-    const c = f.componentInstance
-    expect(c.form.get('q')?.value).toBe('test')
-    expect(c.form.get('completed')?.value).toBe('true')
-    expect(c.form.get('priority')?.value).toBe('high')
-    expect(c.form.get('tagIds')?.value).toEqual([1])
+    it('should init form from data.currentParams', () => {
+      expect(component.form.get('q')?.value).toBe('test')
+      expect(component.form.get('completed')?.value).toBe('true')
+      expect(component.form.get('priority')?.value).toBe('high')
+      expect(component.form.get('tagIds')?.value).toEqual([1])
+    })
   })
 
-  it('should close with SearchParams when apply()', () => {
-    component.form.patchValue({ q: ' keyword ', completed: 'true', priority: 'medium', tagIds: [1, 2] })
-    component.apply()
-    expect(dialogRef.close).toHaveBeenCalledWith(
-      jasmine.objectContaining({
-        q: 'keyword',
-        completed: true,
-        priority: 'medium',
-        tagIds: [1, 2],
-      })
-    )
-  })
+  describe('when MAT_DIALOG_DATA has allTags', () => {
+    let component: AdvancedSearchDialogComponent
+    let fixture: ComponentFixture<AdvancedSearchDialogComponent>
+    beforeEach(async () => {
+      const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
+      await TestBed.configureTestingModule({
+        imports: [AdvancedSearchDialogComponent],
+        providers: [
+          provideNoopAnimations(),
+          { provide: MatDialogRef, useValue: ref },
+          { provide: MAT_DIALOG_DATA, useValue: { currentParams: null, allTags: mockTags } },
+        ],
+      }).compileComponents()
+      fixture = TestBed.createComponent(AdvancedSearchDialogComponent)
+      component = fixture.componentInstance
+      fixture.detectChanges()
+    })
 
-  it('should not include optional fields when empty on apply()', () => {
-    component.form.patchValue({ q: '', completed: '', priority: '', tagIds: [] })
-    component.apply()
-    const call = (dialogRef.close as jasmine.Spy).calls.mostRecent()
-    expect(call.args[0]).toEqual({ q: '' })
-  })
-
-  it('should reset form on clear()', () => {
-    component.form.patchValue({ q: 'x', completed: 'true', priority: 'high', tagIds: [1] })
-    component.clear()
-    expect(component.form.get('q')?.value).toBe('')
-    expect(component.form.get('completed')?.value).toBe('')
-    expect(component.form.get('priority')?.value).toBe('')
-    expect(component.form.get('tagIds')?.value).toEqual([])
-  })
-
-  it('should close with no arg when cancel()', () => {
-    component.cancel()
-    expect(dialogRef.close).toHaveBeenCalledWith()
-  })
-
-  it('should toggle tag in tagIds', async () => {
-    // overrideProvider は親 beforeEach で既に createComponent 済みのため使用不可。allTags を渡すため再構成する。
-    TestBed.resetTestingModule()
-    const ref = jasmine.createSpyObj('MatDialogRef', ['close'])
-    await TestBed.configureTestingModule({
-      imports: [AdvancedSearchDialogComponent],
-      providers: [
-        provideNoopAnimations(),
-        { provide: MatDialogRef, useValue: ref },
-        { provide: MAT_DIALOG_DATA, useValue: { currentParams: null, allTags: mockTags } },
-      ],
-    }).compileComponents()
-
-    const f = TestBed.createComponent(AdvancedSearchDialogComponent)
-    const c = f.componentInstance
-    expect(c.tagIdsFormValue).toEqual([])
-    c.toggleTag(1)
-    expect(c.tagIdsFormValue).toEqual([1])
-    c.toggleTag(2)
-    expect(c.tagIdsFormValue).toEqual([1, 2])
-    c.toggleTag(1)
-    expect(c.tagIdsFormValue).toEqual([2])
-  })
-
-  it('isLight should return true for light hex', () => {
-    expect(component.isLight('#ffffff')).toBe(true)
-  })
-
-  it('isLight should return false for dark hex', () => {
-    expect(component.isLight('#000000')).toBe(false)
-  })
-
-  it('isLight should return false for invalid hex', () => {
-    expect(component.isLight('')).toBe(false)
-    expect(component.isLight('red')).toBe(false)
+    it('should toggle tag in tagIds', () => {
+      expect(component.tagIdsFormValue).toEqual([])
+      component.toggleTag(1)
+      expect(component.tagIdsFormValue).toEqual([1])
+      component.toggleTag(2)
+      expect(component.tagIdsFormValue).toEqual([1, 2])
+      component.toggleTag(1)
+      expect(component.tagIdsFormValue).toEqual([2])
+    })
   })
 })

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
@@ -34,7 +34,7 @@ describe('SearchBarComponent (2.13.2)', () => {
     component.query.setValue('x')
     component.onClear()
     expect(component.query.value).toBe('')
-    expect(emitted).toContain('')
+    expect(emitted).toEqual([''])
   })
 
   it('should not throw on destroy', () => {

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing'
+import { SearchBarComponent } from './search-bar.component'
+
+describe('SearchBarComponent (2.13.2)', () => {
+  let component: SearchBarComponent
+  let fixture: ComponentFixture<SearchBarComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchBarComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(SearchBarComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should emit searchTerm with trimmed value after debounce', fakeAsync(() => {
+    const emitted: string[] = []
+    component.searchTerm.subscribe((v) => emitted.push(v))
+    component.query.setValue('  keyword  ')
+    expect(emitted.length).toBe(0)
+    tick(300)
+    expect(emitted).toEqual(['keyword'])
+  }))
+
+  it('should emit empty string on clear', () => {
+    const emitted: string[] = []
+    component.searchTerm.subscribe((v) => emitted.push(v))
+    component.query.setValue('x')
+    component.onClear()
+    expect(component.query.value).toBe('')
+    expect(emitted).toContain('')
+  })
+
+  it('should not throw on destroy', () => {
+    expect(() => component.ngOnDestroy()).not.toThrow()
+  })
+})

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { environment } from '../../environments/environment'
 import { TodoService } from './todo.service'
 import type { SortOptions } from '../models/sort-options.interface'
+import type { SearchParams } from '../models/search-params.interface'
 
 describe('TodoService', () => {
   let service: TodoService
@@ -99,6 +100,37 @@ describe('TodoService', () => {
       service.deleteArchivedTodos().subscribe()
       const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/archived` && r.method === 'DELETE')
       req.flush(null)
+    })
+  })
+
+  describe('search (2.13.1)', () => {
+    it('should call GET /todos/search with q and return todos', () => {
+      const params: SearchParams = { q: '買い物' }
+      service.search(params).subscribe((list) => expect(list.length).toBe(1))
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/search` && r.method === 'GET')
+      expect(req.request.params.get('q')).toBe('買い物')
+      req.flush([{ id: 1, userId: 1, title: '買い物', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, archived: false, archivedAt: null, createdAt: '', updatedAt: '' }])
+    })
+
+    it('should send completed, priority, tags and sort params when provided', () => {
+      const params: SearchParams = { q: 'x', completed: false, priority: 'high', tagIds: [1, 2] }
+      const sort: SortOptions = { sortBy: 'dueDate', sortOrder: 'desc' }
+      service.search(params, sort).subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/search` && r.method === 'GET')
+      expect(req.request.params.get('q')).toBe('x')
+      expect(req.request.params.get('completed')).toBe('false')
+      expect(req.request.params.get('priority')).toBe('high')
+      expect(req.request.params.get('tags')).toBe('1,2')
+      expect(req.request.params.get('sortBy')).toBe('dueDate')
+      expect(req.request.params.get('sortOrder')).toBe('desc')
+      req.flush([])
+    })
+
+    it('should trim q before sending', () => {
+      service.search({ q: '  keyword  ' }).subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/search` && r.method === 'GET')
+      expect(req.request.params.get('q')).toBe('keyword')
+      req.flush([])
     })
   })
 


### PR DESCRIPTION
## 概要
検索機能の Task 2.13（Frontend テスト）を実装しました。

## 変更内容
- **2.13.1** `todo.service.spec.ts`: `search()` のテスト
  - GET /todos/search に q を送りレスポンスを検証
  - completed, priority, tags, sortBy, sortOrder パラメータの送信
  - q の trim の検証
- **2.13.2** `search-bar.component.spec.ts`: SearchBarComponent のテスト
  - create, debounce 後の searchTerm 発火（trim 済み）, onClear, ngOnDestroy
- **2.13.3** `advanced-search-dialog.component.spec.ts`: AdvancedSearchDialogComponent のテスト
  - create, フォーム初期値（null / currentParams あり）, apply() で close(SearchParams), オプション未指定時は q のみ, clear(), cancel(), toggleTag(), isLight

## 確認
- `docker compose run --rm frontend ng test --watch=false` → 101 SUCCESS（+18）

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)