### PR TITLE
feat(frontend): ProjectsPage 作成 (Task 7.18)

### DIFF
--- a/docs/TODO_FEATURE_07_PROJECTS.md
+++ b/docs/TODO_FEATURE_07_PROJECTS.md
@@ -166,9 +166,9 @@ PATCH /api/projects/:id/archive
 
 ### Task 7.18: ProjectsPage 作成
 
-- [ ] 7.18.1: `ng generate component pages/projects-page` 実行
-- [ ] 7.18.2: ProjectList と ProjectForm 統合
-- [ ] 7.18.3: ルーティング追加
+- [x] 7.18.1: `ng generate component pages/projects-page` 実行
+- [x] 7.18.2: ProjectList と ProjectForm 統合
+- [x] 7.18.3: ルーティング追加
 
 ### Task 7.19: ナビゲーション更新
 

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -22,6 +22,10 @@ const routes: Routes = [
         loadComponent: () => import('./tags/tags-page.component')
       },
       {
+        path: 'projects',
+        loadComponent: () => import('./projects/projects-page/projects-page.component')
+      },
+      {
         path: 'projects/:id',
         loadComponent: () => import('./projects/project-detail-page/project-detail-page.component')
       },

--- a/frontend/src/app/components/pages/dashboard/projects/project-form/project-form.component.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/project-form/project-form.component.ts
@@ -3,6 +3,11 @@ import { CommonModule } from '@angular/common'
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms'
 import type { Project, CreateProjectDto, UpdateProjectDto } from '../../../../../models/project.interface'
 
+function noWhitespaceValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value as string
+  return value && value.trim().length === 0 ? { whitespace: true } : null
+}
+
 @Component({
   selector: 'app-project-form',
   standalone: true,
@@ -10,11 +15,6 @@ import type { Project, CreateProjectDto, UpdateProjectDto } from '../../../../..
   templateUrl: './project-form.component.html',
   styleUrls: ['./project-form.component.scss']
 })
