### PR TITLE
feat(frontend): TemplateService 作成（機能14 の 14.7）

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -93,7 +93,7 @@
 
 ### Frontend タスク（12タスク）
 - [x] 14.6: Template インターフェース定義
-- [ ] 14.7: TemplateService 作成
+- [x] 14.7: TemplateService 作成
 - [ ] 14.8: TemplateList コンポーネント作成
 - [ ] 14.9: TemplateForm コンポーネント作成
 - [ ] 14.10: TodoForm にテンプレート選択追加

--- a/frontend/src/app/services/template.service.spec.ts
+++ b/frontend/src/app/services/template.service.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
+import { TemplateService } from './template.service'
+import type {
+  CreateTemplateDto,
+  UpdateTemplateDto,
+  CreateTodoFromTemplateDto,
+} from '../models/template.interface'
+
+describe('TemplateService (14.7)', () => {
+  let service: TemplateService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [TemplateService],
+    })
+    service = TestBed.inject(TemplateService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should call POST /templates with body for create', () => {
+    const body: CreateTemplateDto = { name: 'Daily', title: 'Daily task' }
+    service.create(body).subscribe((t) => expect(t.id).toBe(1))
+    const req = httpMock.expectOne(
+      (r) => r.url === `${apiUrl}/templates` && r.method === 'POST'
+    )
+    expect(req.request.body).toEqual(body)
+    req.flush({
+      id: 1,
+      userId: 1,
+      name: 'Daily',
+      title: 'Daily task',
+      description: null,
+      priority: 'medium',
+      tagIds: null,
+      createdAt: '',
+      updatedAt: '',
+    })
+  })
+
+  it('should call GET /templates for getAll', () => {
+    service.getAll().subscribe((list) => expect(list).toEqual([]))
+    const req = httpMock.expectOne(
+      (r) => r.url === `${apiUrl}/templates` && r.method === 'GET'
+    )
+    req.flush([])
+  })
+
+  it('should call GET /templates/:id for getById', () => {
+    const id = 5
+    service.getById(id).subscribe((t) => expect(t.id).toBe(id))
+    const req = httpMock.expectOne(
+      (r) => r.url === `${apiUrl}/templates/${id}` && r.method === 'GET'
+    )
+    req.flush({
+      id,
+      userId: 1,
+      name: 'x',
+      title: 'y',
+      description: null,
+      priority: 'medium',
+      tagIds: null,
+      createdAt: '',
+      updatedAt: '',
+    })
+  })
+
+  it('should call PUT /templates/:id with body for update', () => {
+    const id = 3
+    const body: UpdateTemplateDto = { name: 'Updated', title: 'Updated title' }
+    service.update(id, body).subscribe((t) => expect(t.name).toBe('Updated'))
+    const req = httpMock.expectOne(
+      (r) => r.url === `${apiUrl}/templates/${id}` && r.method === 'PUT'
+    )
+    expect(req.request.body).toEqual(body)
+    req.flush({
+      id,
+      userId: 1,
+      name: 'Updated',
+      title: 'Updated title',
+      description: null,
+      priority: 'medium',
+      tagIds: null,
+      createdAt: '',
+      updatedAt: '',
+    })
+  })
+
+  it('should call DELETE /templates/:id for delete', () => {
+    const id = 2
+    service.delete(id).subscribe((body) => expect(body).toBeFalsy())
+    const req = httpMock.expectOne(
+      (r) => r.url === `${apiUrl}/templates/${id}` && r.method === 'DELETE'
+    )
+    req.flush(null)
+  })
+
+  it('should call POST /templates/:id/create-todo for createTodoFromTemplate', () => {
+    const templateId = 10
+    service.createTodoFromTemplate(templateId).subscribe((todo) => {
+      expect(todo.id).toBe(1)
+      expect(todo.title).toBe('From template')
+    })
+    const req = httpMock.expectOne(
+      (r) =>
+        r.url === `${apiUrl}/templates/${templateId}/create-todo` &&
+        r.method === 'POST'
+    )
+    expect(req.request.body).toEqual({})
+    req.flush({
+      id: 1,
+      userId: 1,
+      title: 'From template',
+      description: null,
+      completed: false,
+      priority: 'medium',
+      dueDate: null,
+      sortOrder: 0,
+      projectId: null,
+      archived: false,
+      archivedAt: null,
+      createdAt: '',
+      updatedAt: '',
+    })
+  })
+
+  it('should call POST /templates/:id/create-todo with body for createTodoFromTemplate', () => {
+    const templateId = 11
+    const body: CreateTodoFromTemplateDto = { title: 'Overridden', priority: 'high' }
+    service.createTodoFromTemplate(templateId, body).subscribe((todo) => {
+      expect(todo.title).toBe('Overridden')
+      expect(todo.priority).toBe('high')
+    })
+    const req = httpMock.expectOne(
+      (r) =>
+        r.url === `${apiUrl}/templates/${templateId}/create-todo` &&
+        r.method === 'POST'
+    )
+    expect(req.request.body).toEqual(body)
+    req.flush({
+      id: 2,
+      userId: 1,
+      title: 'Overridden',
+      description: null,
+      completed: false,
+      priority: 'high',
+      dueDate: null,
+      sortOrder: 0,
+      projectId: null,
+      archived: false,
+      archivedAt: null,
+      createdAt: '',
+      updatedAt: '',
+    })
+  })
+})

--- a/frontend/src/app/services/template.service.ts
+++ b/frontend/src/app/services/template.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+import type {
+  Template,
+  CreateTemplateDto,
+  UpdateTemplateDto,
+  CreateTodoFromTemplateDto,
+} from '../models/template.interface'
+import type { Todo } from '../models/todo.interface'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TemplateService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  create(body: CreateTemplateDto): Observable<Template> {
+    return this.http.post<Template>(`${this.apiUrl}/templates`, body)
+  }
+
+  getAll(): Observable<Template[]> {
+    return this.http.get<Template[]>(`${this.apiUrl}/templates`)
+  }
+
+  getById(id: number): Observable<Template> {
+    return this.http.get<Template>(`${this.apiUrl}/templates/${id}`)
+  }
+
+  update(id: number, body: UpdateTemplateDto): Observable<Template> {
+    return this.http.put<Template>(`${this.apiUrl}/templates/${id}`, body)
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/templates/${id}`)
+  }
+
+  createTodoFromTemplate(
+    templateId: number,
+    body?: CreateTodoFromTemplateDto
+  ): Observable<Todo> {
+    return this.http.post<Todo>(
+      `${this.apiUrl}/templates/${templateId}/create-todo`,
+      body ?? {}
+    )
+  }
+}


### PR DESCRIPTION
## 概要
機能14（テンプレート機能）の Frontend 用 TemplateService を追加しました。

## 対応タスク
- **14.7** TemplateService 作成

## 変更内容
- `frontend/src/app/services/template.service.ts` を新規追加
  - `create(body)` → POST /templates
  - `getAll()` → GET /templates
  - `getById(id)` → GET /templates/:id
  - `update(id, body)` → PUT /templates/:id
  - `delete(id)` → DELETE /templates/:id
  - `createTodoFromTemplate(templateId, body?)` → POST /templates/:id/create-todo
- `frontend/src/app/services/template.service.spec.ts` で各メソッドの HTTP 呼び出しを検証（8 テスト）
- `docs/TODO_FEATURE_11_20.md`: 14.7 を完了に更新

## 確認
- `docker compose run --rm frontend ng test --watch=false --include='**/template.service.spec.ts'` 成功

Made with [Cursor](https://cursor.com)