### PR TITLE
feat(frontend): ProjectService 作成 (Task 7.12)

### DIFF
--- a/docs/TODO_FEATURE_07_PROJECTS.md
+++ b/docs/TODO_FEATURE_07_PROJECTS.md
@@ -129,10 +129,10 @@ PATCH /api/projects/:id/archive
 
 ### Task 7.12: ProjectService 作成
 
-- [ ] 7.12.1: `frontend/src/app/services/project.service.ts` 作成
-- [ ] 7.12.2: CRUD メソッド実装
-- [ ] 7.12.3: `getProjectProgress(id: number)` 実装
-- [ ] 7.12.4: `archiveProject(id: number)` 実装
+- [x] 7.12.1: `frontend/src/app/services/project.service.ts` 作成
+- [x] 7.12.2: CRUD メソッド実装
+- [x] 7.12.3: `getProjectProgress(id: number)` 実装
+- [x] 7.12.4: `archiveProject(id: number)` 実装
 
 ### Task 7.13: ProjectList コンポーネント作成
 

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
@@ -15,6 +15,7 @@ const mockArchivedTodos: Todo[] = [
     priority: 'medium',
     dueDate: null,
     sortOrder: 0,
+    projectId: null,
     archived: true,
     archivedAt: '2026-03-01T12:00:00.000Z',
     createdAt: '2026-03-01T10:00:00.000Z',

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
@@ -5,9 +5,9 @@ import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 
 const mockTodos: Todo[] = [
-  { id: 1, userId: 1, title: 'A', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 0, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
-  { id: 2, userId: 1, title: 'B', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 1, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
-  { id: 3, userId: 1, title: 'C', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 2, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 1, userId: 1, title: 'A', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 2, userId: 1, title: 'B', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 1, projectId: null, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 3, userId: 1, title: 'C', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 2, projectId: null, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
 ]
 
 describe('TodoListComponent (3.13.3)', () => {

--- a/frontend/src/app/services/project.service.spec.ts
+++ b/frontend/src/app/services/project.service.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
+import { ProjectService } from './project.service'
+import type { CreateProjectDto, UpdateProjectDto } from '../models/project.interface'
+
+describe('ProjectService (7.12)', () => {
+  let service: ProjectService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  const mockProject = {
+    id: 1,
+    userId: 1,
+    name: 'My Project',
+    description: null,
+    color: '#808080',
+    archived: false,
+    createdAt: '',
+    updatedAt: '',
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ProjectService],
+    })
+    service = TestBed.inject(ProjectService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should call POST /projects with body for create', () => {
+    const body: CreateProjectDto = { name: 'New Project', color: '#ff0000' }
+    service.create(body).subscribe((p) => expect(p.id).toBe(1))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects` && r.method === 'POST')
+    expect(req.request.body).toEqual(body)
+    req.flush(mockProject)
+  })
+
+  it('should call GET /projects without params for getAll()', () => {
+    service.getAll().subscribe((list) => expect(list).toEqual([]))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects` && r.method === 'GET')
+    expect(req.request.params.has('includeArchived')).toBe(false)
+    req.flush([])
+  })
+
+  it('should call GET /projects?includeArchived=true for getAll(true)', () => {
+    service.getAll(true).subscribe((list) => expect(list.length).toBe(1))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects` && r.method === 'GET')
+    expect(req.request.params.get('includeArchived')).toBe('true')
+    req.flush([mockProject])
+  })
+
+  it('should call GET /projects/:id for getById', () => {
+    const id = 5
+    service.getById(id).subscribe((p) => expect(p.id).toBe(id))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects/${id}` && r.method === 'GET')
+    req.flush({ ...mockProject, id })
+  })
+
+  it('should call PUT /projects/:id with body for update', () => {
+    const id = 3
+    const body: UpdateProjectDto = { name: 'Updated' }
+    service.update(id, body).subscribe((p) => expect(p.name).toBe('Updated'))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects/${id}` && r.method === 'PUT')
+    expect(req.request.body).toEqual(body)
+    req.flush({ ...mockProject, id, name: 'Updated' })
+  })
+
+  it('should call DELETE /projects/:id for delete', () => {
+    const id = 2
+    service.delete(id).subscribe()
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects/${id}` && r.method === 'DELETE')
+    req.flush(null)
+  })
+
+  it('should call GET /projects/:id/todos for getProjectTodos', () => {
+    const id = 4
+    service.getProjectTodos(id).subscribe((list) => expect(list).toEqual([]))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects/${id}/todos` && r.method === 'GET')
+    req.flush([])
+  })
+
+  it('should call GET /projects/:id/progress for getProjectProgress', () => {
+    const id = 4
+    service.getProjectProgress(id).subscribe((progress) => {
+      expect(progress.total).toBe(5)
+      expect(progress.completed).toBe(3)
+    })
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects/${id}/progress` && r.method === 'GET')
+    req.flush({ total: 5, completed: 3 })
+  })
+
+  it('should call PATCH /projects/:id/archive with empty body for archive', () => {
+    const id = 6
+    service.archive(id).subscribe((p) => expect(p.archived).toBe(true))
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/projects/${id}/archive` && r.method === 'PATCH')
+    expect(req.request.body).toEqual({})
+    req.flush({ ...mockProject, id, archived: true })
+  })
+})

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+import type {
+  Project,
+  CreateProjectDto,
+  UpdateProjectDto,
+  ProjectProgress,
+} from '../models/project.interface'
+import type { Todo } from '../models/todo.interface'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProjectService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  create(body: CreateProjectDto): Observable<Project> {
+    return this.http.post<Project>(`${this.apiUrl}/projects`, body)
+  }
+
+  getAll(includeArchived = false): Observable<Project[]> {
+    const params: Record<string, string> = {}
+    if (includeArchived) params['includeArchived'] = 'true'
+    return this.http.get<Project[]>(`${this.apiUrl}/projects`, { params })
+  }
+
+  getById(id: number): Observable<Project> {
+    return this.http.get<Project>(`${this.apiUrl}/projects/${id}`)
+  }
+
+  update(id: number, body: UpdateProjectDto): Observable<Project> {
+    return this.http.put<Project>(`${this.apiUrl}/projects/${id}`, body)
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/projects/${id}`)
+  }
+
+  getProjectTodos(id: number): Observable<Todo[]> {
+    return this.http.get<Todo[]>(`${this.apiUrl}/projects/${id}/todos`)
+  }
+
+  getProjectProgress(id: number): Observable<ProjectProgress> {
+    return this.http.get<ProjectProgress>(`${this.apiUrl}/projects/${id}/progress`)
+  }
+
+  archive(id: number): Observable<Project> {
+    return this.http.patch<Project>(`${this.apiUrl}/projects/${id}/archive`, {})
+  }
+}


### PR DESCRIPTION
## 概要

フロントエンドの ProjectService を作成し、バックエンドの Project API との通信メソッドを実装。

## 変更内容

- `frontend/src/app/services/project.service.ts` を新規作成
  - `create(body)` — プロジェクト作成
  - `getAll(includeArchived?)` — 一覧取得（アーカイブ含むかオプション）
  - `getById(id)` — 単一取得
  - `update(id, body)` — 更新
  - `delete(id)` — 削除
  - `getProjectTodos(id)` — プロジェクト内の Todo 一覧取得
  - `getProjectProgress(id)` — 進捗（total / completed）取得
  - `archive(id)` — アーカイブ

## 対応タスク

- Task 7.12: ProjectService 作成（7.12.1〜7.12.4）

## テスト計画

- [x] `ng build` でコンパイルエラーがないことを確認済み

Made with [Cursor](https://cursor.com)