-function noWhitespaceValidator(control: AbstractControl): ValidationErrors | null {
-  const value = control.value as string
-  return value && value.trim().length === 0 ? { whitespace: true } : null
-}
-
 export class ProjectFormComponent implements OnChanges {
   @Input() editingProject: Project | null = null
   @Output() submitForm = new EventEmitter<CreateProjectDto | UpdateProjectDto>()

--- a/frontend/src/app/components/pages/dashboard/projects/projects-page/projects-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/projects/projects-page/projects-page.component.html
@@ -1,0 +1,34 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="プロジェクト管理">
+      @if (error) {
+        <div class="alert alert-danger" role="alert">{{ error }}</div>
+      }
+
+      <div class="mb-4">
+        @if (editingProject) {
+          <app-project-form
+            [editingProject]="editingProject"
+            (submitForm)="onSubmitForm($event)"
+            (cancel)="onCancelEdit()"
+          />
+        } @else {
+          <app-project-form
+            (submitForm)="onSubmitForm($event)"
+          />
+        }
+      </div>
+
+      <hr class="my-3" />
+
+      <app-project-list
+        [projects]="projects"
+        [progressMap]="progressMap"
+        [loading]="loading"
+        (edit)="onEdit($event)"
+        (delete)="onDelete($event)"
+        (archive)="onArchive($event)"
+      />
+    </app-card>
+  </div>
+</div>

--- a/frontend/src/app/components/pages/dashboard/projects/projects-page/projects-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/projects-page/projects-page.component.ts
@@ -1,0 +1,128 @@
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Subject, forkJoin, takeUntil } from 'rxjs'
+import { ProjectService } from '../../../../../services/project.service'
+import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
+import { ProjectListComponent } from '../project-list/project-list.component'
+import { ProjectFormComponent } from '../project-form/project-form.component'
+import type { Project, CreateProjectDto, UpdateProjectDto, ProjectProgress } from '../../../../../models/project.interface'
+
+@Component({
+  selector: 'app-projects-page',
+  standalone: true,
+  imports: [CommonModule, CardComponent, ProjectListComponent, ProjectFormComponent],
+  templateUrl: './projects-page.component.html',
+  styleUrls: ['./projects-page.component.scss']
+})
+export default class ProjectsPageComponent implements OnInit, OnDestroy {
+  projects: Project[] = []
+  progressMap: Record<number, ProjectProgress> = {}
+  loading = false
+  error: string | null = null
+  editingProject: Project | null = null
+  private destroy$ = new Subject<void>()
+
+  constructor(private projectService: ProjectService) {}
+
+  ngOnInit(): void {
+    this.loadProjects()
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  loadProjects(): void {
+    this.loading = true
+    this.error = null
+    this.projectService.getAll(true).pipe(takeUntil(this.destroy$)).subscribe({
+      next: (list) => {
+        this.projects = list
+        this.loading = false
+        this.loadAllProgress(list)
+      },
+      error: (err) => {
+        this.error = err?.error?.error ?? err?.message ?? '取得に失敗しました'
+        this.loading = false
+      }
+    })
+  }
+
+  private loadAllProgress(projects: Project[]): void {
+    if (projects.length === 0) {
+      this.progressMap = {}
+      return
+    }
+    const requests: Record<string, ReturnType<ProjectService['getProjectProgress']>> = {}
+    projects.forEach((p) => {
+      requests[String(p.id)] = this.projectService.getProjectProgress(p.id)
+    })
+    forkJoin(requests).pipe(takeUntil(this.destroy$)).subscribe({
+      next: (result) => {
+        const map: Record<number, ProjectProgress> = {}
+        Object.entries(result).forEach(([id, progress]) => {
+          map[Number(id)] = progress
+        })
+        this.progressMap = map
+      },
+      error: () => {
+        this.progressMap = {}
+      }
+    })
+  }
+
+  onSubmitForm(payload: CreateProjectDto | UpdateProjectDto): void {
+    if (this.editingProject) {
+      this.projectService.update(this.editingProject.id, payload as UpdateProjectDto)
+        .pipe(takeUntil(this.destroy$)).subscribe({
+          next: () => {
+            this.editingProject = null
+            this.loadProjects()
+          },
+          error: (err) => {
+            this.error = err?.error?.error ?? err?.message ?? '更新に失敗しました'
+          }
+        })
+    } else {
+      this.projectService.create(payload as CreateProjectDto)
+        .pipe(takeUntil(this.destroy$)).subscribe({
+          next: () => this.loadProjects(),
+          error: (err) => {
+            this.error = err?.error?.error ?? err?.message ?? '作成に失敗しました'
+          }
+        })
+    }
+  }
+
+  onEdit(project: Project): void {
+    this.editingProject = project
+  }
+
+  onCancelEdit(): void {
+    this.editingProject = null
+  }
+
+  onDelete(project: Project): void {
+    if (!confirm(`プロジェクト「${project.name}」を削除しますか？\n所属する Todo のプロジェクト割り当ては解除されます。`)) return
+    this.projectService.delete(project.id).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => {
+        if (this.editingProject?.id === project.id) this.editingProject = null
+        this.loadProjects()
+      },
+      error: (err) => {
+        this.error = err?.error?.error ?? err?.message ?? '削除に失敗しました'
+      }
+    })
+  }
+
+  onArchive(project: Project): void {
+    if (!confirm(`プロジェクト「${project.name}」をアーカイブしますか？`)) return
+    this.projectService.archive(project.id).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => this.loadProjects(),
+      error: (err) => {
+        this.error = err?.error?.error ?? err?.message ?? 'アーカイブに失敗しました'
+      }
+    })
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/projects/projects-page/projects-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/projects-page/projects-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { CommonModule } from '@angular/common'
-import { Subject, forkJoin, takeUntil } from 'rxjs'
+import { Subject, Observable, forkJoin, takeUntil } from 'rxjs'
 import { ProjectService } from '../../../../../services/project.service'
 import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
 import { ProjectListComponent } from '../project-list/project-list.component'
@@ -54,7 +54,7 @@ export default class ProjectsPageComponent implements OnInit, OnDestroy {
       this.progressMap = {}
       return
     }
-    const requests: Record<string, ReturnType<ProjectService['getProjectProgress']>> = {}
+    const requests: Record<string, Observable<ProjectProgress>> = {}
     projects.forEach((p) => {
       requests[String(p.id)] = this.projectService.getProjectProgress(p.id)
     })


### PR DESCRIPTION
## 概要

ProjectList と ProjectForm を統合したプロジェクト管理ページを作成。

## 変更内容

- `projects-page.component.ts` — ページコンポーネント
  - プロジェクト一覧取得（アーカイブ含む）
  - `forkJoin` で全プロジェクトの進捗を並列取得し `progressMap` を構築
  - 作成・更新・削除・アーカイブの CRUD 操作
  - 確認ダイアログ付きの削除・アーカイブ
  - `takeUntil(destroy$)` によるサブスクリプション管理
- `projects-page.component.html` — ページUI
  - ProjectForm（作成/編集モード切り替え）
  - ProjectList（カード形式の一覧表示）
- `dashboard-routing.module.ts` — `projects` ルート追加
- `project-form.component.ts` — デコレータ配置を修正（既存バグ）

## 対応タスク

- Task 7.18: ProjectsPage 作成（7.18.1〜7.18.3）

## テスト計画

- [x] `ng build` でコンパイルエラーがないことを確認済み
- [ ] `/dashboard/projects` でプロジェクトの作成・編集・削除・アーカイブが動作すること

Made with [Cursor](https://cursor.com)