### PR TITLE
feat(frontend): 機能20 20.3 IndexedDB ラッパーサービス作成

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -235,7 +235,7 @@
 ### Frontend タスク（15タスク）
 - [x] 20.1: Service Worker 設定
 - [x] 20.2: `ng add @angular/pwa` 実行（ng generate service-worker + 手動設定）
-- [ ] 20.3: IndexedDB ラッパーサービス作成
+- [x] 20.3: IndexedDB ラッパーサービス作成
 - [ ] 20.4: OfflineStorageService 作成
 - [ ] 20.5: オンライン/オフライン検知実装
 - [ ] 20.6: オフライン時のデータ保存実装

--- a/frontend/src/app/services/indexed-db.service.spec.ts
+++ b/frontend/src/app/services/indexed-db.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing'
+import { IndexedDbService } from './indexed-db.service'
+
+const TEST_DB = `test-indexeddb-${Date.now()}`
+
+describe('IndexedDbService (20.3)', () => {
+  let service: IndexedDbService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(IndexedDbService)
+  })
+
+  afterEach(() => {
+    service.close()
+    if (typeof indexedDB !== 'undefined') {
+      indexedDB.deleteDatabase(TEST_DB)
+    }
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should open DB and create store from schema', async () => {
+    await expectAsync(
+      service.open(TEST_DB, 1, [
+        { name: 'items', keyPath: 'id', indexes: [{ name: 'byId', keyPath: 'id', unique: true }] }
+      ])
+    ).toBeResolved()
+  })
+
+  it('should put and get value', async () => {
+    await service.open(TEST_DB, 2, [{ name: 'store1', keyPath: 'id' }])
+    await service.put('store1', { id: 'a', value: 1 })
+    const got = await service.get<{ id: string; value: number }>('store1', 'a')
+    expect(got).toEqual({ id: 'a', value: 1 })
+  })
+
+  it('should getAll and delete and clear', async () => {
+    await service.open(TEST_DB, 3, [{ name: 'store2', keyPath: 'id' }])
+    await service.put('store2', { id: 'x', v: 1 })
+    await service.put('store2', { id: 'y', v: 2 })
+    let all = await service.getAll<{ id: string; v: number }>('store2')
+    expect(all.length).toBe(2)
+    await service.delete('store2', 'x')
+    all = await service.getAll<{ id: string; v: number }>('store2')
+    expect(all.length).toBe(1)
+    expect(all[0].id).toBe('y')
+    await service.clear('store2')
+    all = await service.getAll('store2')
+    expect(all.length).toBe(0)
+  })
+
+  it('should throw if get before open', async () => {
+    await expectAsync(service.get('any', 'key')).toBeRejectedWithError(/not open/)
+  })
+})

--- a/frontend/src/app/services/indexed-db.service.spec.ts
+++ b/frontend/src/app/services/indexed-db.service.spec.ts
@@ -11,10 +11,14 @@ describe('IndexedDbService (20.3)', () => {
     service = TestBed.inject(IndexedDbService)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     service.close()
     if (typeof indexedDB !== 'undefined') {
-      indexedDB.deleteDatabase(TEST_DB)
+      await new Promise<void>((resolve) => {
+        const req = indexedDB.deleteDatabase(TEST_DB)
+        req.onsuccess = () => resolve()
+        req.onerror = () => resolve()
+      })
     }
   })
 

