### PR TITLE
feat(frontend): 機能20 20.4 OfflineStorageService 作成

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -236,7 +236,7 @@
 - [x] 20.1: Service Worker 設定
 - [x] 20.2: `ng add @angular/pwa` 実行（ng generate service-worker + 手動設定）
 - [x] 20.3: IndexedDB ラッパーサービス作成
-- [ ] 20.4: OfflineStorageService 作成
+- [x] 20.4: OfflineStorageService 作成
 - [ ] 20.5: オンライン/オフライン検知実装
 - [ ] 20.6: オフライン時のデータ保存実装
 - [ ] 20.7: オンライン復帰時の同期処理実装

--- a/frontend/src/app/services/offline-storage.service.spec.ts
+++ b/frontend/src/app/services/offline-storage.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing'
+import { OfflineStorageService } from './offline-storage.service'
+import { IndexedDbService } from './indexed-db.service'
+import type { Todo } from '../models/todo.interface'
+
+const mockTodos: Todo[] = [
+  {
+    id: 1,
+    userId: 1,
+    title: 'A',
+    description: null,
+    completed: false,
+    priority: 'medium',
+    dueDate: null,
+    sortOrder: 0,
+    projectId: null,
+    archived: false,
+    archivedAt: null,
+    createdAt: '',
+    updatedAt: ''
+  }
+]
+
+describe('OfflineStorageService (20.4)', () => {
+  let service: OfflineStorageService
+  let indexedDb: jasmine.SpyObj<IndexedDbService>
+
+  beforeEach(() => {
+    indexedDb = jasmine.createSpyObj('IndexedDbService', ['open', 'getAll', 'put', 'clear'])
+    indexedDb.open.and.returnValue(Promise.resolve())
+    indexedDb.getAll.and.returnValue(Promise.resolve([]))
+    indexedDb.put.and.returnValue(Promise.resolve())
+    indexedDb.clear.and.returnValue(Promise.resolve())
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: IndexedDbService, useValue: indexedDb }]
+    })
+    service = TestBed.inject(OfflineStorageService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should open DB and return todos from getTodos', async () => {
+    indexedDb.getAll.and.returnValue(Promise.resolve(mockTodos))
+    const result = await service.getTodos()
+    expect(indexedDb.open).toHaveBeenCalled()
+    expect(indexedDb.getAll).toHaveBeenCalledWith('todos')
+    expect(result).toEqual(mockTodos)
+  })
+
+  it('should clear and put each todo in saveTodos', async () => {
+    await service.saveTodos(mockTodos)
+    expect(indexedDb.clear).toHaveBeenCalledWith('todos')
+    expect(indexedDb.put).toHaveBeenCalledWith('todos', mockTodos[0])
+    expect(indexedDb.put).toHaveBeenCalledTimes(mockTodos.length)
+  })
+
+  it('should clear todos store in clearTodos', async () => {
+    await service.clearTodos()
+    expect(indexedDb.clear).toHaveBeenCalledWith('todos')
+  })
+})

--- a/frontend/src/app/services/offline-storage.service.ts
+++ b/frontend/src/app/services/offline-storage.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core'
+import { IndexedDbService } from './indexed-db.service'
+import type { Todo } from '../models/todo.interface'
+
+const DB_NAME = 'app-offline'
+const DB_VERSION = 1
+const STORE_TODOS = 'todos'
+
+/**
+ * オフライン用の Todo キャッシュを IndexedDB で保持するサービス。
+ * 20.6 でオフライン時の保存、20.7 でオンライン復帰時の同期に利用する。
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class OfflineStorageService {
+  private initPromise: Promise<void> | null = null
+
+  constructor(private indexedDb: IndexedDbService) {}
+
+  /** DB を開く（初回のみ。同一 DB なら再利用） */
+  private async ensureOpen(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.indexedDb.open(DB_NAME, DB_VERSION, [
+      { name: STORE_TODOS, keyPath: 'id', indexes: [{ name: 'byId', keyPath: 'id', unique: true }] }
+    ])
+    return this.initPromise
+  }
+
+  /** キャッシュした Todo 一覧を取得 */
+  async getTodos(): Promise<Todo[]> {
+    await this.ensureOpen()
+    return this.indexedDb.getAll<Todo>(STORE_TODOS)
+  }
+
+  /** Todo 一覧をキャッシュに保存（既存を上書き） */
+  async saveTodos(todos: Todo[]): Promise<void> {
+    await this.ensureOpen()
+    await this.indexedDb.clear(STORE_TODOS)
+    for (const todo of todos) {
+      await this.indexedDb.put(STORE_TODOS, todo)
+    }
+  }
+
+  /** Todo キャッシュを空にする */
+  async clearTodos(): Promise<void> {
+    await this.ensureOpen()
+    await this.indexedDb.clear(STORE_TODOS)
+  }
+}

--- a/frontend/src/app/services/offline-storage.service.ts
+++ b/frontend/src/app/services/offline-storage.service.ts
@@ -18,12 +18,17 @@ export class OfflineStorageService {
 
   constructor(private indexedDb: IndexedDbService) {}
 
-  /** DB を開く（初回のみ。同一 DB なら再利用） */
-  private async ensureOpen(): Promise<void> {
+  /** DB を開く（初回のみ。同一 DB なら再利用。失敗時は initPromise をリセットしてリトライ可能に） */
+  private ensureOpen(): Promise<void> {
     if (this.initPromise) return this.initPromise
-    this.initPromise = this.indexedDb.open(DB_NAME, DB_VERSION, [
-      { name: STORE_TODOS, keyPath: 'id', indexes: [{ name: 'byId', keyPath: 'id', unique: true }] }
-    ])
+    this.initPromise = this.indexedDb
+      .open(DB_NAME, DB_VERSION, [
+        { name: STORE_TODOS, keyPath: 'id', indexes: [{ name: 'byId', keyPath: 'id', unique: true }] }
+      ])
+      .catch((err) => {
+        this.initPromise = null
+        return Promise.reject(err)
+      })
     return this.initPromise
   }
 
@@ -37,9 +42,7 @@ export class OfflineStorageService {
   async saveTodos(todos: Todo[]): Promise<void> {
     await this.ensureOpen()
     await this.indexedDb.clear(STORE_TODOS)
-    for (const todo of todos) {
-      await this.indexedDb.put(STORE_TODOS, todo)
-    }
+    await Promise.all(todos.map((todo) => this.indexedDb.put(STORE_TODOS, todo)))
   }
 
   /** Todo キャッシュを空にする */


### PR DESCRIPTION
## 概要
機能20（オフライン対応）の 20.4: OfflineStorageService を追加しました。

## 変更内容
- **OfflineStorageService**: IndexedDbService で `app-offline` DB の `todos` ストアを利用。`getTodos()` / `saveTodos(todos)` / `clearTodos()` を提供。初回利用時に `ensureOpen()` で DB を開く。
- **offline-storage.service.spec.ts**: IndexedDbService をモックし、getTodos・saveTodos・clearTodos の呼び出しを検証。
- **docs**: TODO_FEATURE_11_20.md の 20.4 を `[x]` に更新。

## 対応タスク
- 20.4: OfflineStorageService 作成

レビューよろしくお願いします。

Made with [Cursor](https://cursor.com)