### PR TITLE
feat(frontend): Template インターフェース定義（機能14 の 14.6）

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -92,7 +92,7 @@
 - [x] 14.5: Backend テスト
 
 ### Frontend タスク（12タスク）
-- [ ] 14.6: Template インターフェース定義
+- [x] 14.6: Template インターフェース定義
 - [ ] 14.7: TemplateService 作成
 - [ ] 14.8: TemplateList コンポーネント作成
 - [ ] 14.9: TemplateForm コンポーネント作成

--- a/frontend/src/app/models/template.interface.ts
+++ b/frontend/src/app/models/template.interface.ts
@@ -1,0 +1,47 @@
+import type { TodoPriority } from './todo.interface'
+
+/**
+ * API から返却される TodoTemplate 型
+ */
+export interface Template {
+  id: number
+  userId: number
+  name: string
+  title: string
+  description: string | null
+  priority: TodoPriority
+  tagIds: number[] | null
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * テンプレート作成用 DTO（name, title 必須）
+ */
+export interface CreateTemplateDto {
+  name: string
+  title: string
+  description?: string | null
+  priority?: TodoPriority
+  tagIds?: number[] | null
+}
+
+/**
+ * テンプレート更新用 DTO
+ */
+export interface UpdateTemplateDto {
+  name?: string
+  title?: string
+  description?: string | null
+  priority?: TodoPriority
+  tagIds?: number[] | null
+}
+
+/**
+ * テンプレートから Todo 作成時の上書き用 DTO（省略時はテンプレートの値を使用）
+ */
+export interface CreateTodoFromTemplateDto {
+  title?: string
+  description?: string | null
+  priority?: TodoPriority
+}


### PR DESCRIPTION
## 概要
機能14（テンプレート機能）の Frontend 用型定義を追加しました。

## 対応タスク
- **14.6** Template インターフェース定義

## 変更内容
- `frontend/src/app/models/template.interface.ts` を新規追加
  - `Template`: API 返却型（id, userId, name, title, description, priority, tagIds, createdAt, updatedAt）
  - `CreateTemplateDto`: 作成用（name, title 必須。description, priority, tagIds 任意）
  - `UpdateTemplateDto`: 更新用
  - `CreateTodoFromTemplateDto`: テンプレートから Todo 作成時の上書き用（title, description, priority 任意）
- `TodoPriority` は `todo.interface.ts` から import
- `docs/TODO_FEATURE_11_20.md`: 14.6 を完了に更新

Made with [Cursor](https://cursor.com)