### PR TITLE
feat(frontend): リマインダー設定画面（権限/通知テスト）

### DIFF
--- a/docs/TODO_FEATURE_04_REMINDER.md
+++ b/docs/TODO_FEATURE_04_REMINDER.md
@@ -92,10 +92,10 @@ PATCH /api/todos/:id/reminder
 
 ### Task 4.11: ReminderSettings コンポーネント作成
 
-- [ ] 4.11.1: `ng generate component components/reminder-settings` 実行
-- [ ] 4.11.2: 通知権限リクエストボタン実装
-- [ ] 4.11.3: リマインダー設定 UI 実装
-- [ ] 4.11.4: 通知テストボタン実装
+- [x] 4.11.1: `ng generate component components/reminder-settings` 実行
+- [x] 4.11.2: 通知権限リクエストボタン実装
+- [x] 4.11.3: リマインダー設定 UI 実装
+- [x] 4.11.4: 通知テストボタン実装
 
 ### Task 4.12: App 初期化時にリマインダー開始
 
@@ -112,7 +112,7 @@ PATCH /api/todos/:id/reminder
 
 - [x] 4.14.1: NotificationService のテスト
 - [x] 4.14.2: ReminderService のテスト
-- [ ] 4.14.3: ReminderSettings コンポーネントテスト
+- [x] 4.14.3: ReminderSettings コンポーネントテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/home/home.component.html
+++ b/frontend/src/app/components/pages/dashboard/home/home.component.html
@@ -1,3 +1,5 @@
 <div class="row">
-
+  <div class="col-12 col-lg-6">
+    <app-reminder-settings />
+  </div>
 </div>

--- a/frontend/src/app/components/pages/dashboard/home/home.component.ts
+++ b/frontend/src/app/components/pages/dashboard/home/home.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core'
 import { RouterModule } from '@angular/router'
 import { ReactiveFormsModule } from '@angular/forms'
+import { ReminderSettingsComponent } from '../../../reminder-settings/reminder-settings.component'
 
 @Component({
   selector: 'dashboard',
   standalone: true,
-  imports: [RouterModule, ReactiveFormsModule],
+  imports: [RouterModule, ReactiveFormsModule, ReminderSettingsComponent],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })

--- a/frontend/src/app/components/reminder-settings/reminder-settings.component.html
+++ b/frontend/src/app/components/reminder-settings/reminder-settings.component.html
@@ -1,0 +1,48 @@
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">期限リマインダー設定</h5>
+
+    <div class="mb-2 small text-muted">
+      通知権限: {{ permissionLabel }}
+    </div>
+
+    <div class="mb-3">
+      リマインダー監視: <span class="fw-semibold">{{ (reminderRunning$ | async) ? 'ON' : 'OFF' }}</span>
+    </div>
+
+    @if (!apiAvailable) {
+      <div class="alert alert-warning" role="alert">
+        このブラウザでは通知が利用できません。
+      </div>
+    } @else {
+      <div class="d-flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn btn-primary"
+          data-testid="permission-button"
+          (click)="requestPermission()"
+          [disabled]="loadingRequest || permission === 'granted'"
+        >
+          {{ permission === 'granted' ? '権限は許可済み' : '通知権限を許可' }}
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          data-testid="test-button"
+          (click)="sendTestNotification()"
+          [disabled]="permission !== 'granted'"
+        >
+          通知テスト
+        </button>
+      </div>
+    }
+
+    @if (message) {
+      <div class="alert alert-info mt-3" role="status">
+        {{ message }}
+      </div>
+    }
+  </div>
+</div>
+

--- a/frontend/src/app/components/reminder-settings/reminder-settings.component.scss
+++ b/frontend/src/app/components/reminder-settings/reminder-settings.component.scss
@@ -1,0 +1,4 @@
+.card-title {
+  margin-bottom: 0.5rem;
+}
+

