### PR TITLE
feat(backend): テンプレート API 実装（機能14 の 14.2–14.4）

### DIFF
--- a/backend/controllers/templateController.js
+++ b/backend/controllers/templateController.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const templateService = require('../services/templateService');
+
+function handleTemplateError(fastify, reply, error, clientMessage, statusCode = 500) {
+  fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, clientMessage);
+  reply.code(statusCode).send({ error: clientMessage });
+}
+
+function parseTemplateId(paramId) {
+  const id = parseInt(paramId, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+async function getTemplates(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const templates = await templateService.getTemplatesByUserId(fastify, userId);
+    reply.code(200).send(templates.map((t) => t.toJSON()));
+  } catch (error) {
+    handleTemplateError(fastify, reply, error, 'Failed to get templates');
+  }
+}
+
+async function getTemplateById(fastify, req, reply) {
+  try {
+    const templateId = parseTemplateId(req.params.id);
+    if (templateId === null) return reply.code(400).send({ error: 'Invalid template id' });
+    const template = await templateService.getTemplateById(fastify, templateId, req.user.id);
+    if (!template) return reply.code(404).send({ error: 'Not found' });
+    reply.code(200).send(template.toJSON());
+  } catch (error) {
+    handleTemplateError(fastify, reply, error, 'Failed to get template');
+  }
+}
+
+async function createTemplate(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const template = await templateService.createTemplate(fastify, userId, req.body);
+    if (!template) {
+      return reply.code(400).send({ error: 'name and title are required' });
+    }
+    reply.code(201).send(template.toJSON());
+  } catch (error) {
+    handleTemplateError(fastify, reply, error, 'Template creation failed');
+  }
+}
+
+async function updateTemplate(fastify, req, reply) {
+  try {
+    const templateId = parseTemplateId(req.params.id);
+    if (templateId === null) return reply.code(400).send({ error: 'Invalid template id' });
+    const template = await templateService.updateTemplate(fastify, templateId, req.user.id, req.body);
+    if (!template) return reply.code(404).send({ error: 'Not found' });
+    reply.code(200).send(template.toJSON());
+  } catch (error) {
+    handleTemplateError(fastify, reply, error, 'Template update failed');
+  }
+}
+
+async function deleteTemplate(fastify, req, reply) {
+  try {
+    const templateId = parseTemplateId(req.params.id);
+    if (templateId === null) return reply.code(400).send({ error: 'Invalid template id' });
+    const deleted = await templateService.deleteTemplate(fastify, templateId, req.user.id);
+    if (!deleted) return reply.code(404).send({ error: 'Not found' });
+    reply.code(204).send();
+  } catch (error) {
+    handleTemplateError(fastify, reply, error, 'Template delete failed');
+  }
+}
+
+async function createTodoFromTemplate(fastify, req, reply) {
+  try {
+    const templateId = parseTemplateId(req.params.id);
+    if (templateId === null) return reply.code(400).send({ error: 'Invalid template id' });
+    const todo = await templateService.createTodoFromTemplate(
+      fastify,
+      templateId,
+      req.user.id,
+      req.body || {}
+    );
+    if (!todo) return reply.code(404).send({ error: 'Template not found or invalid' });
+    reply.code(201).send(todo.toJSON());
+  } catch (error) {
+    handleTemplateError(fastify, reply, error, 'Failed to create todo from template');
+  }
+}
+
+module.exports = {
+  getTemplates,
+  getTemplateById,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  createTodoFromTemplate,
+};

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -38,6 +38,14 @@ const {
   getProjectProgress,
   archiveProject,
 } = require('../../../controllers/projectController');
