### PR TITLE
feat(frontend): 検索履歴（LocalStorage）を追加

### DIFF
--- a/docs/TODO_FEATURE_02_SEARCH.md
+++ b/docs/TODO_FEATURE_02_SEARCH.md
@@ -107,9 +107,9 @@ GET /api/todos/search?q=買い物&priority=high&completed=false&tags=1,2
 
 ### Task 2.11: 検索履歴機能（オプション）
 
-- [ ] 2.11.1: LocalStorage に検索履歴保存
-- [ ] 2.11.2: 検索履歴のドロップダウン表示
-- [ ] 2.11.3: 履歴クリア機能
+- [x] 2.11.1: LocalStorage に検索履歴保存
+- [x] 2.11.2: 検索履歴のドロップダウン表示
+- [x] 2.11.3: 履歴クリア機能
 
 ### Task 2.12: スタイリング
 

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,10 +1,13 @@
 import { TestBed } from '@angular/core/testing'
+import { provideHttpClient } from '@angular/common/http'
+import { provideHttpClientTesting } from '@angular/common/http/testing'
 import { AppComponent } from './app.component'
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents()
   })
 

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.html
@@ -5,10 +5,37 @@
     class="form-control"
     placeholder="タイトル・説明で検索..."
     [formControl]="query"
+    (focus)="onFocus()"
+    (blur)="onBlur()"
   />
+  @if (history.length) {
+    <button
+      type="button"
+      class="btn btn-outline-secondary btn-sm"
+      (click)="isHistoryOpen = !isHistoryOpen"
+      aria-label="検索履歴を表示"
+    >
+      履歴
+    </button>
+  }
   @if (query.value) {
     <button type="button" class="btn btn-outline-secondary btn-sm" (click)="onClear()" aria-label="検索をクリア">
       クリア
     </button>
   }
 </div>
+
+@if (isHistoryOpen && filteredHistory.length) {
+  <div class="search-history mb-2">
+    <div class="list-group">
+      @for (item of filteredHistory; track item) {
+        <button type="button" class="list-group-item list-group-item-action" (click)="selectHistory(item)">
+          {{ item }}
+        </button>
+      }
+      <button type="button" class="list-group-item list-group-item-action text-danger" (click)="clearHistory()">
+        履歴をクリア
+      </button>
+    </div>
+  </div>
+}

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.html
@@ -8,7 +8,7 @@
     (focus)="onFocus()"
     (blur)="onBlur()"
   />
