### PR TITLE
feat(backend): 機能11 11.4 完了マーク・11.5 TodoService に共有チェック追加

### DIFF
--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -3,6 +3,7 @@
 const { Op } = require('sequelize');
 const tagService = require('./tagService');
 const projectService = require('./projectService');
+const shareService = require('./shareService');
 
 const SORT_BY_ALLOWED = ['dueDate', 'priority', 'createdAt', 'updatedAt', 'sortOrder'];
 const SORT_ORDER_ALLOWED = ['asc', 'desc'];
@@ -106,18 +107,22 @@ async function getTodosByProjectId(fastify, projectId, userId) {
 }
 
 /**
- * 未アーカイブの Todo を ID とユーザーで 1 件取得する（他ユーザー・アーカイブ済みは null）
- * 通常の GET/PUT/DELETE/toggle は未アーカイブのみ操作可能とする。
+ * 未アーカイブの Todo を 1 件取得する（11.5 共有対応）。
+ * 所有者または view/edit 共有先なら返す。それ以外は null。
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} userId - ユーザー ID
  * @returns {Promise<object|null>}
  */
 async function getTodoById(fastify, todoId, userId) {
-  return fastify.models.Todo.findOne({
-    where: { id: todoId, userId, archived: false },
+  const todo = await fastify.models.Todo.findOne({
+    where: { id: todoId, archived: false },
     include: buildTodoInclude(fastify),
   });
+  if (!todo) return null;
+  if (todo.userId === userId) return todo;
+  const canView = await shareService.canView(fastify, todoId, userId);
+  return canView ? todo : null;
 }
 
 /**
@@ -134,7 +139,7 @@ async function getTodoByIdIncludingArchived(fastify, todoId, userId) {
 }
 
 /**
- * Todo を更新する（所有者のみ）
+ * Todo を更新する（所有者または edit 共有先のみ）（11.5）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} userId - ユーザー ID
@@ -144,6 +149,7 @@ async function getTodoByIdIncludingArchived(fastify, todoId, userId) {
 async function updateTodo(fastify, todoId, userId, updateData) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return null;
+  if (!(await shareService.canEdit(fastify, todoId, userId))) return null;
   const { title, description, priority, dueDate, projectId } = updateData;
   const allowed = { title, description, priority, dueDate, projectId };
   Object.keys(allowed).forEach((k) => {
@@ -154,7 +160,7 @@ async function updateTodo(fastify, todoId, userId, updateData) {
 }
 
 /**
- * Todo を削除する（所有者のみ）
+ * Todo を削除する（所有者または edit 共有先のみ）（11.5）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} userId - ユーザー ID
@@ -163,12 +169,13 @@ async function updateTodo(fastify, todoId, userId, updateData) {
 async function deleteTodo(fastify, todoId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
+  if (!(await shareService.canEdit(fastify, todoId, userId))) return false;
   await todo.destroy();
   return true;
 }
 
 /**
- * 完了/未完了をトグルする（所有者のみ）
+ * 完了/未完了をトグルする（所有者または edit 共有先のみ）（11.5）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} userId - ユーザー ID
@@ -177,6 +184,7 @@ async function deleteTodo(fastify, todoId, userId) {
 async function toggleComplete(fastify, todoId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return null;
+  if (!(await shareService.canEdit(fastify, todoId, userId))) return null;
   todo.completed = !todo.completed;
   await todo.save();
   return todo;
@@ -250,7 +258,7 @@ async function searchTodos(fastify, userId, params = {}) {
 }
 
 /**
- * Todo にタグを付与する（所有者の Todo と Tag のみ、冪等）
+ * Todo にタグを付与する（所有者または edit 共有先の Todo、冪等）（11.5）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} tagId - タグ ID
@@ -260,6 +268,7 @@ async function searchTodos(fastify, userId, params = {}) {
 async function addTagToTodo(fastify, todoId, tagId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
+  if (!(await shareService.canEdit(fastify, todoId, userId))) return false;
   const tag = await tagService.getTagById(fastify, tagId, userId);
   if (!tag) return false;
   const [todoTag] = await fastify.models.TodoTag.findOrCreate({
@@ -270,7 +279,7 @@ async function addTagToTodo(fastify, todoId, tagId, userId) {
 }
 
 /**
- * Todo からタグを外す（所有者のみ）
+ * Todo からタグを外す（所有者または edit 共有先のみ）（11.5）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
  * @param {number} tagId - タグ ID
@@ -280,6 +289,7 @@ async function addTagToTodo(fastify, todoId, tagId, userId) {
 async function removeTagFromTodo(fastify, todoId, tagId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
+  if (!(await shareService.canEdit(fastify, todoId, userId))) return false;
   const tag = await tagService.getTagById(fastify, tagId, userId);
   if (!tag) return false;
   const result = await fastify.models.TodoTag.destroy({

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -149,7 +149,7 @@ async function getTodoByIdIncludingArchived(fastify, todoId, userId) {
 async function updateTodo(fastify, todoId, userId, updateData) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return null;
-  if (!(await shareService.canEdit(fastify, todoId, userId))) return null;
+  if (todo.userId !== userId && !(await shareService.canEdit(fastify, todoId, userId))) return null;
   const { title, description, priority, dueDate, projectId } = updateData;
   const allowed = { title, description, priority, dueDate, projectId };
   Object.keys(allowed).forEach((k) => {
@@ -169,7 +169,7 @@ async function updateTodo(fastify, todoId, userId, updateData) {
 async function deleteTodo(fastify, todoId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
-  if (!(await shareService.canEdit(fastify, todoId, userId))) return false;
+  if (todo.userId !== userId && !(await shareService.canEdit(fastify, todoId, userId))) return false;
   await todo.destroy();
   return true;
 }
@@ -184,7 +184,7 @@ async function deleteTodo(fastify, todoId, userId) {
 async function toggleComplete(fastify, todoId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return null;
-  if (!(await shareService.canEdit(fastify, todoId, userId))) return null;
+  if (todo.userId !== userId && !(await shareService.canEdit(fastify, todoId, userId))) return null;
   todo.completed = !todo.completed;
   await todo.save();
   return todo;
@@ -268,7 +268,7 @@ async function searchTodos(fastify, userId, params = {}) {
 async function addTagToTodo(fastify, todoId, tagId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
-  if (!(await shareService.canEdit(fastify, todoId, userId))) return false;
+  if (todo.userId !== userId && !(await shareService.canEdit(fastify, todoId, userId))) return false;
   const tag = await tagService.getTagById(fastify, tagId, userId);
   if (!tag) return false;
   const [todoTag] = await fastify.models.TodoTag.findOrCreate({
@@ -289,7 +289,7 @@ async function addTagToTodo(fastify, todoId, tagId, userId) {
 async function removeTagFromTodo(fastify, todoId, tagId, userId) {
   const todo = await getTodoById(fastify, todoId, userId);
   if (!todo) return false;
-  if (!(await shareService.canEdit(fastify, todoId, userId))) return false;
+  if (todo.userId !== userId && !(await shareService.canEdit(fastify, todoId, userId))) return false;
   const tag = await tagService.getTagById(fastify, tagId, userId);
   if (!tag) return false;
   const result = await fastify.models.TodoTag.destroy({

--- a/backend/test/routes/todos-share-access.test.js
+++ b/backend/test/routes/todos-share-access.test.js
@@ -1,0 +1,267 @@
+'use strict';
+
+/**
+ * 11.5 共有チェック: view/edit で取得・更新が制御されることを検証する。
+ */
+const crypto = require('node:crypto');
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { build } = require('../helper');
+
+function uniqueSuffix() {
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+async function setupOwnerViewEditUnshared(t, app) {
+  const suffix = uniqueSuffix();
+  const owner = { name: `tsa-owner-${suffix}`, email: `tsa-owner-${suffix}@test.local`, password: 'pass123' };
+  const viewUser = { name: `tsa-view-${suffix}`, email: `tsa-view-${suffix}@test.local`, password: 'pass123' };
+  const editUser = { name: `tsa-edit-${suffix}`, email: `tsa-edit-${suffix}@test.local`, password: 'pass123' };
+  const unshared = { name: `tsa-out-${suffix}`, email: `tsa-out-${suffix}@test.local`, password: 'pass123' };
+  for (const u of [owner, viewUser, editUser, unshared]) {
+    await app.inject({ method: 'POST', url: '/api/v1/register', payload: u });
+  }
+  const ownerLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: owner.email, password: owner.password } });
+  const ownerToken = JSON.parse(ownerLogin.payload).token;
+  const usersList = JSON.parse((await app.inject({ method: 'GET', url: '/api/v1/users', headers: { authorization: `Bearer ${ownerToken}` } })).payload);
+  const viewId = usersList.find((u) => u.email === viewUser.email).id;
+  const editId = usersList.find((u) => u.email === editUser.email).id;
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { title: 'Shared todo' },
+  });
+  assert.strictEqual(todoRes.statusCode, 201);
+  const todo = JSON.parse(todoRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/share`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { sharedWithUserId: viewId, permission: 'view' },
+  });
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/share`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { sharedWithUserId: editId, permission: 'edit' },
+  });
+  const viewLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: viewUser.email, password: viewUser.password } });
+  const editLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: editUser.email, password: editUser.password } });
+  const unsharedLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: unshared.email, password: unshared.password } });
+  return {
+    todo,
+    ownerToken,
+    viewToken: JSON.parse(viewLogin.payload).token,
+    editToken: JSON.parse(editLogin.payload).token,
+    unsharedToken: JSON.parse(unsharedLogin.payload).token,
+  };
+}
+
+test('getTodoById: view 共有先は todo を取得できる', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${viewToken}` },
+  });
+  assert.strictEqual(res.statusCode, 200);
+  const body = JSON.parse(res.payload);
+  assert.strictEqual(body.id, todo.id);
+  assert.strictEqual(body.title, 'Shared todo');
+});
+
+test('getTodoById: 未共有のユーザーは 404', async (t) => {
+  const app = await build(t);
+  const { todo, unsharedToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${unsharedToken}` },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('updateTodo: view 権限のみの共有ユーザーは 404', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${viewToken}` },
+    payload: { title: 'Updated by view' },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('updateTodo: edit 権限の共有ユーザーは更新できる', async (t) => {
+  const app = await build(t);
+  const { todo, editToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { title: 'Updated by edit' },
+  });
+  assert.strictEqual(res.statusCode, 200);
+  const body = JSON.parse(res.payload);
+  assert.strictEqual(body.title, 'Updated by edit');
+});
+
+test('deleteTodo: view 権限のみは 404', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${viewToken}` },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('deleteTodo: edit 権限の共有ユーザーは削除できる', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const owner = { name: `tsa-d-${suffix}`, email: `tsa-d-${suffix}@test.local`, password: 'pass123' };
+  const editUser = { name: `tsa-d-e-${suffix}`, email: `tsa-d-e-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: owner });
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: editUser });
+  const ownerLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: owner.email, password: owner.password } });
+  const ownerToken = JSON.parse(ownerLogin.payload).token;
+  const usersList = JSON.parse((await app.inject({ method: 'GET', url: '/api/v1/users', headers: { authorization: `Bearer ${ownerToken}` } })).payload);
+  const editId = usersList.find((u) => u.email === editUser.email).id;
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { title: 'To delete by edit' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/share`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { sharedWithUserId: editId, permission: 'edit' },
+  });
+  const editLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: editUser.email, password: editUser.password } });
+  const editToken = JSON.parse(editLogin.payload).token;
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/todos/${todo.id}`,
+    headers: { authorization: `Bearer ${editToken}` },
+  });
+  assert.strictEqual(res.statusCode, 204);
+});
+
+test('toggleComplete: view 権限のみは 404', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todo.id}/toggle`,
+    headers: { authorization: `Bearer ${viewToken}` },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('toggleComplete: edit 権限の共有ユーザーはトグルできる', async (t) => {
+  const app = await build(t);
+  const { todo, editToken } = await setupOwnerViewEditUnshared(t, app);
+  const res = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todo.id}/toggle`,
+    headers: { authorization: `Bearer ${editToken}` },
+  });
+  assert.strictEqual(res.statusCode, 200);
+  const body = JSON.parse(res.payload);
+  assert.strictEqual(body.completed, true);
+});
+
+test('addTagToTodo: view 権限のみは 404', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEditUnshared(t, app);
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${viewToken}` },
+    payload: { name: 'ViewTag' },
+  });
+  assert.strictEqual(tagRes.statusCode, 201);
+  const tag = JSON.parse(tagRes.payload);
+  const res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${viewToken}` },
+    payload: { tagId: tag.id },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('addTagToTodo: edit 権限の共有ユーザーはタグ付けできる', async (t) => {
+  const app = await build(t);
+  const { todo, editToken } = await setupOwnerViewEditUnshared(t, app);
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { name: 'EditTag' },
+  });
+  assert.strictEqual(tagRes.statusCode, 201);
+  const tag = JSON.parse(tagRes.payload);
+  const res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { tagId: tag.id },
+  });
+  assert.ok([200, 201].includes(res.statusCode));
+});
+
+test('removeTagFromTodo: view 権限のみは 404', async (t) => {
+  const app = await build(t);
+  const { todo, ownerToken, viewToken } = await setupOwnerViewEditUnshared(t, app);
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { name: 'OwnerTag' },
+  });
+  const tag = JSON.parse(tagRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { tagId: tag.id },
+  });
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/todos/${todo.id}/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${viewToken}` },
+  });
+  assert.strictEqual(res.statusCode, 404);
+});
+
+test('removeTagFromTodo: edit 権限の共有ユーザーはタグ外しできる', async (t) => {
+  const app = await build(t);
+  const { todo, editToken } = await setupOwnerViewEditUnshared(t, app);
+  const tagRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/tags',
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { name: 'EditTag2' },
+  });
+  const tag = JSON.parse(tagRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/tags`,
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { tagId: tag.id },
+  });
+  const res = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/todos/${todo.id}/tags/${tag.id}`,
+    headers: { authorization: `Bearer ${editToken}` },
+  });
+  assert.strictEqual(res.statusCode, 204);
+});

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -12,8 +12,8 @@
 - [x] 11.1: TodoShare モデル作成（マイグレーション、モデル定義）
 - [x] 11.2: ShareService 作成（共有、権限チェック、共有解除）
 - [x] 11.3: ShareController 作成
