### PR TITLE
feat(frontend): ProjectDetail ページ作成 (Task 7.15)

### DIFF
--- a/docs/TODO_FEATURE_07_PROJECTS.md
+++ b/docs/TODO_FEATURE_07_PROJECTS.md
@@ -149,10 +149,10 @@ PATCH /api/projects/:id/archive
 
 ### Task 7.15: ProjectDetail ページ作成
 
-- [ ] 7.15.1: `ng generate component pages/project-detail-page` 実行
-- [ ] 7.15.2: プロジェクト詳細表示
-- [ ] 7.15.3: プロジェクト内の Todo 一覧表示
-- [ ] 7.15.4: ルーティング追加
+- [x] 7.15.1: `ng generate component pages/project-detail-page` 実行
+- [x] 7.15.2: プロジェクト詳細表示
+- [x] 7.15.3: プロジェクト内の Todo 一覧表示
+- [x] 7.15.4: ルーティング追加
 
 ### Task 7.16: TodoForm にプロジェクト選択追加
 

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -21,6 +21,10 @@ const routes: Routes = [
         path: 'tags',
         loadComponent: () => import('./tags/tags-page.component')
       },
+      {
+        path: 'projects/:id',
+        loadComponent: () => import('./projects/project-detail-page/project-detail-page.component')
+      },
     ]
   }
 ]

--- a/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.html
@@ -1,0 +1,88 @@
+<div class="row">
+  <div class="col-12">
+    @if (loading) {
+      <div class="text-center py-5">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">読み込み中...</span>
+        </div>
+      </div>
+    } @else if (error) {
+      <div class="alert alert-danger" role="alert">{{ error }}</div>
+      <a routerLink="/dashboard/projects" class="btn btn-outline-secondary">プロジェクト一覧に戻る</a>
+    } @else if (project) {
+      <app-card [cardTitle]="project.name" [options]="false">
+        <div class="mb-3">
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span
+              class="project-color-badge"
+              [style.background-color]="project.color"
+            ></span>
+            <span class="text-muted small">{{ project.color }}</span>
+            @if (project.archived) {
+              <span class="badge bg-secondary">アーカイブ</span>
+            }
+          </div>
+          @if (project.description) {
+            <p class="text-muted mb-2">{{ project.description }}</p>
+          }
+        </div>
+
+        <div class="mb-4">
+          <div class="d-flex justify-content-between mb-1 small">
+            <span class="fw-semibold">進捗</span>
+            <span>{{ progress.completed }}/{{ progress.total }} ({{ progressPercent }}%)</span>
+          </div>
+          <div class="progress" style="height: 8px;">
+            <div
+              class="progress-bar"
+              role="progressbar"
+              [style.width.%]="progressPercent"
+              [style.background-color]="project.color"
+              [attr.aria-valuenow]="progressPercent"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            ></div>
+          </div>
+        </div>
+
+        <h6 class="fw-semibold mb-2">未完了 ({{ pendingTodos.length }})</h6>
+        @if (pendingTodos.length === 0) {
+          <p class="text-muted small mb-3">未完了の Todo はありません。</p>
+        } @else {
+          <ul class="list-group list-group-flush mb-3">
+            @for (todo of pendingTodos; track todo.id) {
+              <li class="list-group-item d-flex align-items-center gap-2 px-0">
+                <i class="feather icon-circle text-muted"></i>
+                <div class="flex-grow-1">
+                  <span>{{ todo.title }}</span>
+                  <span class="badge ms-1" [ngClass]="priorityClass(todo.priority)">{{ todo.priority }}</span>
+                  @if (todo.dueDate) {
+                    <span class="ms-2 small text-muted">{{ todo.dueDate }}</span>
+                  }
+                </div>
+              </li>
+            }
+          </ul>
+        }
+
+        <h6 class="fw-semibold mb-2">完了済み ({{ completedTodos.length }})</h6>
+        @if (completedTodos.length === 0) {
+          <p class="text-muted small mb-3">完了済みの Todo はありません。</p>
+        } @else {
+          <ul class="list-group list-group-flush mb-3">
+            @for (todo of completedTodos; track todo.id) {
+              <li class="list-group-item d-flex align-items-center gap-2 px-0 text-muted">
+                <i class="feather icon-check-circle text-success"></i>
+                <span class="text-decoration-line-through">{{ todo.title }}</span>
+              </li>
+            }
+          </ul>
+        }
+
+        <a routerLink="/dashboard/projects" class="btn btn-outline-secondary btn-sm">
+          <i class="feather icon-arrow-left me-1"></i>一覧に戻る
+        </a>
+      </app-card>
+    }
+  </div>
+</div>

--- a/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.html
@@ -45,12 +45,15 @@
           </div>
         </div>
 