-  @if (history.length) {
+  @if (filteredHistory.length) {
     <button
       type="button"
       class="btn btn-outline-secondary btn-sm"
@@ -25,13 +25,17 @@
   }
 </div>
 
-@if (isHistoryOpen && filteredHistory.length) {
+@if (isHistoryOpen) {
   <div class="search-history mb-2">
     <div class="list-group">
-      @for (item of filteredHistory; track item) {
-        <button type="button" class="list-group-item list-group-item-action" (click)="selectHistory(item)">
-          {{ item }}
-        </button>
+      @if (filteredHistory.length) {
+        @for (item of filteredHistory; track item) {
+          <button type="button" class="list-group-item list-group-item-action" (click)="selectHistory(item)">
+            {{ item }}
+          </button>
+        }
+      } @else {
+        <div class="list-group-item text-secondary">一致する履歴がありません</div>
       }
       <button type="button" class="list-group-item list-group-item-action text-danger" (click)="clearHistory()">
         履歴をクリア

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.scss
@@ -1,3 +1,7 @@
 .search-bar input {
   max-width: 280px;
 }
+
+.search-history {
+  max-width: 360px;
+}

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
@@ -6,6 +6,7 @@ describe('SearchBarComponent (2.13.2)', () => {
   let fixture: ComponentFixture<SearchBarComponent>
 
   beforeEach(async () => {
+    localStorage.clear()
     await TestBed.configureTestingModule({
       imports: [SearchBarComponent],
     }).compileComponents()
@@ -36,6 +37,32 @@ describe('SearchBarComponent (2.13.2)', () => {
     expect(component.query.value).toBe('')
     expect(emitted).toEqual([''])
   })
+
+  it('should save search history to localStorage', fakeAsync(() => {
+    component.query.setValue('apple')
+    tick(300)
+    const raw = localStorage.getItem('todo.search.history.v1')
+    expect(raw).toBeTruthy()
+    expect(JSON.parse(raw as string)).toEqual(['apple'])
+  }))
+
+  it('should move duplicated term to top', fakeAsync(() => {
+    component.query.setValue('a')
+    tick(300)
+    component.query.setValue('b')
+    tick(300)
+    component.query.setValue('a')
+    tick(300)
+    expect(component.history).toEqual(['a', 'b'])
+  }))
+
+  it('should clear search history', fakeAsync(() => {
+    component.query.setValue('x')
+    tick(300)
+    component.clearHistory()
+    expect(component.history).toEqual([])
+    expect(localStorage.getItem('todo.search.history.v1')).toEqual('[]')
+  }))
 
   it('should not throw on destroy', () => {
     expect(() => component.ngOnDestroy()).not.toThrow()

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.spec.ts
@@ -64,6 +64,51 @@ describe('SearchBarComponent (2.13.2)', () => {
     expect(localStorage.getItem('todo.search.history.v1')).toEqual('[]')
   }))
 
+  it('should filter history by query (case-insensitive)', fakeAsync(() => {
+    component.history = ['Banana', 'Apple']
+    component.query.setValue('app', { emitEvent: false })
+    expect(component.filteredHistory).toEqual(['Apple'])
+  }))
+
+  it('should limit dropdown items to 8', fakeAsync(() => {
+    component.history = Array.from({ length: 12 }, (_, i) => `k${i}`)
+    component.query.setValue('', { emitEvent: false })
+    expect(component.filteredHistory.length).toBe(8)
+  }))
+
+  it('selectHistory should emit once and move to top', fakeAsync(() => {
+    const emitted: string[] = []
+    component.searchTerm.subscribe((v) => emitted.push(v))
+
+    component.history = ['b', 'a']
+
+    component.selectHistory('a')
+    tick(300)
+
+    expect(emitted).toEqual(['a'])
+    expect(component.history).toEqual(['a', 'b'])
+  }))
+
+  it('should open on focus and close on blur (after delay)', fakeAsync(() => {
+    component.onFocus()
+    expect(component.isHistoryOpen).toBeTrue()
+
+    component.onBlur()
+    tick(149)
+    expect(component.isHistoryOpen).toBeTrue()
+    tick(1)
+    expect(component.isHistoryOpen).toBeFalse()
+  }))
+
+  it('should clear blur timer on destroy', fakeAsync(() => {
+    component.query.setValue('x')
+    tick(300)
+    component.onBlur()
+    expect(() => component.ngOnDestroy()).not.toThrow()
+    tick(200)
+    expect(component.isHistoryOpen).toBeFalse()
+  }))
+
   it('should not throw on destroy', () => {
     expect(() => component.ngOnDestroy()).not.toThrow()
   })

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.ts
@@ -11,16 +11,27 @@ import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs'
   styleUrls: ['./search-bar.component.scss']
 })
 export class SearchBarComponent implements OnInit, OnDestroy {
+  private static readonly HISTORY_STORAGE_KEY = 'todo.search.history.v1'
+  private static readonly HISTORY_LIMIT = 10
+
   @Output() searchTerm = new EventEmitter<string>()
   @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>
 
   query = new FormControl('', { nonNullable: true })
+  history: string[] = []
+  isHistoryOpen = false
   private destroy$ = new Subject<void>()
 
   ngOnInit(): void {
+    this.loadHistory()
+
     this.query.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged(), takeUntil(this.destroy$))
-      .subscribe((value) => this.searchTerm.emit((value ?? '').trim()))
+      .subscribe((value) => {
+        const term = (value ?? '').trim()
+        this.searchTerm.emit(term)
+        if (term) this.saveHistory(term)
+      })
   }
 
   ngOnDestroy(): void {
@@ -35,5 +46,64 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 
   focus(): void {
     this.searchInputRef?.nativeElement?.focus()
+  }
+
+  onFocus(): void {
+    this.isHistoryOpen = true
+  }
+
+  onBlur(): void {
+    setTimeout(() => {
+      this.isHistoryOpen = false
+    }, 150)
+  }
+
+  get filteredHistory(): string[] {
+    const q = (this.query.value ?? '').trim().toLowerCase()
+    const list = q ? this.history.filter((h) => h.toLowerCase().includes(q)) : this.history
+    return list.slice(0, 8)
+  }
+
+  selectHistory(term: string): void {
+    this.query.setValue(term)
+    this.searchTerm.emit(term)
+    this.saveHistory(term)
+    this.isHistoryOpen = false
+  }
+
+  clearHistory(): void {
+    this.history = []
+    this.persistHistory([])
+  }
+
+  private loadHistory(): void {
+    try {
+      const raw = localStorage.getItem(SearchBarComponent.HISTORY_STORAGE_KEY)
+      if (!raw) {
+        this.history = []
+        return
+      }
+      const parsed = JSON.parse(raw)
+      this.history = Array.isArray(parsed) ? parsed.filter((v) => typeof v === 'string' && v.trim()).slice(0, SearchBarComponent.HISTORY_LIMIT) : []
+    } catch {
+      this.history = []
+    }
+  }
+
+  private saveHistory(term: string): void {
+    const normalized = term.trim()
+    if (!normalized) return
+
+    const next = [normalized, ...this.history.filter((h) => h !== normalized)].slice(0, SearchBarComponent.HISTORY_LIMIT)
+    this.history = next
+    this.persistHistory(next)
+  }
+
+  private persistHistory(items: string[]): void {
+    try {
+      localStorage.setItem(SearchBarComponent.HISTORY_STORAGE_KEY, JSON.stringify(items))
+    } catch {
+      // ignore (storage full / disabled)
+    }
   }
 }

--- a/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/search-bar/search-bar.component.ts
@@ -13,6 +13,8 @@ import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs'
 export class SearchBarComponent implements OnInit, OnDestroy {
   private static readonly HISTORY_STORAGE_KEY = 'todo.search.history.v1'
   private static readonly HISTORY_LIMIT = 10
+  private static readonly DROPDOWN_MAX_ITEMS = 8
+  private static readonly BLUR_CLOSE_DELAY_MS = 150
 
   @Output() searchTerm = new EventEmitter<string>()
   @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>
@@ -20,6 +22,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   query = new FormControl('', { nonNullable: true })
   history: string[] = []
   isHistoryOpen = false
+  private blurTimer?: ReturnType<typeof setTimeout>
   private destroy$ = new Subject<void>()
 
   ngOnInit(): void {
@@ -35,6 +38,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (this.blurTimer) clearTimeout(this.blurTimer)
     this.destroy$.next()
     this.destroy$.complete()
   }
@@ -49,23 +53,25 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   }
 
   onFocus(): void {
+    if (this.blurTimer) clearTimeout(this.blurTimer)
     this.isHistoryOpen = true
   }
 
   onBlur(): void {
-    setTimeout(() => {
+    if (this.blurTimer) clearTimeout(this.blurTimer)
+    this.blurTimer = setTimeout(() => {
       this.isHistoryOpen = false
-    }, 150)
+    }, SearchBarComponent.BLUR_CLOSE_DELAY_MS)
   }
 
   get filteredHistory(): string[] {
     const q = (this.query.value ?? '').trim().toLowerCase()
     const list = q ? this.history.filter((h) => h.toLowerCase().includes(q)) : this.history
-    return list.slice(0, 8)
+    return list.slice(0, SearchBarComponent.DROPDOWN_MAX_ITEMS)
   }
 
   selectHistory(term: string): void {
-    this.query.setValue(term)
+    this.query.setValue(term, { emitEvent: false })
     this.searchTerm.emit(term)
     this.saveHistory(term)
     this.isHistoryOpen = false
@@ -84,7 +90,11 @@ export class SearchBarComponent implements OnInit, OnDestroy {
         return
       }
       const parsed = JSON.parse(raw)
-      this.history = Array.isArray(parsed) ? parsed.filter((v) => typeof v === 'string' && v.trim()).slice(0, SearchBarComponent.HISTORY_LIMIT) : []
+      this.history = Array.isArray(parsed)
+        ? parsed
+            .filter((v): v is string => typeof v === 'string' && !!v.trim())
+            .slice(0, SearchBarComponent.HISTORY_LIMIT)
+        : []
     } catch {
       this.history = []
     }


### PR DESCRIPTION
## Summary
- SearchBar に検索履歴（LocalStorage 保存/候補表示/クリア）を追加
- テスト安定化のため AppComponent spec に HttpClientTesting を提供
- docs の 2.11.1〜2.11.3 を完了（[x]）に更新

## Test plan
- [x] docker compose run --rm frontend ng test --watch=false


Made with [Cursor](https://cursor.com)