### PR TITLE
feat(backend): 期限リマインダーのAPI基盤を追加

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -271,6 +271,30 @@ async function removeTagFromTodo(fastify, req, reply) {
   }
 }
 
+async function getDueSoonTodos(fastify, req, reply) {
+  try {
+    const todos = await todoService.getDueSoonTodos(fastify, req.user.id);
+    reply.code(200).send(todos.map((t) => t.toJSON()));
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Failed to get due soon todos');
+  }
+}
+
+async function toggleReminder(fastify, req, reply) {
+  try {
+    const todoId = parseTodoId(req.params.id);
+    if (todoId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id' });
+    }
+    const enabled = !!req.body?.enabled;
+    const todo = await todoService.toggleReminder(fastify, todoId, req.user.id, enabled);
+    if (!todo) return reply.code(404).send({ error: 'Not found' });
+    reply.code(200).send(todo.toJSON());
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Failed to toggle reminder');
+  }
+}
+
 module.exports = {
   createTodo,
   getTodos,
@@ -290,4 +314,6 @@ module.exports = {
   bulkAddTag,
   addTagToTodo,
   removeTagFromTodo,
+  getDueSoonTodos,
+  toggleReminder,
 };

--- a/backend/migrations/20260318134500-add-reminder-fields-to-todos.js
+++ b/backend/migrations/20260318134500-add-reminder-fields-to-todos.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('todos', 'reminder_enabled', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+    await queryInterface.addColumn('todos', 'reminder_sent_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addIndex('todos', ['reminder_enabled']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('todos', ['reminder_enabled']);
+    await queryInterface.removeColumn('todos', 'reminder_sent_at');
+    await queryInterface.removeColumn('todos', 'reminder_enabled');
+  }
+};
+

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -62,6 +62,17 @@ module.exports = (sequelize) => {
         allowNull: true,
         field: 'archived_at',
       },
+      reminderEnabled: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+        field: 'reminder_enabled',
+      },
+      reminderSentAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        field: 'reminder_sent_at',
+      },
       projectId: {
         type: DataTypes.INTEGER,
         allowNull: true,

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -410,6 +410,14 @@ module.exports = async function (fastify, opts) {
     handler: async (request, reply) => getArchivedTodos(fastify, request, reply),
   });
   fastify.get('/todos/due-soon', {
+    schema: {
+      response: {
+        200: {
+          type: 'array',
+          items: { type: 'object', additionalProperties: true },
+        },
+      },
+    },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getDueSoonTodos(fastify, request, reply),
   });

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -21,6 +21,8 @@ const {
   bulkAddTag,
   addTagToTodo,
   removeTagFromTodo,
+  getDueSoonTodos,
+  toggleReminder,
 } = require('../../../controllers/todoController');
 const {
   createTag,
@@ -407,6 +409,10 @@ module.exports = async function (fastify, opts) {
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getArchivedTodos(fastify, request, reply),
   });
