### PR TITLE
feat(frontend): リマインダー通知のサービス基盤を追加

### DIFF
--- a/docs/TODO_FEATURE_04_REMINDER.md
+++ b/docs/TODO_FEATURE_04_REMINDER.md
@@ -68,22 +68,22 @@ PATCH /api/todos/:id/reminder
 
 ### Task 4.7: TodoService にリマインダー機能追加
 
-- [ ] 4.7.1: `getDueSoonTodos(): Observable<Todo[]>` 実装
-- [ ] 4.7.2: `toggleReminder(id: number, enabled: boolean): Observable<Todo>` 実装
+- [x] 4.7.1: `getDueSoonTodos(): Observable<Todo[]>` 実装
+- [x] 4.7.2: `toggleReminder(id: number, enabled: boolean): Observable<Todo>` 実装
 
 ### Task 4.8: NotificationService 作成
 
-- [ ] 4.8.1: `frontend/src/app/services/notification.service.ts` 作成
-- [ ] 4.8.2: ブラウザ通知権限リクエスト実装
-- [ ] 4.8.3: `showNotification(title, body, data)` 実装
-- [ ] 4.8.4: 通知クリック時の処理実装
+- [x] 4.8.1: `frontend/src/app/services/notification.service.ts` 作成
+- [x] 4.8.2: ブラウザ通知権限リクエスト実装
+- [x] 4.8.3: `showNotification(title, body, data)` 実装
+- [x] 4.8.4: 通知クリック時の処理実装
 
 ### Task 4.9: ReminderService 作成
 
-- [ ] 4.9.1: `frontend/src/app/services/reminder.service.ts` 作成
-- [ ] 4.9.2: 定期チェック処理実装（5分ごと）
-- [ ] 4.9.3: 期限が近い Todo の通知送信
-- [ ] 4.9.4: 通知済みフラグ管理（LocalStorage）
+- [x] 4.9.1: `frontend/src/app/services/reminder.service.ts` 作成
+- [x] 4.9.2: 定期チェック処理実装（5分ごと）
+- [x] 4.9.3: 期限が近い Todo の通知送信
+- [x] 4.9.4: 通知済みフラグ管理（LocalStorage）
 
 ### Task 4.10: TodoItem にリマインダー切り替え追加
 
@@ -110,8 +110,8 @@ PATCH /api/todos/:id/reminder
 
 ### Task 4.14: Frontend テスト
 
-- [ ] 4.14.1: NotificationService のテスト
-- [ ] 4.14.2: ReminderService のテスト
+- [x] 4.14.1: NotificationService のテスト
+- [x] 4.14.2: ReminderService のテスト
 - [ ] 4.14.3: ReminderSettings コンポーネントテスト
 
 ---

