### PR TITLE
feat(frontend): リマインダーのUIトグルとログイン連動

### DIFF
--- a/docs/TODO_FEATURE_04_REMINDER.md
+++ b/docs/TODO_FEATURE_04_REMINDER.md
@@ -87,8 +87,8 @@ PATCH /api/todos/:id/reminder
 
 ### Task 4.10: TodoItem にリマインダー切り替え追加
 
-- [ ] 4.10.1: リマインダー ON/OFF トグルボタン追加
-- [ ] 4.10.2: @Output() reminderToggled 実装
+- [x] 4.10.1: リマインダー ON/OFF トグルボタン追加
+- [x] 4.10.2: @Output() reminderToggled 実装
 
 ### Task 4.11: ReminderSettings コンポーネント作成
 
@@ -99,9 +99,9 @@ PATCH /api/todos/:id/reminder
 
 ### Task 4.12: App 初期化時にリマインダー開始
 
-- [ ] 4.12.1: AppComponent で ReminderService 初期化
-- [ ] 4.12.2: ログイン時にリマインダー開始
-- [ ] 4.12.3: ログアウト時にリマインダー停止
+- [x] 4.12.1: AppComponent で ReminderService 初期化
+- [x] 4.12.2: ログイン時にリマインダー開始
+- [x] 4.12.3: ログアウト時にリマインダー停止
 
 ### Task 4.13: スタイリング
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router'
 import { MatDialog } from '@angular/material/dialog'
+import { Subject, filter, takeUntil } from 'rxjs'
 import { SharedModule } from './theme/shared/shared.module'
 import { ThemeService } from './services/theme.service'
 import { KeyboardShortcutService } from './services/keyboard-shortcut.service'
 import { SyncService } from './services/sync.service'
 import { ShortcutHelpDialogComponent } from './components/pages/dashboard/todo/shortcut-help-dialog/shortcut-help-dialog.component'
