### PR TITLE
feat(frontend): Project インターフェース定義・Todo インターフェース更新 (Task 7.10, 7.11)

### DIFF
--- a/docs/TODO_FEATURE_07_PROJECTS.md
+++ b/docs/TODO_FEATURE_07_PROJECTS.md
@@ -120,12 +120,12 @@ PATCH /api/projects/:id/archive
 
 ### Task 7.10: Project インターフェース定義
 
-- [ ] 7.10.1: `frontend/src/app/models/project.interface.ts` 作成
-- [ ] 7.10.2: Project, CreateProjectDto, UpdateProjectDto 定義
+- [x] 7.10.1: `frontend/src/app/models/project.interface.ts` 作成
+- [x] 7.10.2: Project, CreateProjectDto, UpdateProjectDto 定義
 
 ### Task 7.11: Todo インターフェース更新
 
-- [ ] 7.11.1: Todo インターフェースに projectId, project 追加
+- [x] 7.11.1: Todo インターフェースに projectId, project 追加
 
 ### Task 7.12: ProjectService 作成
 

--- a/frontend/src/app/models/project.interface.ts
+++ b/frontend/src/app/models/project.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * API から返却される Project 型
+ */
+export interface Project {
+  id: number
+  userId: number
+  name: string
+  description: string | null
+  color: string
+  archived: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateProjectDto {
+  name: string
+  description?: string
+  color?: string
+}
+
+export interface UpdateProjectDto {
+  name?: string
+  description?: string | null
+  color?: string
+}
+
+/**
+ * GET /api/projects/:id/progress のレスポンス型
+ */
+export interface ProjectProgress {
+  total: number
+  completed: number
+}

--- a/frontend/src/app/models/project.interface.ts
+++ b/frontend/src/app/models/project.interface.ts
@@ -14,7 +14,7 @@ export interface Project {
 
 export interface CreateProjectDto {
   name: string
-  description?: string
+  description?: string | null
   color?: string
 }
 

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -1,3 +1,4 @@
+import type { Project } from './project.interface'
 import type { Tag } from './tag.interface'
 
 /**
@@ -17,11 +18,13 @@ export interface Todo {
   priority: TodoPriority
   dueDate: string | null
   sortOrder: number
+  projectId: number | null
   archived: boolean
   archivedAt: string | null
   createdAt: string
   updatedAt: string
   Tags?: Tag[]
+  Project?: Project
 }
 
 /**
@@ -32,4 +35,5 @@ export interface TodoCreateUpdate {
   description?: string | null
   priority?: TodoPriority
   dueDate?: string | null
+  projectId?: number | null
 }


### PR DESCRIPTION
## 概要

フロントエンドの Project 関連インターフェースを定義し、既存の Todo インターフェースにプロジェクト関連フィールドを追加。

## 変更内容

- `frontend/src/app/models/project.interface.ts` を新規作成
  - `Project` / `CreateProjectDto` / `UpdateProjectDto` / `ProjectProgress` を定義
- `frontend/src/app/models/todo.interface.ts` を更新
  - `Todo` に `projectId: number | null` と `Project?: Project` を追加
  - `TodoCreateUpdate` に `projectId?: number | null` を追加

## 対応タスク

- Task 7.10: Project インターフェース定義
- Task 7.11: Todo インターフェース更新

## テスト計画

- [x] TypeScript の型定義のみのため、`ng build` でコンパイルエラーがないことを確認済み（バンドルサイズ budget 超過は既存問題）

Made with [Cursor](https://cursor.com)