--- a/frontend/src/app/components/reminder-settings/reminder-settings.component.spec.ts
+++ b/frontend/src/app/components/reminder-settings/reminder-settings.component.spec.ts
@@ -1,0 +1,69 @@
+import { BehaviorSubject } from 'rxjs'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ReminderSettingsComponent } from './reminder-settings.component'
+import { NotificationService } from '../../services/notification.service'
+import { ReminderService } from '../../services/reminder.service'
+
+describe('ReminderSettingsComponent (4.14.3)', () => {
+  let fixture: ComponentFixture<ReminderSettingsComponent>
+  let component: ReminderSettingsComponent
+
+  const notificationServiceMock = {
+    requestPermission: jasmine.createSpy('requestPermission').and.resolveTo('granted' as NotificationPermission),
+    showNotification: jasmine.createSpy('showNotification'),
+  }
+
+  const reminderRunning$ = new BehaviorSubject<boolean>(true)
+  const reminderServiceMock = {
+    running$: reminderRunning$.asObservable(),
+    start: jasmine.createSpy('start'),
+    stop: jasmine.createSpy('stop'),
+  }
+
+  const originalNotification = (globalThis as any).Notification
+
+  beforeEach(async () => {
+    ;(globalThis as any).Notification = {
+      permission: 'default',
+    }
+
+    await TestBed.configureTestingModule({
+      imports: [ReminderSettingsComponent],
+      providers: [
+        { provide: NotificationService, useValue: notificationServiceMock },
+        { provide: ReminderService, useValue: reminderServiceMock },
+      ],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ReminderSettingsComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).Notification = originalNotification
+    notificationServiceMock.requestPermission.calls.reset()
+    notificationServiceMock.showNotification.calls.reset()
+    reminderRunning$.next(true)
+  })
+
+  it('permission button should request permission', async () => {
+    const permissionBtn: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="permission-button"]')
+    permissionBtn.click()
+
+    await fixture.whenStable()
+    expect(notificationServiceMock.requestPermission).toHaveBeenCalled()
+    expect(component.permission).toBe('granted')
+  })
+
+  it('test button should send notification when granted', () => {
+    component.permission = 'granted'
+    fixture.detectChanges()
+
+    const testBtn: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="test-button"]')
+    testBtn.click()
+
+    expect(notificationServiceMock.showNotification).toHaveBeenCalled()
+  })
+})
+

--- a/frontend/src/app/components/reminder-settings/reminder-settings.component.ts
+++ b/frontend/src/app/components/reminder-settings/reminder-settings.component.ts
@@ -1,0 +1,74 @@
+import { AsyncPipe, CommonModule } from '@angular/common'
+import { Component } from '@angular/core'
+import { NotificationService } from '../../services/notification.service'
+import { ReminderService } from '../../services/reminder.service'
+
+type PermissionState = NotificationPermission | 'unsupported'
+
+@Component({
+  selector: 'app-reminder-settings',
+  standalone: true,
+  imports: [CommonModule, AsyncPipe],
+  templateUrl: './reminder-settings.component.html',
+  styleUrls: ['./reminder-settings.component.scss'],
+})
+export class ReminderSettingsComponent {
+  readonly reminderRunning$ = this.reminderService.running$
+
+  apiAvailable = this.isNotificationApiAvailable()
+  permission: PermissionState = this.getInitialPermission()
+  loadingRequest = false
+
+  message: string | null = null
+
+  constructor(
+    private notificationService: NotificationService,
+    private reminderService: ReminderService
+  ) {}
+
+  get permissionLabel(): string {
+    if (!this.apiAvailable) return '未対応'
+    return this.permission === 'unsupported' ? '未対応' : this.permission
+  }
+
+  async requestPermission(): Promise<void> {
+    if (!this.apiAvailable) {
+      this.message = 'このブラウザでは通知が利用できません。'
+      this.permission = 'unsupported'
+      return
+    }
+    this.loadingRequest = true
+    this.message = null
+    try {
+      const p = await this.notificationService.requestPermission()
+      this.permission = p
+      this.message = p === 'granted' ? '通知権限を許可しました。' : '通知権限は許可されませんでした。'
+    } catch {
+      this.message = '通知権限のリクエストに失敗しました。'
+    } finally {
+      this.loadingRequest = false
+    }
+  }
+
+  sendTestNotification(): void {
+    if (!this.apiAvailable || this.permission !== 'granted') return
+    this.notificationService.showNotification(
+      '通知テスト',
+      'リマインダー通知が表示されるか確認してください。',
+      { url: '/dashboard/todos' }
+    )
+    this.message = '通知テストを送信しました。'
+  }
+
+  private isNotificationApiAvailable(): boolean {
+    const N = (globalThis as any).Notification as typeof Notification | undefined
+    return !!N
+  }
+
+  private getInitialPermission(): PermissionState {
+    const N = (globalThis as any).Notification as typeof Notification | undefined
+    if (!N) return 'unsupported'
+    return N.permission as NotificationPermission
+  }
+}
+

--- a/frontend/src/app/services/reminder.service.ts
+++ b/frontend/src/app/services/reminder.service.ts
@@ -49,7 +49,8 @@ export class ReminderService {
       if (notified.has(t.id)) continue
       const title = '期限が近い Todo'
       const body = t.title
-      this.notificationService.showNotification(title, body, { url: '/dashboard/todo', todoId: t.id })
+      // 期限リマインダー通知の遷移先は Todos 一覧（/dashboard/todos）に統一
+      this.notificationService.showNotification(title, body, { url: '/dashboard/todos', todoId: t.id })
       notified.add(t.id)
     }
 


### PR DESCRIPTION
## Summary
- `ReminderSettings` コンポーネントを追加し、`dashboard/home` に表示
- 通知権限のリクエストと、権限が `granted` のときの通知テストボタンを提供
- 監視状態は `ReminderService.running$` を UI 表示

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)