-        <h6 class="fw-semibold mb-2">未完了 ({{ pendingTodos.length }})</h6>
-        @if (pendingTodos.length === 0) {
+        @let pending = pendingTodos;
+        @let completed = completedTodos;
+
+        <h6 class="fw-semibold mb-2">未完了 ({{ pending.length }})</h6>
+        @if (pending.length === 0) {
           <p class="text-muted small mb-3">未完了の Todo はありません。</p>
         } @else {
           <ul class="list-group list-group-flush mb-3">
-            @for (todo of pendingTodos; track todo.id) {
+            @for (todo of pending; track todo.id) {
               <li class="list-group-item d-flex align-items-center gap-2 px-0">
                 <i class="feather icon-circle text-muted"></i>
                 <div class="flex-grow-1">
@@ -65,12 +68,12 @@
           </ul>
         }
 
-        <h6 class="fw-semibold mb-2">完了済み ({{ completedTodos.length }})</h6>
-        @if (completedTodos.length === 0) {
+        <h6 class="fw-semibold mb-2">完了済み ({{ completed.length }})</h6>
+        @if (completed.length === 0) {
           <p class="text-muted small mb-3">完了済みの Todo はありません。</p>
         } @else {
           <ul class="list-group list-group-flush mb-3">
-            @for (todo of completedTodos; track todo.id) {
+            @for (todo of completed; track todo.id) {
               <li class="list-group-item d-flex align-items-center gap-2 px-0 text-muted">
                 <i class="feather icon-check-circle text-success"></i>
                 <span class="text-decoration-line-through">{{ todo.title }}</span>

--- a/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.scss
+++ b/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.scss
@@ -1,0 +1,7 @@
+.project-color-badge {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}

--- a/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.ts
@@ -30,7 +30,7 @@ export default class ProjectDetailPageComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'))
-    if (isNaN(id)) {
+    if (!Number.isInteger(id) || id <= 0) {
       this.router.navigate(['/dashboard/projects'])
       return
     }

--- a/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/project-detail-page/project-detail-page.component.ts
@@ -1,0 +1,87 @@
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ActivatedRoute, Router, RouterModule } from '@angular/router'
+import { Subject, takeUntil, forkJoin } from 'rxjs'
+import { ProjectService } from '../../../../../services/project.service'
+import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
+import type { Project, ProjectProgress } from '../../../../../models/project.interface'
+import type { Todo } from '../../../../../models/todo.interface'
+
+@Component({
+  selector: 'app-project-detail-page',
+  standalone: true,
+  imports: [CommonModule, RouterModule, CardComponent],
+  templateUrl: './project-detail-page.component.html',
+  styleUrls: ['./project-detail-page.component.scss']
+})
+export default class ProjectDetailPageComponent implements OnInit, OnDestroy {
+  project: Project | null = null
+  todos: Todo[] = []
+  progress: ProjectProgress = { total: 0, completed: 0 }
+  loading = false
+  error: string | null = null
+  private destroy$ = new Subject<void>()
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private projectService: ProjectService
+  ) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'))
+    if (isNaN(id)) {
+      this.router.navigate(['/dashboard/projects'])
+      return
+    }
+    this.loadProject(id)
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  loadProject(id: number): void {
+    this.loading = true
+    this.error = null
+    forkJoin({
+      project: this.projectService.getById(id),
+      todos: this.projectService.getProjectTodos(id),
+      progress: this.projectService.getProjectProgress(id),
+    }).pipe(takeUntil(this.destroy$)).subscribe({
+      next: (result) => {
+        this.project = result.project
+        this.todos = result.todos
+        this.progress = result.progress
+        this.loading = false
+      },
+      error: (err) => {
+        this.error = err?.error?.error ?? err?.message ?? '取得に失敗しました'
+        this.loading = false
+      }
+    })
+  }
+
+  get progressPercent(): number {
+    if (this.progress.total === 0) return 0
+    return Math.round((this.progress.completed / this.progress.total) * 100)
+  }
+
+  get completedTodos(): Todo[] {
+    return this.todos.filter((t) => t.completed)
+  }
+
+  get pendingTodos(): Todo[] {
+    return this.todos.filter((t) => !t.completed)
+  }
+
+  priorityClass(priority: string): string {
+    switch (priority) {
+      case 'high': return 'bg-danger'
+      case 'medium': return 'bg-warning text-dark'
+      case 'low': return 'bg-success'
+      default: return 'bg-secondary'
+    }
+  }
+}


### PR DESCRIPTION
## 概要

プロジェクト詳細ページを作成し、プロジェクト情報と所属 Todo の一覧を表示。

## 変更内容

- `project-detail-page.component.ts` — ページコンポーネント
  - `ActivatedRoute` から `:id` パラメータを取得
  - `forkJoin` でプロジェクト・Todo一覧・進捗を並列取得
  - 未完了/完了済み Todo の分類（getter）
  - 不正 ID 時は一覧ページへリダイレクト
- `project-detail-page.component.html` — 詳細UI
  - プロジェクト名（CardComponent タイトル）・色バッジ・説明・アーカイブバッジ
  - 進捗バー（プロジェクト色で着色）
  - 未完了 Todo 一覧（優先度バッジ・期限付き）
  - 完了済み Todo 一覧（取り消し線）
  - 一覧に戻るリンク
- `dashboard-routing.module.ts` — `projects/:id` ルート追加

## 対応タスク

- Task 7.15: ProjectDetail ページ作成（7.15.1〜7.15.4）

## テスト計画

- [x] `ng build` でコンパイルエラーがないことを確認済み
- [ ] Task 7.18（ProjectsPage）完了後に統合動作確認

Made with [Cursor](https://cursor.com)