### PR TITLE
feat(backend): 機能11 11.2 ShareService 作成

### DIFF
--- a/backend/services/shareService.js
+++ b/backend/services/shareService.js
@@ -26,14 +26,16 @@ async function shareTodo(fastify, todoId, sharedWithUserId, permission, ownerUse
   if (Number(sharedWithUserId) === Number(ownerUserId)) {
     return null;
   }
-  const perm = PERMISSIONS.includes(permission) ? permission : 'view';
+  if (!PERMISSIONS.includes(permission)) {
+    throw fastify.httpErrors.badRequest(`Invalid permission: ${permission}`);
+  }
 
   const [share, created] = await fastify.models.TodoShare.findOrCreate({
     where: { todoId, sharedWithUserId: Number(sharedWithUserId) },
-    defaults: { permission: perm },
+    defaults: { permission },
   });
   if (!created) {
-    share.permission = perm;
+    share.permission = permission;
     await share.save();
   }
   return share;
@@ -49,14 +51,16 @@ async function shareTodo(fastify, todoId, sharedWithUserId, permission, ownerUse
 async function canView(fastify, todoId, userId) {
   const todo = await fastify.models.Todo.findOne({
     where: { id: todoId, archived: false },
+    include: [{
+      model: fastify.models.TodoShare,
+      as: 'TodoShares',
+      required: false,
+      where: { sharedWithUserId: userId },
+      attributes: [],
+    }],
   });
   if (!todo) return false;
-  if (todo.userId === userId) return true;
-
-  const share = await fastify.models.TodoShare.findOne({
-    where: { todoId, sharedWithUserId: userId },
-  });
-  return !!share;
+  return todo.userId === userId || (todo.TodoShares && todo.TodoShares.length > 0);
 }
 
 /**
@@ -69,14 +73,16 @@ async function canView(fastify, todoId, userId) {
 async function canEdit(fastify, todoId, userId) {
   const todo = await fastify.models.Todo.findOne({
     where: { id: todoId, archived: false },
+    include: [{
+      model: fastify.models.TodoShare,
+      as: 'TodoShares',
+      required: false,
+      where: { sharedWithUserId: userId, permission: 'edit' },
+      attributes: [],
+    }],
   });
   if (!todo) return false;
-  if (todo.userId === userId) return true;
-
-  const share = await fastify.models.TodoShare.findOne({
-    where: { todoId, sharedWithUserId: userId, permission: 'edit' },
-  });
-  return !!share;
+  return todo.userId === userId || (todo.TodoShares && todo.TodoShares.length > 0);
 }
 
 /**

--- a/backend/services/shareService.js
+++ b/backend/services/shareService.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * Todo 共有のビジネスロジック（11.2）。
+ * 共有作成・権限チェック・共有解除を担当する。
+ */
+
+const PERMISSIONS = ['view', 'edit'];
+
+/**
+ * Todo を他ユーザーと共有する。所有者のみ実行可能。
+ * 既に同じユーザーへ共有済みの場合は permission を更新する。
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - 共有する Todo の ID
+ * @param {number} sharedWithUserId - 共有先ユーザー ID
+ * @param {string} permission - 'view' | 'edit'
+ * @param {number} ownerUserId - Todo 所有者のユーザー ID
+ * @returns {Promise<object|null>} 作成または更新された TodoShare。Todo が存在しない・所有者でない・自分自身への共有の場合は null
+ */
+async function shareTodo(fastify, todoId, sharedWithUserId, permission, ownerUserId) {
+  const todo = await fastify.models.Todo.findOne({
+    where: { id: todoId, userId: ownerUserId, archived: false },
+  });
+  if (!todo) return null;
+
+  if (Number(sharedWithUserId) === Number(ownerUserId)) {
+    return null;
+  }
+  const perm = PERMISSIONS.includes(permission) ? permission : 'view';
+
+  const [share, created] = await fastify.models.TodoShare.findOrCreate({
+    where: { todoId, sharedWithUserId: Number(sharedWithUserId) },
+    defaults: { permission: perm },
+  });
+  if (!created) {
+    share.permission = perm;
+    await share.save();
+  }
+  return share;
+}
+
+/**
+ * 指定ユーザーが Todo を閲覧可能かどうか（所有者または view/edit 共有先）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<boolean>}
+ */
+async function canView(fastify, todoId, userId) {
+  const todo = await fastify.models.Todo.findOne({
+    where: { id: todoId, archived: false },
+  });
+  if (!todo) return false;
+  if (todo.userId === userId) return true;
+
+  const share = await fastify.models.TodoShare.findOne({
+    where: { todoId, sharedWithUserId: userId },
+  });
+  return !!share;
+}
+
+/**
+ * 指定ユーザーが Todo を編集可能かどうか（所有者または edit 共有先）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - Todo ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<boolean>}
+ */
+async function canEdit(fastify, todoId, userId) {
+  const todo = await fastify.models.Todo.findOne({
+    where: { id: todoId, archived: false },
+  });
+  if (!todo) return false;
+  if (todo.userId === userId) return true;
+
+  const share = await fastify.models.TodoShare.findOne({
+    where: { todoId, sharedWithUserId: userId, permission: 'edit' },
+  });
+  return !!share;
+}
+
+/**
+ * 共有を 1 件削除する。Todo の所有者のみ実行可能。
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} shareId - TodoShare の ID
+ * @param {number} ownerUserId - 呼び出し元ユーザー（Todo 所有者である必要あり）
+ * @returns {Promise<boolean>} 削除した場合 true、共有が存在しないか所有者でない場合は false
+ */
+async function deleteShareById(fastify, shareId, ownerUserId) {
+  const share = await fastify.models.TodoShare.findByPk(shareId, {
+    include: [{ model: fastify.models.Todo, as: 'Todo', attributes: ['userId'] }],
+  });
+  if (!share || !share.Todo || share.Todo.userId !== ownerUserId) {
+    return false;
+  }
+  await share.destroy();
+  return true;
+}
+
+module.exports = {
+  shareTodo,
+  canView,
+  canEdit,
+  deleteShareById,
+};

--- a/backend/test/services/shareService.test.js
+++ b/backend/test/services/shareService.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const shareService = require('../../services/shareService');
+
+function createMockFastify(overrides = {}) {
+  const Todo = {
+    findOne: overrides.TodoFindOne ?? (() => Promise.resolve(null)),
+  };
+  const TodoShare = {
+    findOrCreate: overrides.TodoShareFindOrCreate ?? (() => Promise.resolve([null, false])),
+    findOne: overrides.TodoShareFindOne ?? (() => Promise.resolve(null)),
+    findByPk: overrides.TodoShareFindByPk ?? (() => Promise.resolve(null)),
+  };
+  const badRequest = (msg) => {
+    const err = new Error(msg);
+    err.statusCode = 400;
+    return err;
+  };
+  return {
+    models: { Todo, TodoShare, ...overrides.models },
+    httpErrors: { badRequest: overrides.httpErrorsBadRequest ?? badRequest },
+    ...overrides.fastify,
+  };
+}
+
+test('shareTodo: 新規共有が成功する', async () => {
+  const ownerId = 1;
+  const todoId = 10;
+  const sharedWithId = 2;
+  const createdShare = { id: 1, todoId, sharedWithUserId: sharedWithId, permission: 'edit' };
+  const fastify = createMockFastify({
+    TodoFindOne: () => Promise.resolve({ id: todoId, userId: ownerId }),
+    TodoShareFindOrCreate: () => Promise.resolve([createdShare, true]),
+  });
+  const result = await shareService.shareTodo(fastify, todoId, sharedWithId, 'edit', ownerId);
+  assert.strictEqual(result, createdShare);
+  assert.strictEqual(result.permission, 'edit');
+});
+
+test('shareTodo: 既存共有の場合は permission を更新する', async () => {
+  const ownerId = 1;
+  const todoId = 10;
+  const sharedWithId = 2;
+  const existingShare = { id: 1, todoId, sharedWithUserId: sharedWithId, permission: 'view', save: () => Promise.resolve() };
+  const fastify = createMockFastify({
+    TodoFindOne: () => Promise.resolve({ id: todoId, userId: ownerId }),
+    TodoShareFindOrCreate: () => Promise.resolve([existingShare, false]),
+  });
+  const result = await shareService.shareTodo(fastify, todoId, sharedWithId, 'edit', ownerId);
+  assert.strictEqual(result, existingShare);
+  assert.strictEqual(result.permission, 'edit');
+});
+
+test('shareTodo: 他人の Todo に共有しようとした場合は null', async () => {
+  const fastify = createMockFastify({ TodoFindOne: () => Promise.resolve(null) });
+  const result = await shareService.shareTodo(fastify, 999, 2, 'view', 1);
+  assert.strictEqual(result, null);
+});
+
+test('shareTodo: 自分自身への共有は null', async () => {
+  const ownerId = 1;
+  const fastify = createMockFastify({
+    TodoFindOne: () => Promise.resolve({ id: 10, userId: ownerId }),
+  });
+  const result = await shareService.shareTodo(fastify, 10, ownerId, 'view', ownerId);
+  assert.strictEqual(result, null);
+});
+
+test('shareTodo: 無効な permission の場合は badRequest をスロー', async () => {
+  const ownerId = 1;
+  const fastify = createMockFastify({
+    TodoFindOne: () => Promise.resolve({ id: 10, userId: ownerId }),
+    httpErrorsBadRequest: (msg) => {
+      const err = new Error(msg);
+      err.statusCode = 400;
+      return err;
+    },
+  });
+  await assert.rejects(
+    () => shareService.shareTodo(fastify, 10, 2, 'admin', ownerId),
+    (err) => err.statusCode === 400 && /Invalid permission/.test(err.message)
+  );
+});
+
+test('canView: 所有者は常に true', async () => {
+  const userId = 1;
+  const todo = { id: 10, userId, TodoShares: [] };
+  const fastify = createMockFastify({ TodoFindOne: () => Promise.resolve(todo) });
+  const result = await shareService.canView(fastify, 10, userId);
+  assert.strictEqual(result, true);
+});
+
+test('canView: 共有先なら true、未共有なら false', async () => {
+  const ownerId = 1;
+  const viewerId = 2;
+  const todoWithShare = { id: 10, userId: ownerId, TodoShares: [{ id: 1 }] };
+  const todoNoShare = { id: 11, userId: ownerId, TodoShares: [] };
+  const fastifyShared = createMockFastify({
+    TodoFindOne: () => Promise.resolve(todoWithShare),
+  });
+  const fastifyNotShared = createMockFastify({
+    TodoFindOne: () => Promise.resolve(todoNoShare),
+  });
+  assert.strictEqual(await shareService.canView(fastifyShared, 10, viewerId), true);
+  assert.strictEqual(await shareService.canView(fastifyNotShared, 11, viewerId), false);
+});
+
+test('canView: Todo が存在しなければ false', async () => {
+  const fastify = createMockFastify({ TodoFindOne: () => Promise.resolve(null) });
+  assert.strictEqual(await shareService.canView(fastify, 999, 1), false);
+});
+
+test('canEdit: 所有者は常に true', async () => {
+  const userId = 1;
+  const todo = { id: 10, userId, TodoShares: [] };
+  const fastify = createMockFastify({ TodoFindOne: () => Promise.resolve(todo) });
+  assert.strictEqual(await shareService.canEdit(fastify, 10, userId), true);
+});
+
+test('canEdit: edit 共有先なら true、view のみなら false', async () => {
+  const ownerId = 1;
+  const userId = 2;
+  const todoWithEdit = { id: 10, userId: ownerId, TodoShares: [{ permission: 'edit' }] };
+  const todoWithViewOnly = { id: 11, userId: ownerId, TodoShares: [] };
+  const fastifyEdit = createMockFastify({ TodoFindOne: () => Promise.resolve(todoWithEdit) });
+  const fastifyView = createMockFastify({ TodoFindOne: () => Promise.resolve(todoWithViewOnly) });
+  assert.strictEqual(await shareService.canEdit(fastifyEdit, 10, userId), true);
+  assert.strictEqual(await shareService.canEdit(fastifyView, 11, userId), false);
+});
+
+test('deleteShareById: 所有者が削除すると true', async () => {
+  const ownerId = 1;
+  const shareId = 5;
+  const share = {
+    id: shareId,
+    destroy: () => Promise.resolve(),
+    Todo: { userId: ownerId },
+  };
+  const fastify = createMockFastify({
+    TodoShareFindByPk: () => Promise.resolve(share),
+  });
+  const result = await shareService.deleteShareById(fastify, shareId, ownerId);
+  assert.strictEqual(result, true);
+});
+
+test('deleteShareById: 所有者以外が削除しようとした場合は false', async () => {
+  const share = { id: 5, Todo: { userId: 1 } };
+  const fastify = createMockFastify({
+    TodoShareFindByPk: () => Promise.resolve(share),
+  });
+  const result = await shareService.deleteShareById(fastify, 5, 999);
+  assert.strictEqual(result, false);
+});
+
+test('deleteShareById: 共有が存在しない場合は false', async () => {
+  const fastify = createMockFastify({ TodoShareFindByPk: () => Promise.resolve(null) });
+  const result = await shareService.deleteShareById(fastify, 999, 1);
+  assert.strictEqual(result, false);
+});

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -10,7 +10,7 @@
 
 ### Backend タスク（15タスク）
 - [x] 11.1: TodoShare モデル作成（マイグレーション、モデル定義）
-- [ ] 11.2: ShareService 作成（共有、権限チェック、共有解除）
+- [x] 11.2: ShareService 作成（共有、権限チェック、共有解除）
 - [ ] 11.3: ShareController 作成
 - [ ] 11.4: Share ルート作成（POST /api/todos/:id/share, GET /api/todos/shared, DELETE /api/shares/:id）
 - [ ] 11.5: TodoService に共有チェック追加


### PR DESCRIPTION
## 概要
機能11 Todo 共有の 11.2（ShareService 作成）を実装しました。

## 変更内容
- **backend/services/shareService.js** を新規追加
  - `shareTodo(fastify, todoId, sharedWithUserId, permission, ownerUserId)`: Todo を他ユーザーと共有。所有者のみ実行可。既に同じユーザーへ共有済みの場合は permission を更新。
  - `canView(fastify, todoId, userId)`: 指定ユーザーが Todo を閲覧可能か（所有者または view/edit 共有先）
  - `canEdit(fastify, todoId, userId)`: 指定ユーザーが Todo を編集可能か（所有者または edit 共有先）
  - `deleteShareById(fastify, shareId, ownerUserId)`: 共有 1 件削除。Todo の所有者のみ実行可。
- **docs/TODO_FEATURE_11_20.md**: 11.2 を [x] に更新

## 確認
- `docker compose run --rm backend npm run test` 104 件すべて成功

Made with [Cursor](https://cursor.com)