### PR TITLE
feat(backend): エクスポート/インポート API 実装（機能17 Backend）

### DIFF
--- a/backend/controllers/exportController.js
+++ b/backend/controllers/exportController.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const exportService = require('../services/exportService');
+
+/**
+ * GET /api/v1/todos/export?format=json|csv のハンドラ
+ */
+async function exportTodos(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const format = (req.query.format || 'json').toLowerCase();
+    if (format === 'csv') {
+      const csv = await exportService.exportTodosAsCSV(fastify, userId);
+      reply
+        .header('Content-Type', 'text/csv; charset=utf-8')
+        .header('Content-Disposition', 'attachment; filename="todos.csv"')
+        .send(csv);
+    } else {
+      const data = await exportService.exportTodosAsJSON(fastify, userId);
+      reply.code(200).send(data);
+    }
+  } catch (error) {
+    fastify.log.error({ err: error }, 'Export failed');
+    reply.code(500).send({ error: 'Export failed' });
+  }
+}
+
+module.exports = {
+  exportTodos,
+};

--- a/backend/controllers/importController.js
+++ b/backend/controllers/importController.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const importService = require('../services/importService');
+
+/**
+ * POST /api/v1/todos/import のハンドラ
+ * body: { format: 'json'|'csv', data: object|string }
+ */
+async function importTodos(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const format = (req.body?.format || 'json').toLowerCase();
+    const payload = req.body?.data;
+    if (payload === undefined) {
+      return reply.code(400).send({ error: 'Missing data' });
+    }
+    if (format === 'csv') {
+      const result = await importService.importTodosFromCSV(fastify, userId, typeof payload === 'string' ? payload : String(payload));
+      return reply.code(200).send(result);
+    }
+    if (format === 'json') {
+      const data = typeof payload === 'object' && payload !== null ? payload : {};
+      const result = await importService.importTodosFromJSON(fastify, userId, data);
+      return reply.code(200).send(result);
+    }
+    return reply.code(400).send({ error: 'Invalid format. Use json or csv' });
+  } catch (error) {
+    fastify.log.error({ err: error }, 'Import failed');
+    reply.code(500).send({ error: 'Import failed' });
+  }
+}
+
+module.exports = {
+  importTodos,
+};

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -47,6 +47,8 @@ const {
   deleteTemplate,
   createTodoFromTemplate,
 } = require('../../../controllers/templateController');
