### PR TITLE
feat(frontend): 共有機能の型定義(11.7)

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -14,10 +14,10 @@
 - [x] 11.3: ShareController 作成
 - [x] 11.4: Share ルート作成（POST /api/todos/:id/share, GET /api/todos/shared, DELETE /api/shares/:id）
 - [x] 11.5: TodoService に共有チェック追加
-- [ ] 11.6: Backend テスト
+- [x] 11.6: Backend テスト
 
 ### Frontend タスク（10タスク）
-- [ ] 11.7: Share インターフェース定義
+- [x] 11.7: Share インターフェース定義
 - [ ] 11.8: ShareService 作成
 - [ ] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
 - [ ] 11.10: TodoItem に共有ボタン追加

--- a/frontend/src/app/models/share.interface.ts
+++ b/frontend/src/app/models/share.interface.ts
@@ -1,0 +1,20 @@
+export type SharePermission = 'view' | 'edit'
+
+/**
+ * POST /api/v1/todos/:id/share のレスポンス型
+ */
+export interface TodoShare {
+  id: number
+  todoId: number
+  sharedWithUserId: number
+  permission: SharePermission
+  createdAt: string
+}
+
+/**
+ * GET /api/v1/todos/shared のレスポンス要素
+ * Todo に共有権限を付与した型
+ */
+export type SharedTodo<TTodo> = TTodo & {
+  sharedPermission: SharePermission
+}


### PR DESCRIPTION
## Summary
- Todo共有APIのレスポンス型（`TodoShare` / `SharedTodo`）を追加
- `docs/TODO_FEATURE_11_20.md` の 11.7 を完了に更新
- 11.6（Backend テスト）は **過去PRで `backend/test/routes/shares.test.js` が追加済み**（commit: `7563e6e`）だったため、チェック漏れの是正として `[x]` に更新

## Test plan
- [ ] 型定義のみのため、既存ビルド/テストが通ることを CI で確認