+const {
+  getTemplates,
+  getTemplateById,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  createTodoFromTemplate,
+} = require('../../../controllers/templateController');
 
 module.exports = async function (fastify, opts) {
   /**
@@ -227,6 +235,93 @@ module.exports = async function (fastify, opts) {
     schema: { ...projectIdParam },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => archiveProject(fastify, request, reply),
+  });
+
+  /**
+   * templates CRUD API routes (JWT 必須)
+   */
+  fastify.get('/templates', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getTemplates(fastify, request, reply),
+  });
+  fastify.post('/templates', {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['name', 'title'],
+        properties: {
+          name: { type: 'string', maxLength: 100 },
+          title: { type: 'string', maxLength: 255 },
+          description: { type: 'string' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+          tagIds: { type: 'array', items: { type: 'integer' } },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => createTemplate(fastify, request, reply),
+  });
+  fastify.get('/templates/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getTemplateById(fastify, request, reply),
+  });
+  fastify.put('/templates/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', maxLength: 100 },
+          title: { type: 'string', maxLength: 255 },
+          description: { type: 'string' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+          tagIds: { type: 'array', items: { type: 'integer' } },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => updateTemplate(fastify, request, reply),
+  });
+  fastify.delete('/templates/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => deleteTemplate(fastify, request, reply),
+  });
+  fastify.post('/templates/:id/create-todo', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          title: { type: 'string', maxLength: 255 },
+          description: { type: 'string' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => createTodoFromTemplate(fastify, request, reply),
   });
 
   /**

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -250,8 +250,8 @@ module.exports = async function (fastify, opts) {
         type: 'object',
         required: ['name', 'title'],
         properties: {
-          name: { type: 'string', maxLength: 100 },
-          title: { type: 'string', maxLength: 255 },
+          name: { type: 'string', minLength: 1, maxLength: 100 },
+          title: { type: 'string', minLength: 1, maxLength: 255 },
           description: { type: 'string' },
           priority: { type: 'string', enum: ['low', 'medium', 'high'] },
           tagIds: { type: 'array', items: { type: 'integer' } },
@@ -282,8 +282,8 @@ module.exports = async function (fastify, opts) {
       body: {
         type: 'object',
         properties: {
-          name: { type: 'string', maxLength: 100 },
-          title: { type: 'string', maxLength: 255 },
+          name: { type: 'string', minLength: 1, maxLength: 100 },
+          title: { type: 'string', minLength: 1, maxLength: 255 },
           description: { type: 'string' },
           priority: { type: 'string', enum: ['low', 'medium', 'high'] },
           tagIds: { type: 'array', items: { type: 'integer' } },

--- a/backend/services/templateService.js
+++ b/backend/services/templateService.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const { Op } = require('sequelize');
+
+/**
+ * ユーザーのテンプレート一覧を取得する
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object[]>} TodoTemplate 配列
+ */
+async function getTemplatesByUserId(fastify, userId) {
+  return fastify.models.TodoTemplate.findAll({
+    where: { userId },
+    order: [['createdAt', 'DESC'], ['id', 'DESC']],
+  });
+}
+
+/**
+ * テンプレートを 1 件取得する（所有者のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} templateId - テンプレート ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object|null>}
+ */
+async function getTemplateById(fastify, templateId, userId) {
+  return fastify.models.TodoTemplate.findOne({
+    where: { id: templateId, userId },
+  });
+}
+
+/**
+ * テンプレートを作成する
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @param {object} data - { name, title, description?, priority?, tagIds? }
+ * @returns {Promise<object|null>} 作成されたテンプレート。name または title が空なら null。
+ */
+async function createTemplate(fastify, userId, data) {
+  const name = typeof data.name === 'string' ? data.name.trim() : '';
+  const title = typeof data.title === 'string' ? data.title.trim() : '';
+  if (!name || !title) return null;
+
+  const description =
+    data.description != null ? String(data.description).trim() || null : null;
+  const priority =
+    data.priority && ['low', 'medium', 'high'].includes(data.priority)
+      ? data.priority
+      : 'medium';
+
+  const tagIds =
+    Array.isArray(data.tagIds) && data.tagIds.length > 0
+      ? data.tagIds
+          .map((id) => Number(id))
+          .filter((id) => Number.isInteger(id) && id > 0)
+      : null;
+
+  return fastify.models.TodoTemplate.create({
+    userId,
+    name,
+    title,
+    description,
+    priority,
+    tagIds,
+  });
+}
+
+/**
+ * テンプレートを更新する
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} templateId - テンプレート ID
+ * @param {number} userId - ユーザー ID
+ * @param {object} data - { name?, title?, description?, priority?, tagIds? }
+ * @returns {Promise<object|null>} 更新後のテンプレート。存在しなければ null。
+ */
+async function updateTemplate(fastify, templateId, userId, data) {
+  const template = await getTemplateById(fastify, templateId, userId);
+  if (!template) return null;
+
+  if (data.name !== undefined) {
+    const name = typeof data.name === 'string' ? data.name.trim() : '';
+    if (name) template.name = name;
+  }
+  if (data.title !== undefined) {
+    const title = typeof data.title === 'string' ? data.title.trim() : '';
+    if (title) template.title = title;
+  }
+  if (data.description !== undefined) {
+    template.description =
+      data.description === null || data.description === ''
+        ? null
+        : String(data.description).trim();
+  }
+  if (data.priority !== undefined) {
+    template.priority =
+      ['low', 'medium', 'high'].includes(data.priority) && data.priority
+        ? data.priority
+        : template.priority;
+  }
+  if (data.tagIds !== undefined) {
+    const tagIds =
+      Array.isArray(data.tagIds) && data.tagIds.length > 0
+        ? data.tagIds
+            .map((id) => Number(id))
+            .filter((id) => Number.isInteger(id) && id > 0)
+        : null;
+    template.tagIds = tagIds;
+  }
+
+  await template.save();
+  return template;
+}
+
+/**
+ * テンプレートを削除する（所有者のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} templateId - テンプレート ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<boolean>} 削除した場合 true、存在しなければ false
+ */
+async function deleteTemplate(fastify, templateId, userId) {
+  const template = await getTemplateById(fastify, templateId, userId);
+  if (!template) return false;
+  await template.destroy();
+  return true;
+}
+
+/**
+ * テンプレートから Todo を 1 件作成する
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} templateId - テンプレート ID
+ * @param {number} userId - ユーザー ID
+ * @param {object} overrides - 上書きデータ { title?, description?, priority? }
+ * @returns {Promise<object|null>} 作成された Todo。テンプレート不存在なら null。
+ */
+async function createTodoFromTemplate(fastify, templateId, userId, overrides = {}) {
+  const template = await getTemplateById(fastify, templateId, userId);
+  if (!template) return null;
+
+  const titleSource =
+    overrides.title != null && String(overrides.title).trim()
+      ? String(overrides.title).trim()
+      : template.title;
+  if (!titleSource) return null;
+
+  const descriptionSource =
+    overrides.description !== undefined
+      ? overrides.description
+      : template.description;
+
+  const prioritySource =
+    overrides.priority && ['low', 'medium', 'high'].includes(overrides.priority)
+      ? overrides.priority
+      : template.priority || 'medium';
+
+  const todo = await fastify.models.Todo.create({
+    userId,
+    title: titleSource,
+    description:
+      descriptionSource === null || descriptionSource === ''
+        ? null
+        : descriptionSource,
+    priority: prioritySource,
+    dueDate: null,
+  });
+
+  // テンプレートにタグがあれば紐付ける
+  if (Array.isArray(template.tagIds) && template.tagIds.length > 0) {
+    const validTagIds = template.tagIds
+      .map((id) => Number(id))
+      .filter((id) => Number.isInteger(id) && id > 0);
+    if (validTagIds.length > 0) {
+      const tags = await fastify.models.Tag.findAll({
+        where: { userId, id: { [Op.in]: validTagIds } },
+      });
+      if (tags.length > 0) {
+        await todo.setTags(tags);
+      }
+    }
+  }
+
+  return todo;
+}
+
+module.exports = {
+  getTemplatesByUserId,
+  getTemplateById,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  createTodoFromTemplate,
+};
+

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -86,9 +86,9 @@
 
 ### Backend タスク（12タスク）
 - [x] 14.1: TodoTemplate モデル作成