+const { exportTodos } = require('../../../controllers/exportController');
+const { importTodos } = require('../../../controllers/importController');
 
 module.exports = async function (fastify, opts) {
   /**
@@ -449,6 +451,32 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => bulkAddTag(fastify, request, reply),
+  });
+  fastify.get('/todos/export', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          format: { type: 'string', enum: ['json', 'csv'] },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => exportTodos(fastify, request, reply),
+  });
+  fastify.post('/todos/import', {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['format', 'data'],
+        properties: {
+          format: { type: 'string', enum: ['json', 'csv'] },
+          data: {},
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => importTodos(fastify, request, reply),
   });
   fastify.post('/todos/:todoId/tags', {
     schema: {

--- a/backend/services/exportService.js
+++ b/backend/services/exportService.js
@@ -26,10 +26,8 @@ async function getTodosForExport(fastify, userId) {
     const plain = t.toJSON();
     plain.tagIds = (t.Tags || []).map((tag) => tag.id);
     delete plain.Tags;
-    if (plain.Project) {
-      plain.projectId = plain.Project?.id ?? null;
-      delete plain.Project;
-    }
+    plain.projectId = plain.Project?.id ?? null;
+    delete plain.Project;
     return plain;
   });
 }

--- a/backend/services/exportService.js
+++ b/backend/services/exportService.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * エクスポート用にユーザー全 Todo を取得（アーカイブ含む、Tags・Project 付き）
+ */
+function buildExportInclude(fastify) {
+  return [
+    { model: fastify.models.Tag, as: 'Tags', through: { attributes: [] }, required: false },
+    { model: fastify.models.Project, as: 'Project', required: false },
+  ];
+}
+
+/**
+ * 指定ユーザーの全 Todo をエクスポート用形式で取得する
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object[]>} エクスポート用 Todo 配列（tagIds, projectId 含む）
+ */
+async function getTodosForExport(fastify, userId) {
+  const todos = await fastify.models.Todo.findAll({
+    where: { userId },
+    include: buildExportInclude(fastify),
+    order: [['createdAt', 'ASC']],
+  });
+  return todos.map((t) => {
+    const plain = t.toJSON();
+    plain.tagIds = (t.Tags || []).map((tag) => tag.id);
+    delete plain.Tags;
+    if (plain.Project) {
+      plain.projectId = plain.Project?.id ?? null;
+      delete plain.Project;
+    }
+    return plain;
+  });
+}
+
+/**
+ * 指定ユーザーの Todo を JSON 形式でエクスポートする
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object>} { todos: object[] }
+ */
+async function exportTodosAsJSON(fastify, userId) {
+  const todos = await getTodosForExport(fastify, userId);
+  return { todos };
+}
+
+/**
+ * 指定ユーザーの Todo を CSV 形式でエクスポートする（1行ヘッダー + データ行）
+ * カラム: title, description, completed, priority, dueDate, tagIds, projectId
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<string>} CSV 文字列
+ */
+function escapeCsvCell(value) {
+  if (value == null) return '';
+  const s = String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+async function exportTodosAsCSV(fastify, userId) {
+  const todos = await getTodosForExport(fastify, userId);
+  const header = ['title', 'description', 'completed', 'priority', 'dueDate', 'tagIds', 'projectId'];
+  const rows = [header.join(',')];
+  for (const t of todos) {
+    rows.push(
+      [
+        escapeCsvCell(t.title),
+        escapeCsvCell(t.description),
+        escapeCsvCell(t.completed),
+        escapeCsvCell(t.priority),
+        escapeCsvCell(t.dueDate),
+        escapeCsvCell(Array.isArray(t.tagIds) ? t.tagIds.join(';') : ''),
+        escapeCsvCell(t.projectId),
+      ].join(',')
+    );
+  }
+  return rows.join('\n');
+}
+
+module.exports = {
+  getTodosForExport,
+  exportTodosAsJSON,
+  exportTodosAsCSV,
+};

--- a/backend/services/importService.js
+++ b/backend/services/importService.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const todoService = require('./todoService');
+const tagService = require('./tagService');
+const projectService = require('./projectService');
+
+/**
+ * JSON 形式の Todo 配列をインポートする
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @param {object} data - { todos: Array<{ title, description?, completed?, priority?, dueDate?, projectId?, tagIds? }> }
+ * @returns {Promise<{ created: number, failed: number }>}
+ */
+async function importTodosFromJSON(fastify, userId, data) {
+  const list = Array.isArray(data?.todos) ? data.todos : [];
+  let created = 0;
+  let failed = 0;
+  for (const row of list) {
+    try {
+      const title = typeof row.title === 'string' ? row.title.trim() : '';
+      if (!title) {
+        failed += 1;
+        continue;
+      }
+      const description = row.description != null ? String(row.description).trim() || null : null;
+      const priority = ['low', 'medium', 'high'].includes(row.priority) ? row.priority : 'medium';
+      const dueDate = row.dueDate != null ? String(row.dueDate).trim() || null : null;
+      let projectId = row.projectId != null ? Number(row.projectId) : null;
+      if (projectId != null && (!Number.isInteger(projectId) || projectId <= 0)) projectId = null;
+      if (projectId != null) {
+        const project = await projectService.getProjectById(fastify, projectId, userId);
+        if (!project) projectId = null;
+      }
+      const todo = await todoService.createTodo(fastify, userId, {
+        title,
+        description,
+        priority,
+        dueDate,
+        projectId,
+      });
+      if (row.completed === true) {
+        await todoService.toggleComplete(fastify, todo.id, userId);
+      }
+      const tagIds = Array.isArray(row.tagIds)
+        ? row.tagIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0)
+        : [];
+      for (const tagId of tagIds) {
+        const tag = await tagService.getTagById(fastify, tagId, userId);
+        if (tag) await todoService.addTagToTodo(fastify, todo.id, tagId, userId);
+      }
+      created += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  return { created, failed };
+}
+
+/**
+ * CSV 1行をパースする（ダブルクォート囲み対応）
+ */
+function parseCsvLine(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (c === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (c === ',' && !inQuotes) {
+      result.push(current.trim());
+      current = '';
+    } else {
+      current += c;
+    }
+  }
+  result.push(current.trim());
+  return result;
+}
+
+/**
+ * CSV 形式の Todo をインポートする（ヘッダー行をスキップ、title, description, completed, priority, dueDate 列）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} userId - ユーザー ID
+ * @param {string} csvText - CSV 文字列
+ * @returns {Promise<{ created: number, failed: number }>}
+ */
+async function importTodosFromCSV(fastify, userId, csvText) {
+  const lines = String(csvText ?? '')
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (lines.length < 2) return { created: 0, failed: 0 };
+  const header = parseCsvLine(lines[0]).map((h) => h.toLowerCase());
+  const titleIdx = header.indexOf('title');
+  if (titleIdx === -1) return { created: 0, failed: 0 };
+  const descIdx = header.indexOf('description') !== -1 ? header.indexOf('description') : -1;
+  const completedIdx = header.indexOf('completed') !== -1 ? header.indexOf('completed') : -1;
+  const priorityIdx = header.indexOf('priority') !== -1 ? header.indexOf('priority') : -1;
+  const dueDateIdx = header.indexOf('duedate') !== -1 ? header.indexOf('duedate') : -1;
+  let created = 0;
+  let failed = 0;
+  for (let i = 1; i < lines.length; i++) {
+    try {
+      const cells = parseCsvLine(lines[i]);
+      const title = (cells[titleIdx] ?? '').trim();
+      if (!title) {
+        failed += 1;
+        continue;
+      }
+      const description = descIdx >= 0 && cells[descIdx] != null ? cells[descIdx].trim() || null : null;
+      let priority = 'medium';
+      if (priorityIdx >= 0 && cells[priorityIdx] != null && ['low', 'medium', 'high'].includes(cells[priorityIdx])) {
+        priority = cells[priorityIdx];
+      }
+      const dueDate = dueDateIdx >= 0 && cells[dueDateIdx] != null ? cells[dueDateIdx].trim() || null : null;
+      const completed = completedIdx >= 0 && cells[completedIdx] !== undefined && /^(true|1|yes)$/i.test(String(cells[completedIdx]).trim());
+      const todo = await todoService.createTodo(fastify, userId, {
+        title,
+        description,
+        priority,
+        dueDate,
+        projectId: null,
+      });
+      if (completed) await todoService.toggleComplete(fastify, todo.id, userId);
+      created += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  return { created, failed };
+}
+
+module.exports = {
+  importTodosFromJSON,
+  importTodosFromCSV,
+};

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -1460,3 +1460,120 @@ test('bulk-add-tag with other user todo ids returns added 0 and does not add tag
   assert.strictEqual(getA.statusCode, 200)
   assert.strictEqual((JSON.parse(getA.payload).Tags || []).length, 0)
 })
+
+// --- Export / Import (17.9) ---
+test('GET /api/v1/todos/export without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/export'
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('GET /api/v1/todos/export with auth returns JSON with todos array', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `ex-${suffix}`, email: `ex-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Export todo' }
+  })
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/export',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.ok(Array.isArray(body.todos))
+  assert.ok(body.todos.length >= 1)
+  assert.ok(body.todos.some((row) => row.title === 'Export todo'))
+})
+
+test('GET /api/v1/todos/export?format=csv with auth returns CSV', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `csv-${suffix}`, email: `csv-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/export',
+    headers: { authorization: `Bearer ${token}` },
+    query: { format: 'csv' }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  assert.ok(res.payload.includes('title,description,completed,priority,dueDate,tagIds,projectId'))
+})
+
+test('POST /api/v1/todos/import without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/import',
+    payload: { format: 'json', data: { todos: [] } }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('POST /api/v1/todos/import with json format creates todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `im-${suffix}`, email: `im-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/import',
+    headers: { authorization: `Bearer ${token}` },
+    payload: {
+      format: 'json',
+      data: {
+        todos: [
+          { title: 'Imported one' },
+          { title: 'Imported two', priority: 'high', completed: true }
+        ]
+      }
+    }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.created, 2)
+  assert.strictEqual(body.failed, 0)
+  const listRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` }
+  })
+  const list = JSON.parse(listRes.payload)
+  assert.ok(list.some((todo) => todo.title === 'Imported one'))
+  assert.ok(list.some((todo) => todo.title === 'Imported two' && todo.completed === true))
+})
+
+test('POST /api/v1/todos/import with csv format creates todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `imcsv-${suffix}`, email: `imcsv-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+  const csv = 'title,description,completed,priority,dueDate\nA task,,false,medium,\nB task,desc,true,high,'
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/import',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { format: 'csv', data: csv }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const body = JSON.parse(res.payload)
+  assert.strictEqual(body.created, 2)
+  assert.strictEqual(body.failed, 0)
+})

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -156,15 +156,15 @@
 - 既存テーブルのみ使用
 
 ### Backend タスク（10タスク）
-- [ ] 17.1: ExportService 作成
-- [ ] 17.2: `exportTodosAsJSON(userId)` 実装
-- [ ] 17.3: `exportTodosAsCSV(userId)` 実装
-- [ ] 17.4: ImportService 作成
-- [ ] 17.5: `importTodosFromJSON(userId, data)` 実装
-- [ ] 17.6: `importTodosFromCSV(userId, data)` 実装
-- [ ] 17.7: ExportController, ImportController 作成
-- [ ] 17.8: GET /api/todos/export, POST /api/todos/import ルート定義
-- [ ] 17.9: Backend テスト
+- [x] 17.1: ExportService 作成
+- [x] 17.2: `exportTodosAsJSON(userId)` 実装
+- [x] 17.3: `exportTodosAsCSV(userId)` 実装
+- [x] 17.4: ImportService 作成
+- [x] 17.5: `importTodosFromJSON(userId, data)` 実装
+- [x] 17.6: `importTodosFromCSV(userId, data)` 実装
+- [x] 17.7: ExportController, ImportController 作成
+- [x] 17.8: GET /api/todos/export, POST /api/todos/import ルート定義
+- [x] 17.9: Backend テスト
 
 ### Frontend タスク（10タスク）
 - [ ] 17.10: ExportService 作成


### PR DESCRIPTION
## 概要
機能17「エクスポート/インポート」の Backend タスク（17.1〜17.9）を実装しました。

## 変更内容
- **ExportService**: `exportTodosAsJSON(userId)` / `exportTodosAsCSV(userId)`（全 Todo・Tags・Project 含む）
- **ImportService**: `importTodosFromJSON(userId, data)` / `importTodosFromCSV(userId, data)`（projectId・tagIds の所有権チェック、不正行は failed カウント）
- **ExportController / ImportController**: 各 1 ハンドラ
- **ルート**: GET `/api/v1/todos/export?format=json|csv`、POST `/api/v1/todos/import`（body: `{ format, data }`）・JWT 必須・スキーマ定義
- **テスト**: 認証 401、JSON/CSV エクスポート、JSON/CSV インポートの 6 本追加
- **docs/TODO_FEATURE_11_20.md**: 17.1〜17.9 を `[x]` に更新

## 動作
- **エクスポート**: ログインユーザーの全 Todo（アーカイブ含む）を JSON または CSV で取得
- **インポート**: `{ format: 'json', data: { todos: [...] } }` または `{ format: 'csv', data: '...' }` で新規 Todo 作成（タグ・プロジェクトは JSON のみ、自ユーザー所有 ID のみ有効）

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)