--- a/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/archived-todos/archived-todos-page.component.spec.ts
@@ -18,6 +18,8 @@ const mockArchivedTodos: Todo[] = [
     projectId: null,
     archived: true,
     archivedAt: '2026-03-01T12:00:00.000Z',
+    reminderEnabled: true,
+    reminderSentAt: null,
     createdAt: '2026-03-01T10:00:00.000Z',
     updatedAt: '2026-03-01T12:00:00.000Z',
     Tags: [],

--- a/frontend/src/app/components/pages/dashboard/templates/templates-page/templates-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/templates/templates-page/templates-page.component.spec.ts
@@ -167,6 +167,8 @@ describe('TemplatesPageComponent (14.12)', () => {
         projectId: null,
         archived: false,
         archivedAt: null,
+        reminderEnabled: true,
+        reminderSentAt: null,
         createdAt: '',
         updatedAt: '',
       })

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
@@ -14,6 +14,8 @@ const mockTodo: Todo = {
   projectId: null,
   archived: false,
   archivedAt: null,
+  reminderEnabled: true,
+  reminderSentAt: null,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   Tags: [],

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
@@ -5,9 +5,9 @@ import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 
 const mockTodos: Todo[] = [
-  { id: 1, userId: 1, title: 'A', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
-  { id: 2, userId: 1, title: 'B', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 1, projectId: null, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
-  { id: 3, userId: 1, title: 'C', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 2, projectId: null, archived: false, archivedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 1, userId: 1, title: 'A', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 2, userId: 1, title: 'B', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 1, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
+  { id: 3, userId: 1, title: 'C', description: '', completed: false, priority: 'medium', dueDate: null, sortOrder: 2, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), Tags: [] },
 ]
 
 describe('TodoListComponent (3.13.3)', () => {

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -21,6 +21,8 @@ export interface Todo {
   projectId: number | null
   archived: boolean
   archivedAt: string | null
+  reminderEnabled?: boolean
+  reminderSentAt?: string | null
   createdAt: string
   updatedAt: string
   Tags?: Tag[]

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -21,8 +21,8 @@ export interface Todo {
   projectId: number | null
   archived: boolean
   archivedAt: string | null
-  reminderEnabled?: boolean
-  reminderSentAt?: string | null
+  reminderEnabled: boolean
+  reminderSentAt: string | null
   createdAt: string
   updatedAt: string
   Tags?: Tag[]

--- a/frontend/src/app/services/notification.service.spec.ts
+++ b/frontend/src/app/services/notification.service.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing'
+import { provideRouter } from '@angular/router'
+import { NotificationService } from './notification.service'
+
+describe('NotificationService (4.14.1)', () => {
+  let service: NotificationService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideRouter([])],
+    })
+    service = TestBed.inject(NotificationService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should not throw when Notification API is not available', () => {
+    const original = (globalThis as any).Notification
+    ;(globalThis as any).Notification = undefined
+    expect(() => service.showNotification('t', 'b')).not.toThrow()
+    ;(globalThis as any).Notification = original
+  })
+})
+

--- a/frontend/src/app/services/notification.service.spec.ts
+++ b/frontend/src/app/services/notification.service.spec.ts
@@ -12,15 +12,79 @@ describe('NotificationService (4.14.1)', () => {
     service = TestBed.inject(NotificationService)
   })
 
+  afterEach(() => {
+    // restore global Notification if tests replaced it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = globalThis as any
+    if (g.__originalNotification__ !== undefined) {
+      g.Notification = g.__originalNotification__
+      delete g.__originalNotification__
+    }
+  })
+
   it('should be created', () => {
     expect(service).toBeTruthy()
   })
 
   it('should not throw when Notification API is not available', () => {
-    const original = (globalThis as any).Notification
-    ;(globalThis as any).Notification = undefined
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = globalThis as any
+    g.__originalNotification__ = g.Notification
+    g.Notification = undefined
     expect(() => service.showNotification('t', 'b')).not.toThrow()
-    ;(globalThis as any).Notification = original
+  })
+
+  it('requestPermission should return denied when Notification API is not available', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = globalThis as any
+    g.__originalNotification__ = g.Notification
+    g.Notification = undefined
+    await expectAsync(service.requestPermission()).toBeResolvedTo('denied')
+  })
+
+  it('requestPermission should return current permission when not default', async () => {
+    class FakeNotification {
+      static permission: NotificationPermission = 'granted'
+      static requestPermission = jasmine.createSpy('requestPermission')
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = globalThis as any
+    g.__originalNotification__ = g.Notification
+    g.Notification = FakeNotification as any
+
+    await expectAsync(service.requestPermission()).toBeResolvedTo('granted')
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('requestPermission should call requestPermission when default', async () => {
+    class FakeNotification {
+      static permission: NotificationPermission = 'default'
+      static requestPermission = jasmine
+        .createSpy('requestPermission')
+        .and.resolveTo('denied' as NotificationPermission)
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = globalThis as any
+    g.__originalNotification__ = g.Notification
+    g.Notification = FakeNotification as any
+
+    await expectAsync(service.requestPermission()).toBeResolvedTo('denied')
+    expect(FakeNotification.requestPermission).toHaveBeenCalled()
+  })
+
+  it('showNotification should not create notification when permission is not granted', () => {
+    class FakeNotification {
+      static permission: NotificationPermission = 'denied'
+      constructor() {
+        throw new Error('should not be instantiated')
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = globalThis as any
+    g.__originalNotification__ = g.Notification
+    g.Notification = FakeNotification as any
+
+    expect(() => service.showNotification('t', 'b')).not.toThrow()
   })
 })
 

--- a/frontend/src/app/services/notification.service.ts
+++ b/frontend/src/app/services/notification.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core'
+import { Router } from '@angular/router'
+
+export interface AppNotificationData {
+  url?: string
+  todoId?: number
+}
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  constructor(private router: Router) {}
+
+  async requestPermission(): Promise<NotificationPermission> {
+    const N = (globalThis as any).Notification as typeof Notification | undefined
+    if (!N) return 'denied'
+    if (N.permission !== 'default') return N.permission
+    return await N.requestPermission()
+  }
+
+  showNotification(title: string, body: string, data?: AppNotificationData): void {
+    const N = (globalThis as any).Notification as typeof Notification | undefined
+    if (!N) return
+    if (N.permission !== 'granted') return
+
+    const n = new N(title, { body, data })
+    n.onclick = () => {
+      const url = data?.url
+      if (url) {
+        this.router.navigateByUrl(url).catch(() => {})
+      }
+      n.close()
+    }
+  }
+}
+

--- a/frontend/src/app/services/offline-storage.service.spec.ts
+++ b/frontend/src/app/services/offline-storage.service.spec.ts
@@ -16,6 +16,8 @@ const mockTodos: Todo[] = [
     projectId: null,
     archived: false,
     archivedAt: null,
+    reminderEnabled: true,
+    reminderSentAt: null,
     createdAt: '',
     updatedAt: ''
   }

--- a/frontend/src/app/services/reminder.service.spec.ts
+++ b/frontend/src/app/services/reminder.service.spec.ts
@@ -31,8 +31,8 @@ describe('ReminderService (4.14.2)', () => {
 
   it('start should poll and notify once per todoId', fakeAsync(() => {
     const todos: Todo[] = [
-      { id: 1, userId: 1, title: 'A', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, createdAt: '', updatedAt: '' },
-      { id: 2, userId: 1, title: 'B', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, createdAt: '', updatedAt: '' },
+      { id: 1, userId: 1, title: 'A', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: '', updatedAt: '' },
+      { id: 2, userId: 1, title: 'B', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: '', updatedAt: '' },
     ]
     todoService.getDueSoonTodos.and.returnValue(of(todos))
 
@@ -53,6 +53,32 @@ describe('ReminderService (4.14.2)', () => {
     tick(0)
     expect(notification.showNotification).not.toHaveBeenCalled()
     service.stop()
+  }))
+
+  it('start should continue polling after error', fakeAsync(() => {
+    const todos: Todo[] = [
+      { id: 1, userId: 1, title: 'A', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: '', updatedAt: '' },
+    ]
+    todoService.getDueSoonTodos.and.returnValues(
+      throwError(() => new Error('first fail')),
+      of(todos)
+    )
+
+    service.start()
+    tick(0)
+    expect(notification.showNotification).not.toHaveBeenCalled()
+    tick(5 * 60 * 1000)
+    expect(notification.showNotification).toHaveBeenCalled()
+    service.stop()
+  }))
+
+  it('stop should set running$ false', fakeAsync(() => {
+    todoService.getDueSoonTodos.and.returnValue(of([]))
+    service.start()
+    tick(0)
+    expect(service.running$.value).toBeTrue()
+    service.stop()
+    expect(service.running$.value).toBeFalse()
   }))
 })
 

--- a/frontend/src/app/services/reminder.service.spec.ts
+++ b/frontend/src/app/services/reminder.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing'
+import { of, throwError } from 'rxjs'
+import { ReminderService } from './reminder.service'
+import { TodoService } from './todo.service'
+import { NotificationService } from './notification.service'
+import type { Todo } from '../models/todo.interface'
+
+describe('ReminderService (4.14.2)', () => {
+  let service: ReminderService
+  let todoService: jasmine.SpyObj<TodoService>
+  let notification: jasmine.SpyObj<NotificationService>
+
+  beforeEach(() => {
+    localStorage.clear()
+    todoService = jasmine.createSpyObj('TodoService', ['getDueSoonTodos'])
+    notification = jasmine.createSpyObj('NotificationService', ['showNotification'])
+
+    TestBed.configureTestingModule({
+      providers: [
+        ReminderService,
+        { provide: TodoService, useValue: todoService },
+        { provide: NotificationService, useValue: notification },
+      ]
+    })
+    service = TestBed.inject(ReminderService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('start should poll and notify once per todoId', fakeAsync(() => {
+    const todos: Todo[] = [
+      { id: 1, userId: 1, title: 'A', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, createdAt: '', updatedAt: '' },
+      { id: 2, userId: 1, title: 'B', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, createdAt: '', updatedAt: '' },
+    ]
+    todoService.getDueSoonTodos.and.returnValue(of(todos))
+
+    service.start()
+    tick(0)
+    expect(notification.showNotification).toHaveBeenCalledTimes(2)
+
+    // second tick returns same todos -> no extra notifications
+    tick(5 * 60 * 1000)
+    expect(notification.showNotification).toHaveBeenCalledTimes(2)
+
+    service.stop()
+  }))
+
+  it('start should not throw when API errors', fakeAsync(() => {
+    todoService.getDueSoonTodos.and.returnValue(throwError(() => new Error('x')))
+    expect(() => service.start()).not.toThrow()
+    tick(0)
+    expect(notification.showNotification).not.toHaveBeenCalled()
+    service.stop()
+  }))
+})
+

--- a/frontend/src/app/services/reminder.service.ts
+++ b/frontend/src/app/services/reminder.service.ts
@@ -24,10 +24,11 @@ export class ReminderService {
 
     this.sub = timer(0, this.intervalMs)
       .pipe(
-        switchMap(() => this.todoService.getDueSoonTodos()),
-        catchError(() => {
-          return of([] as Todo[])
-        })
+        switchMap(() =>
+          this.todoService.getDueSoonTodos().pipe(
+            catchError(() => of([] as Todo[]))
+          )
+        )
       )
       .subscribe((todos) => this.handleDueSoon(todos))
   }
@@ -40,7 +41,8 @@ export class ReminderService {
 
   private handleDueSoon(todos: Todo[]): void {
     if (!todos.length) return
-    const notified = this.loadNotified()
+    const currentIds = new Set(todos.map((t) => t.id).filter((id) => Number.isInteger(id)))
+    const notified = new Set([...this.loadNotified()].filter((id) => currentIds.has(id)))
 
     for (const t of todos) {
       if (!t?.id) continue

--- a/frontend/src/app/services/reminder.service.ts
+++ b/frontend/src/app/services/reminder.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core'
+import { BehaviorSubject, Subscription, timer, of } from 'rxjs'
+import { switchMap, catchError } from 'rxjs/operators'
+import { TodoService } from './todo.service'
+import { NotificationService } from './notification.service'
+import type { Todo } from '../models/todo.interface'
+
+@Injectable({ providedIn: 'root' })
+export class ReminderService {
+  private sub?: Subscription
+  private readonly intervalMs = 5 * 60 * 1000
+  private readonly notifiedKey = 'todo.reminder.notified.v1'
+
+  readonly running$ = new BehaviorSubject<boolean>(false)
+
+  constructor(
+    private todoService: TodoService,
+    private notificationService: NotificationService
+  ) {}
+
+  start(): void {
+    if (this.sub) return
+    this.running$.next(true)
+
+    this.sub = timer(0, this.intervalMs)
+      .pipe(
+        switchMap(() => this.todoService.getDueSoonTodos()),
+        catchError(() => {
+          return of([] as Todo[])
+        })
+      )
+      .subscribe((todos) => this.handleDueSoon(todos))
+  }
+
+  stop(): void {
+    this.sub?.unsubscribe()
+    this.sub = undefined
+    this.running$.next(false)
+  }
+
+  private handleDueSoon(todos: Todo[]): void {
+    if (!todos.length) return
+    const notified = this.loadNotified()
+
+    for (const t of todos) {
+      if (!t?.id) continue
+      if (notified.has(t.id)) continue
+      const title = '期限が近い Todo'
+      const body = t.title
+      this.notificationService.showNotification(title, body, { url: '/dashboard/todo', todoId: t.id })
+      notified.add(t.id)
+    }
+
+    this.saveNotified(notified)
+  }
+
+  private loadNotified(): Set<number> {
+    try {
+      const raw = localStorage.getItem(this.notifiedKey)
+      if (!raw) return new Set<number>()
+      const parsed = JSON.parse(raw)
+      if (!Array.isArray(parsed)) return new Set<number>()
+      return new Set<number>(parsed.filter((v) => Number.isInteger(v)))
+    } catch {
+      return new Set<number>()
+    }
+  }
+
+  private saveNotified(set: Set<number>): void {
+    try {
+      localStorage.setItem(this.notifiedKey, JSON.stringify(Array.from(set)))
+    } catch {
+      // ignore
+    }
+  }
+}
+

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -180,6 +180,22 @@ describe('TodoService', () => {
     })
   })
 
+  describe('reminder (4.7)', () => {
+    it('should call GET /todos/due-soon for getDueSoonTodos', () => {
+      service.getDueSoonTodos().subscribe((list) => expect(list).toEqual([]))
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/due-soon` && r.method === 'GET')
+      req.flush([])
+    })
+
+    it('should call PATCH /todos/:id/reminder with enabled for toggleReminder', () => {
+      const id = 10
+      service.toggleReminder(id, false).subscribe()
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${id}/reminder` && r.method === 'PATCH')
+      expect(req.request.body).toEqual({ enabled: false })
+      req.flush({ id, reminderEnabled: false })
+    })
+  })
+
   describe('bulk (15.17)', () => {
     it('should call POST /todos/bulk-complete with todoIds in body', () => {
       const todoIds = [1, 2, 3]

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -20,6 +20,8 @@ const mockTodo: Todo = {
   projectId: null,
   archived: false,
   archivedAt: null,
+  reminderEnabled: true,
+  reminderSentAt: null,
   createdAt: '',
   updatedAt: ''
 }
@@ -155,7 +157,7 @@ describe('TodoService', () => {
       service.search(params).subscribe((list) => expect(list.length).toBe(1))
       const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/search` && r.method === 'GET')
       expect(req.request.params.get('q')).toBe('買い物')
-      req.flush([{ id: 1, userId: 1, title: '買い物', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, archived: false, archivedAt: null, createdAt: '', updatedAt: '' }])
+      req.flush([{ id: 1, userId: 1, title: '買い物', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: '', updatedAt: '' }])
     })
 
     it('should send completed, priority, tags and sort params when provided', () => {

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -72,6 +72,14 @@ export class TodoService {
     return this.http.patch<Todo>(`${this.apiUrl}/todos/${id}/toggle`, {})
   }
 
+  getDueSoonTodos(): Observable<Todo[]> {
+    return this.http.get<Todo[]>(`${this.apiUrl}/todos/due-soon`)
+  }
+
+  toggleReminder(id: number, enabled: boolean): Observable<Todo> {
+    return this.http.patch<Todo>(`${this.apiUrl}/todos/${id}/reminder`, { enabled })
+  }
+
   /**
    * タイトル・説明で検索（q 必須。completed, priority, sort で絞り込み・ソート可）
    */


### PR DESCRIPTION
## Summary
- TodoService に due-soon 取得/リマインダーON-OFF API を追加（4.7）
- NotificationService / ReminderService を追加（権限リクエスト、定期チェック、通知済み管理）（4.8/4.9）
- テスト追加（4.14.1/4.14.2）
- docs の進捗更新（4.7/4.8/4.9/4.14.1/4.14.2 → [x]）

## Test plan
- [x] docker compose run --rm frontend ng test --watch=false


Made with [Cursor](https://cursor.com)