### PR TITLE
feat(backend): Project ルート追加 (Task 7.8)

### DIFF
--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -28,6 +28,16 @@ const {
   updateTag,
   deleteTag,
 } = require('../../../controllers/tagController');
+const {
+  createProject,
+  getProjects,
+  getProjectById,
+  updateProject,
+  deleteProject,
+  getProjectTodos,
+  getProjectProgress,
+  archiveProject,
+} = require('../../../controllers/projectController');
 
 module.exports = async function (fastify, opts) {
   /**
@@ -141,6 +151,82 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => deleteTag(fastify, request, reply),
+  });
+
+  /**
+   * projects CRUD API routes (JWT 必須)
+   */
+  const projectIdParam = {
+    params: {
+      type: 'object',
+      required: ['id'],
+      properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+    },
+  };
+  fastify.post('/projects', {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string', minLength: 1, maxLength: 100 },
+          description: { type: 'string' },
+          color: { type: 'string', maxLength: 7 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => createProject(fastify, request, reply),
+  });
+  fastify.get('/projects', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: { includeArchived: { type: 'string', enum: ['true', 'false'] } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getProjects(fastify, request, reply),
+  });
+  fastify.get('/projects/:id', {
+    schema: { ...projectIdParam },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getProjectById(fastify, request, reply),
+  });
+  fastify.put('/projects/:id', {
+    schema: {
+      ...projectIdParam,
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1, maxLength: 100 },
+          description: { type: 'string' },
+          color: { type: 'string', maxLength: 7 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => updateProject(fastify, request, reply),
+  });
+  fastify.delete('/projects/:id', {
+    schema: { ...projectIdParam },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => deleteProject(fastify, request, reply),
+  });
+  fastify.get('/projects/:id/todos', {
+    schema: { ...projectIdParam },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getProjectTodos(fastify, request, reply),
+  });
+  fastify.get('/projects/:id/progress', {
+    schema: { ...projectIdParam },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getProjectProgress(fastify, request, reply),
+  });
+  fastify.patch('/projects/:id/archive', {
+    schema: { ...projectIdParam },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => archiveProject(fastify, request, reply),
   });
 
   /**

--- a/docs/TODO_FEATURE_07_PROJECTS.md
+++ b/docs/TODO_FEATURE_07_PROJECTS.md
@@ -105,9 +105,9 @@ PATCH /api/projects/:id/archive
 
 ### Task 7.8: Project ルート作成
 
-- [ ] 7.8.1: `backend/routes/api/projects.js` 作成
-- [ ] 7.8.2: 各エンドポイントの JSON Schema 定義
-- [ ] 7.8.3: JWT 認証 preHandler 適用
+- [x] 7.8.1: Project ルート定義（`backend/routes/api/v1/index.js` に追加）
+- [x] 7.8.2: 各エンドポイントの JSON Schema 定義
+- [x] 7.8.3: JWT 認証 preHandler 適用
 
 ### Task 7.9: Backend テスト
 


### PR DESCRIPTION
## 概要
- `backend/routes/api/v1/index.js` に Project ルートを追加
- POST/GET/PUT/DELETE /api/v1/projects、GET /projects/:id/todos、GET /projects/:id/progress、PATCH /projects/:id/archive
- 各エンドポイントに JSON Schema 定義・JWT 認証 preHandler 適用

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)