### PR TITLE
feat(frontend): TodoForm にテンプレート選択追加（機能14 の 14.10）

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -96,7 +96,7 @@
 - [x] 14.7: TemplateService 作成
 - [x] 14.8: TemplateList コンポーネント作成
 - [x] 14.9: TemplateForm コンポーネント作成
-- [ ] 14.10: TodoForm にテンプレート選択追加
+- [x] 14.10: TodoForm にテンプレート選択追加
 - [ ] 14.11: TemplatesPage 作成
 - [ ] 14.12: Frontend テスト
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.html
@@ -1,4 +1,19 @@
 <form [formGroup]="form" (ngSubmit)="onSubmit()" class="todo-form">
+  @if (templates.length > 0 && !editingTodo) {
+    <div class="mb-2">
+      <label for="todo-template" class="form-label">テンプレートから入力（任意）</label>
+      <select
+        id="todo-template"
+        class="form-select"
+        (change)="onTemplateSelect($event)"
+      >
+        <option value="">選択してください</option>
+        @for (t of templates; track t.id) {
+          <option [value]="t.id">{{ t.name }} — {{ t.title }}</option>
+        }
+      </select>
+    </div>
+  }
   <div class="mb-2">
     <label for="todo-title" class="form-label">タイトル <span class="text-danger">*</span></label>
     <input

--- a/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common'
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms'
 import type { Todo, TodoCreateUpdate } from '../../../../../models/todo.interface'
 import type { Project } from '../../../../../models/project.interface'
+import type { Template } from '../../../../../models/template.interface'
 
 function noWhitespaceValidator(control: AbstractControl): ValidationErrors | null {
   const value = control.value as string
@@ -19,6 +20,7 @@ function noWhitespaceValidator(control: AbstractControl): ValidationErrors | nul
 export class TodoFormComponent implements OnChanges {
   @Input() editingTodo: Todo | null = null
   @Input() projects: Project[] = []
+  @Input() templates: Template[] = []
   @Output() submitForm = new EventEmitter<TodoCreateUpdate>()
   @Output() cancel = new EventEmitter<void>()
 
@@ -70,5 +72,19 @@ export class TodoFormComponent implements OnChanges {
 
   onCancel(): void {
     this.cancel.emit()
+  }
+
+  onTemplateSelect(event: Event): void {
+    const el = event.target as HTMLSelectElement
+    const id = el.value ? Number(el.value) : null
+    if (id == null) return
+    const template = this.templates.find((t) => t.id === id)
+    if (!template) return
+    this.form.patchValue({
+      title: template.title,
+      description: template.description ?? '',
+      priority: template.priority,
+    })
+    el.value = ''
   }
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -83,12 +83,14 @@
         <app-todo-form
           [editingTodo]="editingTodo"
           [projects]="allProjects"
+          [templates]="allTemplates"
           (submitForm)="onSubmitForm($event)"
           (cancel)="onCancelEdit()"
         />
       } @else {
         <app-todo-form
           [projects]="allProjects"
+          [templates]="allTemplates"
           (submitForm)="onSubmitForm($event)"
         />
       }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog'
 import { TodoService, type TodoListFilters } from '../../../../../services/todo.service'
 import { TagService } from '../../../../../services/tag.service'
 import { ProjectService } from '../../../../../services/project.service'
+import { TemplateService } from '../../../../../services/template.service'
 import { TodoListComponent } from '../todo-list/todo-list.component'
 import { TodoFormComponent } from '../todo-form/todo-form.component'
 import { SearchBarComponent } from '../search-bar/search-bar.component'
@@ -18,6 +19,7 @@ import {
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 import type { Project } from '../../../../../models/project.interface'
+import type { Template } from '../../../../../models/template.interface'
 import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
 import type { SearchParams } from '../../../../../models/search-params.interface'
 
@@ -52,6 +54,7 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
   selectedIds: number[] = []
   allTags: Tag[] = []
   allProjects: Project[] = []
+  allTemplates: Template[] = []
 
   private destroy$ = new Subject<void>()
 
@@ -59,12 +62,14 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     private todoService: TodoService,
     private tagService: TagService,
     private projectService: ProjectService,
+    private templateService: TemplateService,
     private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
     this.loadTags()
     this.loadProjects()
+    this.loadTemplates()
     this.loadTodos()
   }
 
@@ -79,6 +84,13 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     this.projectService.getAll().pipe(takeUntil(this.destroy$)).subscribe({
       next: (projects) => { this.allProjects = projects },
       error: () => { this.allProjects = [] }
+    })
+  }
+
+  loadTemplates(): void {
+    this.templateService.getAll().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (templates) => { this.allTemplates = templates },
+      error: () => { this.allTemplates = [] }
     })
   }
 


### PR DESCRIPTION
## 概要
Todo 作成フォームにテンプレート選択を追加し、選択したテンプレートでタイトル・説明・優先度を入力できるようにしました。

## 対応タスク
- **14.10** TodoForm にテンプレート選択追加

## 変更内容
- **TodoFormComponent**
  - `@Input() templates: Template[] = []` を追加
  - 新規作成時（`!editingTodo`）かつ `templates.length > 0` のとき「テンプレートから入力（任意）」セレクトを表示
  - テンプレート選択時に `onTemplateSelect` で title / description / priority をフォームに反映し、セレクトを「選択してください」に戻す
- **TodoPageComponent**
  - `TemplateService` を注入し、`allTemplates` を `loadTemplates()` で取得
  - `app-todo-form` に `[templates]="allTemplates"` を渡す
- `docs/TODO_FEATURE_11_20.md`: 14.10 を完了に更新

## 補足
- テンプレート選択はあくまでフォームの事前入力用。作成は従来どおり `TodoService.create` で実行
- 編集時はテンプレートセレクトは表示しない

## 確認
- `docker compose run --rm frontend ng test --watch=false` 154 テスト成功

Made with [Cursor](https://cursor.com)