+  fastify.get('/todos/due-soon', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getDueSoonTodos(fastify, request, reply),
+  });
   fastify.delete('/todos/archived', {
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => deleteArchivedTodos(fastify, request, reply),
@@ -588,6 +594,24 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => unarchiveTodo(fastify, request, reply),
+  });
+  fastify.patch('/todos/:id/reminder', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: { type: 'boolean' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => toggleReminder(fastify, request, reply),
   });
   fastify.post('/todos/:id/share', {
     schema: {

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -480,6 +480,66 @@ async function bulkAddTag(fastify, todoIds, tagId, userId) {
   return newIds.length;
 }
 
+/**
+ * 期限が近い Todo を取得する（24時間以内）。アーカイブ済み・完了済み・リマインダー無効は除外。
+ * @param {object} fastify
+ * @param {number} userId
+ * @returns {Promise<object[]>}
+ */
+async function getDueSoonTodos(fastify, userId) {
+  const now = new Date();
+  const limit = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const startDate = now.toISOString().slice(0, 10);
+  const endDate = limit.toISOString().slice(0, 10);
+  return fastify.models.Todo.findAll({
+    where: {
+      userId,
+      archived: false,
+      completed: false,
+      reminderEnabled: true,
+      dueDate: { [Op.between]: [startDate, endDate] },
+      // 現状は「未通知のみ」を返す（通知のスパム防止・シンプル優先）
+      reminderSentAt: { [Op.is]: null },
+    },
+    include: buildTodoInclude(fastify),
+    order: [['dueDate', 'ASC']],
+  });
+}
+
+/**
+ * リマインダーの有効/無効を切り替える（所有者のみ）
+ * @param {object} fastify
+ * @param {number} todoId
+ * @param {number} userId
+ * @param {boolean} enabled
+ * @returns {Promise<object|null>}
+ */
+async function toggleReminder(fastify, todoId, userId, enabled) {
+  const todo = await getTodoByIdIncludingArchived(fastify, todoId, userId);
+  if (!todo) return null;
+  todo.reminderEnabled = !!enabled;
+  if (!todo.reminderEnabled) {
+    todo.reminderSentAt = null;
+  }
+  await todo.save();
+  return todo;
+}
+
+/**
+ * 指定 Todo を通知済みとしてマーク（所有者のみ）
+ * @param {object} fastify
+ * @param {number} todoId
+ * @param {number} userId
+ * @returns {Promise<boolean>}
+ */
+async function markReminderSent(fastify, todoId, userId) {
+  const todo = await getTodoByIdIncludingArchived(fastify, todoId, userId);
+  if (!todo) return false;
+  todo.reminderSentAt = new Date();
+  await todo.save();
+  return true;
+}
+
 module.exports = {
   createTodo,
   getTodosByUserId,
@@ -500,4 +560,7 @@ module.exports = {
   bulkAddTag,
   addTagToTodo,
   removeTagFromTodo,
+  getDueSoonTodos,
+  toggleReminder,
+  markReminderSent,
 };

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -488,16 +488,16 @@ async function bulkAddTag(fastify, todoIds, tagId, userId) {
  */
 async function getDueSoonTodos(fastify, userId) {
   const now = new Date();
-  const limit = new Date(now.getTime() + 24 * 60 * 60 * 1000);
-  const startDate = now.toISOString().slice(0, 10);
-  const endDate = limit.toISOString().slice(0, 10);
+  const tomorrow = new Date(now);
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const endDate = tomorrow.toISOString().slice(0, 10);
   return fastify.models.Todo.findAll({
     where: {
       userId,
       archived: false,
       completed: false,
       reminderEnabled: true,
-      dueDate: { [Op.between]: [startDate, endDate] },
+      dueDate: { [Op.lte]: endDate },
       // 現状は「未通知のみ」を返す（通知のスパム防止・シンプル優先）
       reminderSentAt: { [Op.is]: null },
     },
@@ -519,6 +519,7 @@ async function toggleReminder(fastify, todoId, userId, enabled) {
   if (!todo) return null;
   todo.reminderEnabled = !!enabled;
   if (!todo.reminderEnabled) {
+    // 再有効化時に再通知が走るよう、無効化時に送信履歴をリセットする
     todo.reminderSentAt = null;
   }
   await todo.save();

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -488,8 +488,11 @@ async function bulkAddTag(fastify, todoIds, tagId, userId) {
  */
 async function getDueSoonTodos(fastify, userId) {
   const now = new Date();
+  const yesterday = new Date(now);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
   const tomorrow = new Date(now);
   tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const startDate = yesterday.toISOString().slice(0, 10);
   const endDate = tomorrow.toISOString().slice(0, 10);
   return fastify.models.Todo.findAll({
     where: {
@@ -497,7 +500,8 @@ async function getDueSoonTodos(fastify, userId) {
       archived: false,
       completed: false,
       reminderEnabled: true,
-      dueDate: { [Op.lte]: endDate },
+      // 「昨日〜明日」の範囲でタイムゾーン差を吸収する（最大 ±14h 程度）意図
+      dueDate: { [Op.between]: [startDate, endDate] },
       // 現状は「未通知のみ」を返す（通知のスパム防止・シンプル優先）
       reminderSentAt: { [Op.is]: null },
     },

--- a/backend/test/routes/todos-reminder.test.js
+++ b/backend/test/routes/todos-reminder.test.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const crypto = require('node:crypto')
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { build } = require('../helper')
+
+function uniqueSuffix() {
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`
+}
+
+function ymd(d) {
+  return d.toISOString().slice(0, 10)
+}
+
+async function registerAndLogin(app, suffix) {
+  const user = { name: `rem-${suffix}`, email: `rem-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/login',
+    payload: { email: user.email, password: user.password }
+  })
+  return JSON.parse(loginRes.payload).token
+}
+
+test('GET /api/v1/todos/due-soon without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({ method: 'GET', url: '/api/v1/todos/due-soon' })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('PATCH /api/v1/todos/:id/reminder without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'PATCH',
+    url: '/api/v1/todos/1/reminder',
+    payload: { enabled: false }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
+test('GET /api/v1/todos/due-soon returns only due soon & reminder enabled todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const token = await registerAndLogin(app, suffix)
+
+  const today = new Date()
+  const in3days = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
+
+  const todoSoonRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'due today', dueDate: ymd(today) }
+  })
+  assert.strictEqual(todoSoonRes.statusCode, 201)
+  const todoSoon = JSON.parse(todoSoonRes.payload)
+
+  const todoLaterRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'due later', dueDate: ymd(in3days) }
+  })
+  assert.strictEqual(todoLaterRes.statusCode, 201)
+
+  const dueRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/due-soon',
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(dueRes.statusCode, 200)
+  const list = JSON.parse(dueRes.payload)
+  assert(Array.isArray(list))
+  assert(list.some((t) => t.id === todoSoon.id))
+  assert(list.every((t) => t.title !== 'due later'))
+
+  // disable reminder -> should be excluded
+  const disableRes = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoSoon.id}/reminder`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { enabled: false }
+  })
+  assert.strictEqual(disableRes.statusCode, 200)
+  const updated = JSON.parse(disableRes.payload)
+  assert.strictEqual(updated.reminderEnabled, false)
+
+  const dueRes2 = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/due-soon',
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(dueRes2.statusCode, 200)
+  const list2 = JSON.parse(dueRes2.payload)
+  assert(list2.every((t) => t.id !== todoSoon.id))
+})
+

--- a/backend/test/routes/todos-reminder.test.js
+++ b/backend/test/routes/todos-reminder.test.js
@@ -191,3 +191,28 @@ test('GET /api/v1/todos/due-soon excludes archived and completed todos', async (
   assert(list.every((t) => t.id !== todoArchived.id))
 })
 
+test('GET /api/v1/todos/due-soon excludes far past due todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const token = await registerAndLogin(app, suffix)
+
+  const farPast = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+  const farPastRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'far past', dueDate: ymd(farPast) }
+  })
+  assert.strictEqual(farPastRes.statusCode, 201)
+  const farPastTodo = JSON.parse(farPastRes.payload)
+
+  const dueRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/due-soon',
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(dueRes.statusCode, 200)
+  const list = JSON.parse(dueRes.payload)
+  assert(list.every((t) => t.id !== farPastTodo.id))
+})
+

--- a/backend/test/routes/todos-reminder.test.js
+++ b/backend/test/routes/todos-reminder.test.js
@@ -45,14 +45,14 @@ test('GET /api/v1/todos/due-soon returns only due soon & reminder enabled todos'
   const suffix = uniqueSuffix()
   const token = await registerAndLogin(app, suffix)
 
-  const today = new Date()
+  const now = new Date()
   const in3days = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
 
   const todoSoonRes = await app.inject({
     method: 'POST',
     url: '/api/v1/todos',
     headers: { authorization: `Bearer ${token}` },
-    payload: { title: 'due today', dueDate: ymd(today) }
+    payload: { title: 'due today', dueDate: ymd(now) }
   })
   assert.strictEqual(todoSoonRes.statusCode, 201)
   const todoSoon = JSON.parse(todoSoonRes.payload)
@@ -95,5 +95,99 @@ test('GET /api/v1/todos/due-soon returns only due soon & reminder enabled todos'
   assert.strictEqual(dueRes2.statusCode, 200)
   const list2 = JSON.parse(dueRes2.payload)
   assert(list2.every((t) => t.id !== todoSoon.id))
+})
+
+test('PATCH /api/v1/todos/:id/reminder for missing todo returns 404', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const token = await registerAndLogin(app, suffix)
+
+  const res = await app.inject({
+    method: 'PATCH',
+    url: '/api/v1/todos/999999/reminder',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { enabled: false }
+  })
+  assert.strictEqual(res.statusCode, 404)
+})
+
+test('PATCH /api/v1/todos/:id/reminder cannot update other user todo (404)', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const owner = { name: `rmo-${suffix}`, email: `rmo-${suffix}@test.local`, password: 'pass123' }
+  const other = { name: `rmb-${suffix}`, email: `rmb-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: owner })
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: other })
+  const ownerLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: owner.email, password: owner.password } })
+  const otherLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: other.email, password: other.password } })
+  const ownerToken = JSON.parse(ownerLogin.payload).token
+  const otherToken = JSON.parse(otherLogin.payload).token
+
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { title: 'owner todo', dueDate: ymd(new Date()) }
+  })
+  assert.strictEqual(todoRes.statusCode, 201)
+  const todo = JSON.parse(todoRes.payload)
+
+  const res = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todo.id}/reminder`,
+    headers: { authorization: `Bearer ${otherToken}` },
+    payload: { enabled: false }
+  })
+  assert.strictEqual(res.statusCode, 404)
+})
+
+test('GET /api/v1/todos/due-soon excludes archived and completed todos', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const token = await registerAndLogin(app, suffix)
+
+  const due = ymd(new Date())
+
+  const todoActive = JSON.parse((await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'active', dueDate: due }
+  })).payload)
+
+  const todoDone = JSON.parse((await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'done', dueDate: due }
+  })).payload)
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoDone.id}/toggle`,
+    headers: { authorization: `Bearer ${token}` },
+  })
+
+  const todoArchived = JSON.parse((await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'archived', dueDate: due }
+  })).payload)
+  await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${todoArchived.id}/archive`,
+    headers: { authorization: `Bearer ${token}` },
+  })
+
+  const dueRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/due-soon',
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(dueRes.statusCode, 200)
+  const list = JSON.parse(dueRes.payload)
+  assert(list.some((t) => t.id === todoActive.id))
+  assert(list.every((t) => t.id !== todoDone.id))
+  assert(list.every((t) => t.id !== todoArchived.id))
 })
 

--- a/docs/TODO_FEATURE_04_REMINDER.md
+++ b/docs/TODO_FEATURE_04_REMINDER.md
@@ -32,35 +32,35 @@ PATCH /api/todos/:id/reminder
 
 ### Task 4.1: リマインダーカラム追加
 
-- [ ] 4.1.1: マイグレーション生成 `add-reminder-fields-to-todos`
-- [ ] 4.1.2: reminderEnabled, reminderSentAt カラム追加
+- [x] 4.1.1: マイグレーション生成 `add-reminder-fields-to-todos`
+- [x] 4.1.2: reminderEnabled, reminderSentAt カラム追加
 - [ ] 4.1.3: マイグレーション実行
 
 ### Task 4.2: Todo モデル更新
 
-- [ ] 4.2.1: reminderEnabled, reminderSentAt フィールド追加
+- [x] 4.2.1: reminderEnabled, reminderSentAt フィールド追加
 
 ### Task 4.3: TodoService にリマインダー機能追加
 
-- [ ] 4.3.1: `getDueSoonTodos(userId)` 実装（24時間以内の期限）
-- [ ] 4.3.2: `toggleReminder(todoId, userId, enabled)` 実装
-- [ ] 4.3.3: `markReminderSent(todoId)` 実装
+- [x] 4.3.1: `getDueSoonTodos(userId)` 実装（24時間以内の期限）
+- [x] 4.3.2: `toggleReminder(todoId, userId, enabled)` 実装
+- [x] 4.3.3: `markReminderSent(todoId)` 実装
 
 ### Task 4.4: TodoController にリマインダー機能追加
 
-- [ ] 4.4.1: `getDueSoonTodos` ハンドラ実装
-- [ ] 4.4.2: `toggleReminder` ハンドラ実装
+- [x] 4.4.1: `getDueSoonTodos` ハンドラ実装
+- [x] 4.4.2: `toggleReminder` ハンドラ実装
 
 ### Task 4.5: Todo ルート更新
 
-- [ ] 4.5.1: GET /api/todos/due-soon のルート定義
-- [ ] 4.5.2: PATCH /api/todos/:id/reminder のルート定義
-- [ ] 4.5.3: JSON Schema 定義
+- [x] 4.5.1: GET /api/todos/due-soon のルート定義
+- [x] 4.5.2: PATCH /api/todos/:id/reminder のルート定義
+- [x] 4.5.3: JSON Schema 定義
 
 ### Task 4.6: Backend テスト
 
 - [ ] 4.6.1: TodoService リマインダー機能のテスト
-- [ ] 4.6.2: リマインダー API のテスト
+- [x] 4.6.2: リマインダー API のテスト
 
 ---
 


### PR DESCRIPTION
## Summary
- todos に reminderEnabled/reminderSentAt を追加（マイグレーション + モデル更新）
- due-soon API（GET /api/v1/todos/due-soon）を追加
- リマインダーON/OFF API（PATCH /api/v1/todos/:id/reminder）を追加
- docs の TODO(4.1/4.2/4.3/4.4/4.5/4.6.2) を更新

## Test plan
- [x] docker compose run --rm backend npx sequelize-cli db:migrate --env test
- [x] docker compose run --rm backend node --test test/routes/todos-reminder.test.js


Made with [Cursor](https://cursor.com)