### PR TITLE
feat(backend): 機能11 11.1 TodoShare モデル作成

### DIFF
--- a/backend/migrations/20260312100000-create-todo-shares.js
+++ b/backend/migrations/20260312100000-create-todo-shares.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('todo_shares', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      todo_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      shared_with_user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      permission: {
+        type: Sequelize.ENUM('view', 'edit'),
+        allowNull: false,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+    await queryInterface.addIndex('todo_shares', ['todo_id']);
+    await queryInterface.addIndex('todo_shares', ['shared_with_user_id']);
+    await queryInterface.addIndex('todo_shares', ['todo_id', 'shared_with_user_id'], { unique: true });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('todo_shares');
+  },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -7,6 +7,7 @@ const Tag = require('./tag')
 const TodoTag = require('./todoTag')
 const Project = require('./project')
 const TodoTemplate = require('./todoTemplate')
+const TodoShare = require('./todoShare')
 
 module.exports = fp(async function (fastify, opts) {
   const sequelize = fastify.sequelize
@@ -18,6 +19,7 @@ module.exports = fp(async function (fastify, opts) {
     TodoTag: TodoTag(sequelize),
     Project: Project(sequelize),
     TodoTemplate: TodoTemplate(sequelize),
+    TodoShare: TodoShare(sequelize),
   }
 
   Object.keys(models).forEach((name) => {

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -82,6 +82,7 @@ module.exports = (sequelize) => {
     Todo.belongsTo(models.User, { foreignKey: 'userId' });
     Todo.belongsTo(models.Project, { foreignKey: 'projectId' });
     Todo.belongsToMany(models.Tag, { through: models.TodoTag, foreignKey: 'todoId', otherKey: 'tagId' });
+    Todo.hasMany(models.TodoShare, { foreignKey: 'todoId' });
   };
 
   return Todo;

--- a/backend/models/todoShare.js
+++ b/backend/models/todoShare.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { DataTypes } = require('sequelize');
+
+/**
+ * Todo 共有（11.1）。
+ * todo_shares: id, todoId, sharedWithUserId, permission (view|edit), createdAt
+ */
+module.exports = (sequelize) => {
+  const TodoShare = sequelize.define(
+    'TodoShare',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      todoId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'todo_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      sharedWithUserId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'shared_with_user_id',
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      permission: {
+        type: DataTypes.ENUM('view', 'edit'),
+        allowNull: false,
+      },
+    },
+    {
+      tableName: 'todo_shares',
+      timestamps: true,
+      updatedAt: false,
+      underscored: true,
+    }
+  );
+
+  TodoShare.associate = function (models) {
+    TodoShare.belongsTo(models.Todo, { foreignKey: 'todoId' });
+    TodoShare.belongsTo(models.User, { foreignKey: 'sharedWithUserId' });
+  };
+
+  return TodoShare;
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -30,6 +30,7 @@ module.exports = (sequelize) => {
     User.hasMany(models.Todo, { foreignKey: 'userId' });
     User.hasMany(models.Tag, { foreignKey: 'userId' });
     User.hasMany(models.Project, { foreignKey: 'userId' });
+    User.hasMany(models.TodoShare, { foreignKey: 'sharedWithUserId' });
   };
 
   return User;

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -9,7 +9,7 @@
 - permission: ENUM('view', 'edit')
 
 ### Backend タスク（15タスク）
-- [ ] 11.1: TodoShare モデル作成（マイグレーション、モデル定義）
+- [x] 11.1: TodoShare モデル作成（マイグレーション、モデル定義）
 - [ ] 11.2: ShareService 作成（共有、権限チェック、共有解除）
 - [ ] 11.3: ShareController 作成
 - [ ] 11.4: Share ルート作成（POST /api/todos/:id/share, GET /api/todos/shared, DELETE /api/shares/:id）


### PR DESCRIPTION
## 概要
機能11 Todo 共有の 11.1（TodoShare モデル作成）を実装しました。

## 変更内容
- **マイグレーション** `20260312100000-create-todo-shares.js`: `todo_shares` テーブル作成
  - `id`, `todo_id` (FK → todos), `shared_with_user_id` (FK → users), `permission` ENUM('view','edit'), `created_at`
  - インデックス: todo_id, shared_with_user_id, ユニーク (todo_id, shared_with_user_id)
- **モデル** `backend/models/todoShare.js`: TodoShare 定義、Todo/User への belongsTo 関連
- **models/index.js**: TodoShare を登録
- **Todo モデル**: `hasMany(TodoShare)` を追加
- **TODO**: `docs/TODO_FEATURE_11_20.md` の 11.1 を [x] に更新

## 確認
- `docker compose run --rm backend npx sequelize-cli db:migrate` 成功
- `docker compose run --rm backend npm run test` 104 件すべて成功

Made with [Cursor](https://cursor.com)