-- [ ] 14.2: TemplateService 作成（CRUD、テンプレートから Todo 作成）
-- [ ] 14.3: TemplateController 作成
-- [ ] 14.4: Template ルート作成
+- [x] 14.2: TemplateService 作成（CRUD、テンプレートから Todo 作成）
+- [x] 14.3: TemplateController 作成
+- [x] 14.4: Template ルート作成
 - [ ] 14.5: Backend テスト
 
 ### Frontend タスク（12タスク）


### PR DESCRIPTION
## 概要
機能14（テンプレート機能）のバックエンド API を実装しました。

## 対応タスク
- **14.2** TemplateService 作成（CRUD + テンプレートから Todo 作成）
- **14.3** TemplateController 作成
- **14.4** Template ルート作成

## 変更内容
- `backend/services/templateService.js`: テンプレート CRUD、テンプレートから Todo 作成（タグ紐付け対応）
- `backend/controllers/templateController.js`: 各 API ハンドラとエラーハンドリング
- `backend/routes/api/v1/index.js`: 以下ルート追加（JWT 必須・JSON Schema 付与）
  - `GET /api/v1/templates` 一覧
  - `POST /api/v1/templates` 作成（name, title 必須）
  - `GET /api/v1/templates/:id` 1件取得
  - `PUT /api/v1/templates/:id` 更新
  - `DELETE /api/v1/templates/:id` 削除
  - `POST /api/v1/templates/:id/create-todo` テンプレートから Todo 作成（body で title/description/priority 上書き可）

## 確認
- `docker compose run --rm backend npm run test` 済み（成功）
- 14.5（Backend テスト追加）は別 PR 想定

Made with [Cursor](https://cursor.com)