### PR TITLE
test(frontend): ProjectList / ProjectForm のテスト追加 (Task 7.21)

### DIFF
--- a/docs/TODO_FEATURE_07_PROJECTS.md
+++ b/docs/TODO_FEATURE_07_PROJECTS.md
@@ -182,8 +182,8 @@ PATCH /api/projects/:id/archive
 
 ### Task 7.21: Frontend テスト
 
-- [ ] 7.21.1: ProjectService のテスト
-- [ ] 7.21.2: 各コンポーネントのテスト
+- [x] 7.21.1: ProjectService のテスト
+- [x] 7.21.2: 各コンポーネントのテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/projects/project-form/project-form.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/project-form/project-form.component.spec.ts
@@ -1,0 +1,89 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ProjectFormComponent } from './project-form.component'
+import type { Project } from '../../../../../models/project.interface'
+
+const mockProject: Project = {
+  id: 1,
+  userId: 1,
+  name: 'Edit Project',
+  description: 'Desc',
+  color: '#00ff00',
+  archived: false,
+  createdAt: '',
+  updatedAt: '',
+}
+
+describe('ProjectFormComponent (7.21)', () => {
+  let component: ProjectFormComponent
+  let fixture: ComponentFixture<ProjectFormComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectFormComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ProjectFormComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should have invalid form when name is empty', () => {
+    expect(component.form.valid).toBe(false)
+    expect(component.form.get('name')?.errors?.['required']).toBeTruthy()
+  })
+
+  it('should emit submitForm with payload when valid and submit', () => {
+    component.form.patchValue({ name: 'New Project', color: '#808080' })
+    let emitted: unknown
+    component.submitForm.subscribe((v) => (emitted = v))
+    component.onSubmit()
+    expect(emitted).toEqual({
+      name: 'New Project',
+      description: null,
+      color: '#808080',
+    })
+  })
+
+  it('should not emit when form is invalid', () => {
+    let emitted = false
+    component.submitForm.subscribe(() => (emitted = true))
+    component.onSubmit()
+    expect(emitted).toBe(false)
+  })
+
+  it('should not emit when name is whitespace only', () => {
+    component.form.patchValue({ name: '   ', color: '#808080' })
+    let emitted = false
+    component.submitForm.subscribe(() => (emitted = true))
+    component.onSubmit()
+    expect(emitted).toBe(false)
+  })
+
+  it('should emit cancel when onCancel is called', () => {
+    let emitted = false
+    component.cancel.subscribe(() => (emitted = true))
+    component.onCancel()
+    expect(emitted).toBe(true)
+  })
+
+  it('should patch form when editingProject is set', () => {
+    component.editingProject = mockProject
+    component.ngOnChanges()
+    expect(component.form.get('name')?.value).toBe('Edit Project')
+    expect(component.form.get('description')?.value).toBe('Desc')
+    expect(component.form.get('color')?.value).toBe('#00ff00')
+  })
+
+  it('should reset form when editingProject is null', () => {
+    component.editingProject = mockProject
+    component.ngOnChanges()
+    component.editingProject = null
+    component.ngOnChanges()
+    expect(component.form.get('name')?.value).toBe('')
+    expect(component.form.get('color')?.value).toBe('#808080')
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/projects/project-list/project-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/project-list/project-list.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { ProjectListComponent } from './project-list.component'
+import type { Project, ProjectProgress } from '../../../../../models/project.interface'
+
+const mockProject: Project = {
+  id: 1,
+  userId: 1,
+  name: 'Test Project',
+  description: 'Description',
+  color: '#ff0000',
+  archived: false,
+  createdAt: '',
+  updatedAt: '',
+}
+
+describe('ProjectListComponent (7.21)', () => {
+  let component: ProjectListComponent
+  let fixture: ComponentFixture<ProjectListComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectListComponent, RouterTestingModule],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ProjectListComponent)
+    component = fixture.componentInstance
+    component.projects = [mockProject]
+    component.progressMap = { 1: { total: 5, completed: 2 } }
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should return progress from progressMap', () => {
+    expect(component.getProgress(1)).toEqual({ total: 5, completed: 2 })
+  })
+
+  it('should return default progress when projectId not in map', () => {
+    expect(component.getProgress(99)).toEqual({ total: 0, completed: 0 })
+  })
+
+  it('should return progress percent', () => {
+    expect(component.getProgressPercent(1)).toBe(40)
+  })
+
+  it('should return 0 percent when total is 0', () => {
+    component.progressMap = { 1: { total: 0, completed: 0 } }
+    expect(component.getProgressPercent(1)).toBe(0)
+  })
+
+  it('should emit edit when edit button is clicked', () => {
+    let emitted: Project | undefined
+    component.edit.subscribe((p) => (emitted = p))
+    const editBtn = fixture.nativeElement.querySelector('button[title="編集"]')
+    editBtn?.click()
+    expect(emitted).toEqual(mockProject)
+  })
+
+  it('should emit delete when delete button is clicked', () => {
+    let emitted: Project | undefined
+    component.delete.subscribe((p) => (emitted = p))
+    const deleteBtn = fixture.nativeElement.querySelector('button[title="削除"]')
+    deleteBtn?.click()
+    expect(emitted).toEqual(mockProject)
+  })
+
+  it('should emit archive when archive button is clicked for non-archived project', () => {
+    let emitted: Project | undefined
+    component.archive.subscribe((p) => (emitted = p))
+    const archiveBtn = fixture.nativeElement.querySelector('button[title="アーカイブ"]')
+    archiveBtn?.click()
+    expect(emitted).toEqual(mockProject)
+  })
+
+  it('should not show archive button when project is archived', () => {
+    component.projects = [{ ...mockProject, archived: true }]
+    fixture.detectChanges()
+    const archiveBtn = fixture.nativeElement.querySelector('button[title="アーカイブ"]')
+    expect(archiveBtn).toBeNull()
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/projects/project-list/project-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/projects/project-list/project-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { RouterTestingModule } from '@angular/router/testing'
+import { provideRouter } from '@angular/router'
 import { ProjectListComponent } from './project-list.component'
 import type { Project, ProjectProgress } from '../../../../../models/project.interface'
 
@@ -20,7 +20,8 @@ describe('ProjectListComponent (7.21)', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProjectListComponent, RouterTestingModule],
+      imports: [ProjectListComponent],
+      providers: [provideRouter([])],
     }).compileComponents()
 
     fixture = TestBed.createComponent(ProjectListComponent)


### PR DESCRIPTION
## 概要

Task 7.21 Frontend テストとして、ProjectList と ProjectForm のユニットテストを追加。ProjectService は既存の project.service.spec.ts で対応済み。

## 変更内容

- **project-list.component.spec.ts** 新規
  - should create
  - getProgress / getProgressPercent（progressMap あり・なし、total 0）
  - edit / delete / archive ボタンクリックで各 Output が emit されること
  - アーカイブ済みプロジェクトではアーカイブボタンが表示されないこと
- **project-form.component.spec.ts** 新規
  - should create
  - 名前空で form invalid、submit で emit しない
  - 有効な値で submit すると submitForm に payload が emit されること
  - スペースのみ名前で emit しない（noWhitespaceValidator）
  - cancel で cancel が emit されること
  - editingProject 設定で patchValue、null で reset されること
- **docs/TODO_FEATURE_07_PROJECTS.md** 7.21.1 / 7.21.2 を完了に更新

## 対応タスク

- Task 7.21: Frontend テスト（7.21.1〜7.21.2）

## テスト結果

- 128 SUCCESS（既存 + 新規 ProjectList/ProjectForm）

Made with [Cursor](https://cursor.com)