### PR TITLE
feat(frontend): TemplateForm コンポーネント作成（機能14 の 14.9）

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -95,7 +95,7 @@
 - [x] 14.6: Template インターフェース定義
 - [x] 14.7: TemplateService 作成
 - [x] 14.8: TemplateList コンポーネント作成
-- [ ] 14.9: TemplateForm コンポーネント作成
+- [x] 14.9: TemplateForm コンポーネント作成
 - [ ] 14.10: TodoForm にテンプレート選択追加
 - [ ] 14.11: TemplatesPage 作成
 - [ ] 14.12: Frontend テスト

--- a/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.html
+++ b/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.html
@@ -1,0 +1,79 @@
+<form [formGroup]="form" (ngSubmit)="onSubmit()" class="template-form">
+  <div class="mb-2">
+    <label for="template-name" class="form-label">テンプレート名 <span class="text-danger">*</span></label>
+    <input
+      id="template-name"
+      type="text"
+      class="form-control"
+      formControlName="name"
+      placeholder="テンプレート名を入力"
+      maxlength="100"
+    />
+    @if (form.get('name')?.invalid && form.get('name')?.touched) {
+      <div class="invalid-feedback d-block">テンプレート名を入力してください。</div>
+    }
+  </div>
+  <div class="mb-2">
+    <label for="template-title" class="form-label">Todo タイトル <span class="text-danger">*</span></label>
+    <input
+      id="template-title"
+      type="text"
+      class="form-control"
+      formControlName="title"
+      placeholder="このテンプレートで作成する Todo のデフォルトタイトル"
+      maxlength="255"
+    />
+    @if (form.get('title')?.invalid && form.get('title')?.touched) {
+      <div class="invalid-feedback d-block">Todo タイトルを入力してください。</div>
+    }
+  </div>
+  <div class="mb-2">
+    <label for="template-description" class="form-label">説明</label>
+    <textarea
+      id="template-description"
+      class="form-control"
+      formControlName="description"
+      rows="2"
+      placeholder="説明（任意）"
+    ></textarea>
+  </div>
+  <div class="mb-2">
+    <label for="template-priority" class="form-label">優先度</label>
+    <select id="template-priority" class="form-select" formControlName="priority">
+      @for (opt of priorityOptions; track opt.value) {
+        <option [value]="opt.value">{{ opt.label }}</option>
+      }
+    </select>
+  </div>
+  @if (availableTags.length > 0) {
+    <div class="mb-3">
+      <span class="form-label d-block">タグ（任意）</span>
+      <div class="d-flex flex-wrap gap-2">
+        @for (tag of availableTags; track tag.id) {
+          <label class="form-check-label d-inline-flex align-items-center gap-1 border rounded px-2 py-1 template-tag-check">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              [checked]="isTagSelected(tag.id)"
+              (change)="onTagToggle(tag.id)"
+            />
+            <span
+              class="badge rounded-pill"
+              [style.background-color]="tag.color"
+              [class.text-dark]="isLight(tag.color)"
+              [class.text-white]="!isLight(tag.color)"
+            >{{ tag.name }}</span>
+          </label>
+        }
+      </div>
+    </div>
+  }
+  <div class="d-flex gap-2">
+    <button type="submit" class="btn btn-primary" [disabled]="form.invalid">
+      {{ editingTemplate ? '更新' : '作成' }}
+    </button>
+    @if (editingTemplate) {
+      <button type="button" class="btn btn-outline-secondary" (click)="onCancel()">キャンセル</button>
+    }
+  </div>
+</form>