+import { AuthService } from './services/auth.service'
+import { ReminderService } from './services/reminder.service'
 
 @Component({
   selector: 'app-root',
@@ -19,23 +22,34 @@ import { ShortcutHelpDialogComponent } from './components/pages/dashboard/todo/s
 })
 export class AppComponent implements OnInit, OnDestroy {
   title = 'Node App Frontend'
+  private destroy$ = new Subject<void>()
 
   constructor(
     private router: Router,
     private themeService: ThemeService,
     private shortcutService: KeyboardShortcutService,
     private dialog: MatDialog,
-    private syncService: SyncService
+    private syncService: SyncService,
+    private authService: AuthService,
+    private reminderService: ReminderService
   ) {}
 
   ngOnInit() {
     this.themeService.init()
-    this.router.events.subscribe((evt) => {
-      if (!(evt instanceof NavigationEnd)) {
-        return
-      }
-      window.scrollTo(0, 0)
-    })
+    this.router.events
+      .pipe(
+        filter((evt): evt is NavigationEnd => evt instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => window.scrollTo(0, 0))
+
+    this.authService.authState$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((authed) => {
+        if (authed) this.reminderService.start()
+        else this.reminderService.stop()
+      })
+
     this.shortcutService.register('Shift+?', () => {
       this.dialog.open(ShortcutHelpDialogComponent, { width: '400px' })
     }, 'ショートカット一覧を表示')
@@ -43,5 +57,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.shortcutService.unregister('Shift+?')
+    this.destroy$.next()
+    this.destroy$.complete()
   }
 }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -53,6 +53,17 @@
     @if (todo.completed) {
       <button type="button" class="btn btn-outline-secondary" (click)="onArchive()" title="アーカイブ">アーカイブ</button>
     }
+    <button
+      type="button"
+      class="btn"
+      [class.btn-outline-warning]="todo.reminderEnabled"
+      [class.btn-outline-secondary]="!todo.reminderEnabled"
+      (click)="onToggleReminder()"
+      [attr.aria-label]="'リマインダー切り替え: ' + todo.title"
+      title="リマインダー"
+    >
+      @if (todo.reminderEnabled) { リマインダーON } @else { リマインダーOFF }
+    </button>
     <button type="button" class="btn btn-outline-primary" (click)="onEdit()">編集</button>
     <button type="button" class="btn btn-outline-danger" (click)="onDelete()">削除</button>
   </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { TodoItemComponent } from './todo-item.component'
+import type { ReminderToggleEvent } from './todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
 
 const mockTodo: Todo = {
@@ -65,6 +66,26 @@ describe('TodoItemComponent (2.12.2)', () => {
   it('should not throw on special regex chars in query', () => {
     component.highlightQuery = '(買い物)'
     expect(() => component.highlightParts('(買い物)に行く')).not.toThrow()
+  })
+
+  it('onToggleReminder should emit false when reminderEnabled is true', () => {
+    const emitted: ReminderToggleEvent[] = []
+    component.reminderToggled.subscribe((e) => emitted.push(e))
+
+    component.todo = { ...mockTodo, reminderEnabled: true }
+    component.onToggleReminder()
+
+    expect(emitted).toEqual([{ todoId: mockTodo.id, enabled: false }])
+  })
+
+  it('onToggleReminder should emit true when reminderEnabled is false', () => {
+    const emitted: ReminderToggleEvent[] = []
+    component.reminderToggled.subscribe((e) => emitted.push(e))
+
+    component.todo = { ...mockTodo, reminderEnabled: false }
+    component.onToggleReminder()
+
+    expect(emitted).toEqual([{ todoId: mockTodo.id, enabled: true }])
   })
 })
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -5,6 +5,11 @@ import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 import { TagChipComponent } from '../tag-chip/tag-chip.component'
 
+export interface ReminderToggleEvent {
+  todoId: number
+  enabled: boolean
+}
+
 @Component({
   selector: 'app-todo-item',
   standalone: true,
@@ -21,6 +26,7 @@ export class TodoItemComponent implements OnChanges {
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
+  @Output() reminderToggled = new EventEmitter<ReminderToggleEvent>()
   @Output() tagRemoved = new EventEmitter<{ todoId: number; tag: Tag }>()
   @Output() tagAdded = new EventEmitter<{ todoId: number; tagId: number }>()
 
@@ -48,6 +54,10 @@ export class TodoItemComponent implements OnChanges {
 
   onArchive(): void {
     this.archive.emit(this.todo.id)
+  }
+
+  onToggleReminder(): void {
+    this.reminderToggled.emit({ todoId: this.todo.id, enabled: !this.todo.reminderEnabled })
   }
 
   onTagRemoved(tag: Tag): void {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -34,6 +34,7 @@
           (edit)="edit.emit($event)"
           (delete)="delete.emit($event)"
           (archive)="archive.emit($event)"
+          (reminderToggled)="reminderToggled.emit($event)"
           (tagRemoved)="tagRemoved.emit($event)"
           (tagAdded)="tagAdded.emit($event)"
         />

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop'
 import { TodoItemComponent } from '../todo-item/todo-item.component'
+import type { ReminderToggleEvent } from '../todo-item/todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 
@@ -26,6 +27,7 @@ export class TodoListComponent {
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
+  @Output() reminderToggled = new EventEmitter<ReminderToggleEvent>()
   @Output() reorder = new EventEmitter<number[]>()
   @Output() tagRemoved = new EventEmitter<{ todoId: number; tag: Tag }>()
   @Output() tagAdded = new EventEmitter<{ todoId: number; tagId: number }>()

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -125,6 +125,7 @@
         [selectedIds]="selectedIds"
         (selectionChange)="onSelectionChange($event)"
         (toggle)="onToggle($event)"
+        (reminderToggled)="onReminderToggled($event)"
         (edit)="onEdit($event)"
         (delete)="onDelete($event)"
         (archive)="onArchived($event)"

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -19,6 +19,7 @@ import {
 import { ImportDialogComponent } from '../import-dialog/import-dialog.component'
 import { ExportService } from '../../../../../services/export.service'
 import { KeyboardShortcutService } from '../../../../../services/keyboard-shortcut.service'
+import type { ReminderToggleEvent } from '../todo-item/todo-item.component'
 import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 import type { Project } from '../../../../../models/project.interface'
@@ -379,6 +380,18 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
   onToggle(id: number): void {
     this.todoService
       .toggleComplete(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '更新に失敗しました'
+        }
+      })
+  }
+
+  onReminderToggled(event: ReminderToggleEvent): void {
+    this.todoService
+      .toggleReminder(event.todoId, event.enabled)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => this.loadTodos(),

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -394,7 +394,9 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
       .toggleReminder(event.todoId, event.enabled)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: () => this.loadTodos(),
+        next: (updated) => {
+          this.todos = this.todos.map((t) => (t.id === updated.id ? updated : t))
+        },
         error: (err) => {
           this.error = err?.error?.message ?? err?.message ?? '更新に失敗しました'
         }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core'
 import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { Observable } from 'rxjs'
+import { BehaviorSubject } from 'rxjs'
 import { environment } from '../../environments/environment'
 
 @Injectable({
@@ -8,6 +9,7 @@ import { environment } from '../../environments/environment'
 })
 export class AuthService {
   private apiUrl = environment.apiUrl
+  readonly authState$ = new BehaviorSubject<boolean>(this.isAuthenticated())
 
   constructor(private http: HttpClient) { }
 
@@ -24,6 +26,7 @@ export class AuthService {
 
   saveToken(token: string): void {
     localStorage.setItem('authToken', token)
+    this.authState$.next(true)
   }
 
   getToken(): string | null {
@@ -32,6 +35,7 @@ export class AuthService {
 
   logout(): void {
     localStorage.removeItem('authToken')
+    this.authState$.next(false)
   }
 
   isAuthenticated(): boolean {

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core'
 import { HttpClient, HttpHeaders } from '@angular/common/http'
-import { Observable } from 'rxjs'
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, Observable } from 'rxjs'
 import { environment } from '../../environments/environment'
 
 @Injectable({


### PR DESCRIPTION
## Summary
- TodoItem にリマインダー ON/OFF トグルを追加し、切り替えイベントを親へ伝播
- Todo 一覧ページで `toggleReminder` API を呼び出して状態を反映（全件再取得せず差分更新）
- 認証状態に応じて `ReminderService` を開始/停止（ログインで開始、ログアウトで停止）

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`
- [ ] ログイン後にリマインダーが動作すること（権限が granted の場合のみ通知）
- [ ] ログアウトでポーリングが停止すること
- [ ] TodoItem の「リマインダーON/OFF」ボタンで状態が更新されること