-- [ ] 11.4: Share ルート作成（POST /api/todos/:id/share, GET /api/todos/shared, DELETE /api/shares/:id）
-- [ ] 11.5: TodoService に共有チェック追加
+- [x] 11.4: Share ルート作成（POST /api/todos/:id/share, GET /api/todos/shared, DELETE /api/shares/:id）
+- [x] 11.5: TodoService に共有チェック追加
 - [ ] 11.6: Backend テスト
 
 ### Frontend タスク（10タスク）


### PR DESCRIPTION
## 概要
- 11.4 は PR#71 でルート登録済みのため TODO を [x] に更新。
- 11.5 TodoService に共有チェックを追加し、共有された Todo の取得・編集を可能にしました。

## 変更内容
- **getTodoById**: 所有者に加え、`shareService.canView` が true のユーザー（view/edit 共有先）にも Todo を返す。
- **updateTodo / deleteTodo / toggleComplete**: `shareService.canEdit` を追加。所有者または edit 共有先のみ実行可。
- **addTagToTodo / removeTagFromTodo**: 同様に canEdit チェックを追加。
- **archive / unarchive**: 従来どおり `getTodoByIdIncludingArchived`（所有者のみ）のまま。
- **docs**: 11.4, 11.5 を [x] に更新。

## 確認
- `node --test test/services/shareService.test.js` 15 件成功。

Made with [Cursor](https://cursor.com)