--- a/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.scss
+++ b/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.scss
@@ -1,0 +1,12 @@
+.template-form {
+  max-width: 480px;
+}
+
+.template-tag-check {
+  cursor: pointer;
+  user-select: none;
+
+  .form-check-input {
+    cursor: pointer;
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.spec.ts
@@ -1,0 +1,147 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { TemplateFormComponent } from './template-form.component'
+import type { Template } from '../../../../../models/template.interface'
+import type { Tag } from '../../../../../models/tag.interface'
+
+const mockTemplate: Template = {
+  id: 1,
+  userId: 1,
+  name: 'Edit Template',
+  title: 'Edit Title',
+  description: 'Edit desc',
+  priority: 'high',
+  tagIds: [10, 20],
+  createdAt: '',
+  updatedAt: '',
+}
+
+const mockTags: Tag[] = [
+  { id: 10, userId: 1, name: 'Tag1', color: '#ff0000', createdAt: '', updatedAt: '' },
+  { id: 20, userId: 1, name: 'Tag2', color: '#00ff00', createdAt: '', updatedAt: '' },
+]
+
+describe('TemplateFormComponent (14.9)', () => {
+  let component: TemplateFormComponent
+  let fixture: ComponentFixture<TemplateFormComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TemplateFormComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(TemplateFormComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should have invalid form when name is empty', () => {
+    expect(component.form.valid).toBe(false)
+    expect(component.form.get('name')?.errors?.['required']).toBeTruthy()
+  })
+
+  it('should have invalid form when title is empty', () => {
+    component.form.patchValue({ name: 'Name' })
+    expect(component.form.get('title')?.errors?.['required']).toBeTruthy()
+  })
+
+  it('should emit submitForm with payload when valid and submit', () => {
+    component.form.patchValue({
+      name: 'New Template',
+      title: 'New Title',
+      priority: 'medium',
+    })
+    let emitted: unknown
+    component.submitForm.subscribe((v) => (emitted = v))
+    component.onSubmit()
+    expect(emitted).toEqual({
+      name: 'New Template',
+      title: 'New Title',
+      description: null,
+      priority: 'medium',
+      tagIds: null,
+    })
+  })
+
+  it('should not emit when form is invalid', () => {
+    let emitted = false
+    component.submitForm.subscribe(() => (emitted = true))
+    component.onSubmit()
+    expect(emitted).toBe(false)
+  })
+
+  it('should not emit when name is whitespace only', () => {
+    component.form.patchValue({ name: '   ', title: 'Title', priority: 'medium' })
+    let emitted = false
+    component.submitForm.subscribe(() => (emitted = true))
+    component.onSubmit()
+    expect(emitted).toBe(false)
+  })
+
+  it('should emit cancel when onCancel is called', () => {
+    let emitted = false
+    component.cancel.subscribe(() => (emitted = true))
+    component.onCancel()
+    expect(emitted).toBe(true)
+  })
+
+  it('should patch form when editingTemplate is set', () => {
+    component.editingTemplate = mockTemplate
+    component.ngOnChanges()
+    expect(component.form.get('name')?.value).toBe('Edit Template')
+    expect(component.form.get('title')?.value).toBe('Edit Title')
+    expect(component.form.get('description')?.value).toBe('Edit desc')
+    expect(component.form.get('priority')?.value).toBe('high')
+    expect(component.form.get('tagIds')?.value).toEqual([10, 20])
+  })
+
+  it('should reset form when editingTemplate is null', () => {
+    component.editingTemplate = mockTemplate
+    component.ngOnChanges()
+    component.editingTemplate = null
+    component.ngOnChanges()
+    expect(component.form.get('name')?.value).toBe('')
+    expect(component.form.get('title')?.value).toBe('')
+    expect(component.form.get('priority')?.value).toBe('medium')
+    expect(component.form.get('tagIds')?.value).toEqual([])
+  })
+
+  it('should report tag selected state', () => {
+    component.form.patchValue({ tagIds: [10] })
+    expect(component.isTagSelected(10)).toBe(true)
+    expect(component.isTagSelected(20)).toBe(false)
+  })
+
+  it('should toggle tag in tagIds on onTagToggle', () => {
+    component.availableTags = mockTags
+    expect(component.form.get('tagIds')?.value).toEqual([])
+    component.onTagToggle(10)
+    expect(component.form.get('tagIds')?.value).toEqual([10])
+    component.onTagToggle(20)
+    expect(component.form.get('tagIds')?.value).toEqual([10, 20])
+    component.onTagToggle(10)
+    expect(component.form.get('tagIds')?.value).toEqual([20])
+  })
+
+  it('should emit tagIds when tags selected on submit', () => {
+    component.form.patchValue({
+      name: 'T',
+      title: 'T',
+      priority: 'low',
+      tagIds: [10, 20],
+    })
+    let emitted: unknown
+    component.submitForm.subscribe((v) => (emitted = v))
+    component.onSubmit()
+    expect(emitted).toEqual({
+      name: 'T',
+      title: 'T',
+      description: null,
+      priority: 'low',
+      tagIds: [10, 20],
+    })
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.ts
+++ b/frontend/src/app/components/pages/dashboard/templates/template-form/template-form.component.ts
@@ -1,0 +1,136 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnChanges,
+} from '@angular/core'
+import { CommonModule } from '@angular/common'
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms'
+import type {
+  Template,
+  CreateTemplateDto,
+  UpdateTemplateDto,
+} from '../../../../../models/template.interface'
+import type { Tag } from '../../../../../models/tag.interface'
+import type { TodoPriority } from '../../../../../models/todo.interface'
+
+function noWhitespaceValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value as string
+  return value && value.trim().length === 0 ? { whitespace: true } : null
+}
+
+const PRIORITY_OPTIONS: { value: TodoPriority; label: string }[] = [
+  { value: 'low', label: '低' },
+  { value: 'medium', label: '中' },
+  { value: 'high', label: '高' },
+]
+
+@Component({
+  selector: 'app-template-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './template-form.component.html',
+  styleUrls: ['./template-form.component.scss'],
+})
+export class TemplateFormComponent implements OnChanges {
+  @Input() editingTemplate: Template | null = null
+  @Input() availableTags: Tag[] = []
+  @Output() submitForm = new EventEmitter<CreateTemplateDto | UpdateTemplateDto>()
+  @Output() cancel = new EventEmitter<void>()
+
+  form: FormGroup
+  readonly priorityOptions = PRIORITY_OPTIONS
+
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      name: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(100),
+          noWhitespaceValidator,
+        ],
+      ],
+      title: [
+        '',
+        [
+          Validators.required,
+          Validators.maxLength(255),
+          noWhitespaceValidator,
+        ],
+      ],
+      description: [''],
+      priority: ['medium' as const],
+      tagIds: [[] as number[]],
+    })
+  }
+
+  ngOnChanges(): void {
+    if (this.editingTemplate) {
+      this.form.patchValue({
+        name: this.editingTemplate.name,
+        title: this.editingTemplate.title,
+        description: this.editingTemplate.description ?? '',
+        priority: this.editingTemplate.priority,
+        tagIds: this.editingTemplate.tagIds ?? [],
+      })
+    } else {
+      this.form.reset({
+        name: '',
+        title: '',
+        description: '',
+        priority: 'medium',
+        tagIds: [],
+      })
+    }
+  }
+
+  isTagSelected(tagId: number): boolean {
+    const ids: number[] = this.form.get('tagIds')?.value ?? []
+    return ids.includes(tagId)
+  }
+
+  onTagToggle(tagId: number): void {
+    const control = this.form.get('tagIds')
+    if (!control) return
+    const current: number[] = control.value ?? []
+    const next = current.includes(tagId)
+      ? current.filter((id) => id !== tagId)
+      : [...current, tagId]
+    control.setValue(next)
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) return
+    const v = this.form.value
+    const tagIds = Array.isArray(v.tagIds) && v.tagIds.length > 0 ? v.tagIds : null
+    const payload: CreateTemplateDto | UpdateTemplateDto = {
+      name: v.name.trim(),
+      title: v.title.trim(),
+      description: v.description?.trim() || null,
+      priority: (v.priority as TodoPriority) || 'medium',
+      tagIds,
+    }
+    this.submitForm.emit(payload)
+  }
+
+  onCancel(): void {
+    this.cancel.emit()
+  }
+
+  isLight(hex: string): boolean {
+    if (!hex || !hex.startsWith('#')) return false
+    const r = parseInt(hex.slice(1, 3), 16)
+    const g = parseInt(hex.slice(3, 5), 16)
+    const b = parseInt(hex.slice(5, 7), 16)
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6
+  }
+}


