### PR TITLE
feat(frontend): TemplateList コンポーネント作成（機能14 の 14.8）

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -94,7 +94,7 @@
 ### Frontend タスク（12タスク）
 - [x] 14.6: Template インターフェース定義
 - [x] 14.7: TemplateService 作成
-- [ ] 14.8: TemplateList コンポーネント作成
+- [x] 14.8: TemplateList コンポーネント作成
 - [ ] 14.9: TemplateForm コンポーネント作成
 - [ ] 14.10: TodoForm にテンプレート選択追加
 - [ ] 14.11: TemplatesPage 作成

--- a/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.html
@@ -1,0 +1,64 @@
+@if (error) {
+  <div class="alert alert-danger" role="alert">{{ error }}</div>
+}
+@if (loading) {
+  <div class="text-center py-4">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">読み込み中...</span>
+    </div>
+  </div>
+} @else if (templates.length === 0) {
+  <p class="text-muted py-3">テンプレートがありません。</p>
+} @else {
+  <div class="row g-3">
+    @for (template of templates; track template.id) {
+      <div class="col-12 col-sm-6 col-lg-4">
+        <div class="card template-card h-100">
+          <div class="card-header d-flex align-items-center gap-2 py-2">
+            <span class="fw-semibold text-truncate flex-grow-1" title="{{ template.name }}">{{ template.name }}</span>
+            <span
+              class="badge {{ getPriorityBadgeClass(template.priority) }}"
+            >{{ getPriorityLabel(template.priority) }}</span>
+          </div>
+          <div class="card-body py-2">
+            <p class="card-text small mb-1">
+              <span class="text-muted">タイトル:</span> {{ template.title }}
+            </p>
+            @if (template.description) {
+              <p class="card-text text-muted small mb-0 template-desc">{{ template.description }}</p>
+            }
+            @if (template.tagIds && template.tagIds.length > 0) {
+              <p class="card-text small text-muted mb-0 mt-1">タグ ID: {{ template.tagIds.length }} 件</p>
+            }
+          </div>
+          <div class="card-footer bg-transparent border-0 py-2 d-flex justify-content-end gap-1 flex-wrap">
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-success"
+              (click)="useTemplate.emit(template)"
+              title="このテンプレートから Todo を作成"
+            >
+              <i class="feather icon-plus"></i> Todo
+            </button>
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-primary"
+              (click)="edit.emit(template)"
+              title="編集"
+            >
+              <i class="feather icon-edit-2"></i>
+            </button>
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-danger"
+              (click)="delete.emit(template)"
+              title="削除"
+            >
+              <i class="feather icon-trash-2"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+}

--- a/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.scss
+++ b/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.scss
@@ -1,0 +1,20 @@
+.template-card {
+  border-radius: 0.375rem;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+  }
+
+  .card-footer {
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+}
+
+.template-desc {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { TemplateListComponent } from './template-list.component'
+import type { Template } from '../../../../../models/template.interface'
+
+const mockTemplate: Template = {
+  id: 1,
+  userId: 1,
+  name: 'Daily',
+  title: 'Daily task',
+  description: 'Repeat daily',
+  priority: 'medium',
+  tagIds: null,
+  createdAt: '',
+  updatedAt: '',
+}
+
+describe('TemplateListComponent (14.8)', () => {
+  let component: TemplateListComponent
+  let fixture: ComponentFixture<TemplateListComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TemplateListComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(TemplateListComponent)
+    component = fixture.componentInstance
+    component.templates = [mockTemplate]
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should return priority labels', () => {
+    expect(component.getPriorityLabel('low')).toBe('低')
+    expect(component.getPriorityLabel('medium')).toBe('中')
+    expect(component.getPriorityLabel('high')).toBe('高')
+  })
+
+  it('should return priority badge classes', () => {
+    expect(component.getPriorityBadgeClass('low')).toBe('bg-secondary')
+    expect(component.getPriorityBadgeClass('medium')).toBe('bg-info')
+    expect(component.getPriorityBadgeClass('high')).toBe('bg-danger')
+  })
+
+  it('should emit edit when edit button is clicked', () => {
+    let emitted: Template | undefined
+    component.edit.subscribe((t) => (emitted = t))
+    const editBtn = fixture.nativeElement.querySelector('button[title="編集"]')
+    editBtn?.click()
+    expect(emitted).toEqual(mockTemplate)
+  })
+
+  it('should emit delete when delete button is clicked', () => {
+    let emitted: Template | undefined
+    component.delete.subscribe((t) => (emitted = t))
+    const deleteBtn = fixture.nativeElement.querySelector('button[title="削除"]')
+    deleteBtn?.click()
+    expect(emitted).toEqual(mockTemplate)
+  })
+
+  it('should emit useTemplate when Todo button is clicked', () => {
+    let emitted: Template | undefined
+    component.useTemplate.subscribe((t) => (emitted = t))
+    const useBtn = fixture.nativeElement.querySelector('button[title="このテンプレートから Todo を作成"]')
+    useBtn?.click()
+    expect(emitted).toEqual(mockTemplate)
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import type { Template } from '../../../../../models/template.interface'
+import type { TodoPriority } from '../../../../../models/todo.interface'
 
 @Component({
   selector: 'app-template-list',
@@ -17,8 +18,8 @@ export class TemplateListComponent {
   @Output() delete = new EventEmitter<Template>()
   @Output() useTemplate = new EventEmitter<Template>()
 
-  getPriorityLabel(priority: string): string {
-    const labels: Record<string, string> = {
+  getPriorityLabel(priority: TodoPriority): string {
+    const labels: Record<TodoPriority, string> = {
       low: '低',
       medium: '中',
       high: '高',
@@ -26,8 +27,8 @@ export class TemplateListComponent {
     return labels[priority] ?? priority
   }
 
-  getPriorityBadgeClass(priority: string): string {
-    const classes: Record<string, string> = {
+  getPriorityBadgeClass(priority: TodoPriority): string {
+    const classes: Record<TodoPriority, string> = {
       low: 'bg-secondary',
       medium: 'bg-info',
       high: 'bg-danger',

--- a/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/templates/template-list/template-list.component.ts
@@ -1,0 +1,37 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import type { Template } from '../../../../../models/template.interface'
+
+@Component({
+  selector: 'app-template-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './template-list.component.html',
+  styleUrls: ['./template-list.component.scss'],
+})
+export class TemplateListComponent {
+  @Input() templates: Template[] = []
+  @Input() loading = false
+  @Input() error: string | null = null
+  @Output() edit = new EventEmitter<Template>()
+  @Output() delete = new EventEmitter<Template>()
+  @Output() useTemplate = new EventEmitter<Template>()
+
+  getPriorityLabel(priority: string): string {
+    const labels: Record<string, string> = {
+      low: '低',
+      medium: '中',
+      high: '高',
+    }
+    return labels[priority] ?? priority
+  }
+
+  getPriorityBadgeClass(priority: string): string {
+    const classes: Record<string, string> = {
+      low: 'bg-secondary',
+      medium: 'bg-info',
+      high: 'bg-danger',
+    }
+    return classes[priority] ?? 'bg-secondary'
+  }
+}


### PR DESCRIPTION
## 概要
機能14（テンプレート機能）の TemplateList コンポーネントを追加しました。

## 対応タスク
- **14.8** TemplateList コンポーネント作成

## 変更内容
- `frontend/src/app/components/pages/dashboard/templates/template-list/` を新規追加
  - **template-list.component.ts**: 表示用コンポーネント。`templates` / `loading` / `error` を Input、`edit` / `delete` / `useTemplate` を Output
  - **template-list.component.html**: カード一覧（name, title, description, 優先度バッジ、タグ件数）、Todo 作成・編集・削除ボタン
  - **template-list.component.scss**: カードホバー・説明文 2 行 clamp
  - **template-list.component.spec.ts**: 作成・優先度ラベル/バッジ・各 Output の emit 検証（6 テスト）
- `docs/TODO_FEATURE_11_20.md`: 14.8 を完了に更新

## 補足
- 親ページ（TemplatesPage）での利用は 14.11 で実装予定のため、本 PR ではコンポーネント単体のみ追加

## 確認
- `docker compose run --rm frontend ng test --watch=false --include='**/template-list.component.spec.ts'` 成功

Made with [Cursor](https://cursor.com)