--- a/frontend/src/app/services/indexed-db.service.ts
+++ b/frontend/src/app/services/indexed-db.service.ts
@@ -29,6 +29,7 @@ export class IndexedDbService {
     storeSchemas: IndexedDBStoreSchema[]
   ): Promise<void> {
     if (this.db && this.dbName === dbName) return
+    if (this.db) this.close()
 
     return new Promise((resolve, reject) => {
       const req = indexedDB.open(dbName, version)
@@ -86,10 +87,12 @@ export class IndexedDbService {
     return new Promise((resolve, reject) => {
       const db = this.assertOpen()
       const tx = db.transaction(storeName, 'readwrite')
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'))
       const store = tx.objectStore(storeName)
       const req = key !== undefined ? store.put(value, key) : store.put(value)
       req.onerror = () => reject(req.error)
-      req.onsuccess = () => resolve()
     })
   }
 
@@ -98,10 +101,12 @@ export class IndexedDbService {
     return new Promise((resolve, reject) => {
       const db = this.assertOpen()
       const tx = db.transaction(storeName, 'readwrite')
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'))
       const store = tx.objectStore(storeName)
       const req = store.delete(key)
       req.onerror = () => reject(req.error)
-      req.onsuccess = () => resolve()
     })
   }
 
@@ -122,10 +127,12 @@ export class IndexedDbService {
     return new Promise((resolve, reject) => {
       const db = this.assertOpen()
       const tx = db.transaction(storeName, 'readwrite')
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'))
       const store = tx.objectStore(storeName)
       const req = store.clear()
       req.onerror = () => reject(req.error)
-      req.onsuccess = () => resolve()
     })
   }
 }

--- a/frontend/src/app/services/indexed-db.service.ts
+++ b/frontend/src/app/services/indexed-db.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@angular/core'
+
+/** オブジェクトストア定義（open 時に未存在なら作成） */
+export interface IndexedDBStoreSchema {
+  name: string
+  keyPath?: string | string[]
+  autoIncrement?: boolean
+  indexes?: { name: string; keyPath: string | string[]; unique?: boolean }[]
+}
+
+/**
+ * IndexedDB の薄いラッパー。
+ * オフライン保存（20.4 以降）で OfflineStorageService から利用する。
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class IndexedDbService {
+  private db: IDBDatabase | null = null
+  private dbName: string | null = null
+
+  /**
+   * DB を開く。既に同名で開いていれば何もしない。
+   * スキーマで指定したストアが無い場合は作成する。
+   */
+  async open(
+    dbName: string,
+    version: number,
+    storeSchemas: IndexedDBStoreSchema[]
+  ): Promise<void> {
+    if (this.db && this.dbName === dbName) return
+
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(dbName, version)
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => {
+        this.db = req.result
+        this.dbName = dbName
+        resolve()
+      }
+      req.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result
+        for (const schema of storeSchemas) {
+          if (!db.objectStoreNames.contains(schema.name)) {
+            const store = db.createObjectStore(schema.name, {
+              keyPath: schema.keyPath,
+              autoIncrement: schema.autoIncrement ?? false
+            })
+            for (const idx of schema.indexes ?? []) {
+              store.createIndex(idx.name, idx.keyPath, { unique: idx.unique ?? false })
+            }
+          }
+        }
+      }
+    })
+  }
+
+  /** 開いている DB を閉じる */
+  close(): void {
+    if (this.db) {
+      this.db.close()
+      this.db = null
+      this.dbName = null
+    }
+  }
+
+  private assertOpen(): IDBDatabase {
+    if (!this.db) throw new Error('IndexedDB is not open. Call open() first.')
+    return this.db
+  }
+
+  /** トランザクションでストアを取得（readonly） */
+  get<T>(storeName: string, key: IDBValidKey): Promise<T | undefined> {
+    return new Promise((resolve, reject) => {
+      const db = this.assertOpen()
+      const tx = db.transaction(storeName, 'readonly')
+      const store = tx.objectStore(storeName)
+      const req = store.get(key)
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => resolve(req.result as T | undefined)
+    })
+  }
+
+  /** トランザクションでストアに put */
+  put(storeName: string, value: unknown, key?: IDBValidKey): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const db = this.assertOpen()
+      const tx = db.transaction(storeName, 'readwrite')
+      const store = tx.objectStore(storeName)
+      const req = key !== undefined ? store.put(value, key) : store.put(value)
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => resolve()
+    })
+  }
+
+  /** トランザクションでストアから delete */
+  delete(storeName: string, key: IDBValidKey): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const db = this.assertOpen()
+      const tx = db.transaction(storeName, 'readwrite')
+      const store = tx.objectStore(storeName)
+      const req = store.delete(key)
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => resolve()
+    })
+  }
+
+  /** ストア内の全件取得 */
+  getAll<T>(storeName: string): Promise<T[]> {
+    return new Promise((resolve, reject) => {
+      const db = this.assertOpen()
+      const tx = db.transaction(storeName, 'readonly')
+      const store = tx.objectStore(storeName)
+      const req = store.getAll()
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => resolve((req.result ?? []) as T[])
+    })
+  }
+
+  /** ストアを空にする */
+  clear(storeName: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const db = this.assertOpen()
+      const tx = db.transaction(storeName, 'readwrite')
+      const store = tx.objectStore(storeName)
+      const req = store.clear()
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => resolve()
+    })
+  }
+}


### PR DESCRIPTION
## 概要
機能20（オフライン対応）の 20.3: IndexedDB ラッパーサービスを追加しました。

## 変更内容
- **IndexedDbService**: `open(dbName, version, storeSchemas)` で DB を開き、スキーマに基づきストア・インデックスを作成。`get` / `put` / `delete` / `getAll` / `clear` を提供。`close()` で DB を閉じる。
- **indexed-db.service.spec.ts**: open・put/get・getAll/delete/clear・未 open 時のエラーを検証。
- **docs**: TODO_FEATURE_11_20.md の 20.3 を `[x]` に更新。

## 対応タスク
- 20.3: IndexedDB ラッパーサービス作成

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)