### PR DESCRIPTION
## 概要
機能14（テンプレート機能）の TemplateForm コンポーネントを追加しました。

## 対応タスク
- **14.9** TemplateForm コンポーネント作成

## 変更内容
- `frontend/src/app/components/pages/dashboard/templates/template-form/` を新規追加
  - **template-form.component.ts**: Reactive Form（name, title 必須・noWhitespace、description, priority, tagIds）。`editingTemplate` / `availableTags` を Input、`submitForm` / `cancel` を Output。タグの選択状態と `onTagToggle`、`isLight` でバッジ文字色を制御
  - **template-form.component.html**: テンプレート名・Todo タイトル・説明・優先度セレクト・タグチェックボックス（availableTags がある場合のみ表示）、作成/更新・キャンセルボタン
  - **template-form.component.scss**: フォーム幅・タグチェックラベル
  - **template-form.component.spec.ts**: バリデーション・submit/cancel・patch/reset・タグトグル・tagIds 送信の検証（12 テスト）
- `docs/TODO_FEATURE_11_20.md`: 14.9 を完了に更新

## 補足
- 親（TemplatesPage）での利用は 14.11 で実装予定

## 確認
- `docker compose run --rm frontend ng test --watch=false --include='**/template-form.component.spec.ts'` 成功（12 テスト）

Made with [Cursor](https://cursor.com)