### PR TITLE
feat(frontend): ShareService 作成（11.8 再実装）

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -18,7 +18,7 @@
 
 ### Frontend タスク（10タスク）
 - [x] 11.7: Share インターフェース定義
-- [ ] 11.8: ShareService 作成
+- [x] 11.8: ShareService 作成
 - [ ] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
 - [ ] 11.10: TodoItem に共有ボタン追加
 - [ ] 11.11: SharedTodosPage 作成

--- a/frontend/src/app/services/share.service.spec.ts
+++ b/frontend/src/app/services/share.service.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
+import { ShareService } from './share.service'
+import type { SharePermission, TodoShare, SharedTodo } from '../models/share.interface'
+import type { Todo } from '../models/todo.interface'
+
+describe('ShareService (11.8)', () => {
+  let service: ShareService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ShareService],
+    })
+    service = TestBed.inject(ShareService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should call POST /todos/:id/share for shareTodo', () => {
+    const todoId = 10
+    const sharedWithUserId = 2
+    const permission: SharePermission = 'edit'
+
+    const mockShare: TodoShare = {
+      id: 1,
+      todoId,
+      sharedWithUserId,
+      permission,
+      createdAt: '',
+    }
+
+    service.shareTodo(todoId, sharedWithUserId, permission).subscribe((share) => {
+      expect(share).toEqual(mockShare)
+    })
+
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${todoId}/share` && r.method === 'POST')
+    expect(req.request.body).toEqual({ sharedWithUserId, permission })
+    req.flush(mockShare)
+  })
+
+  it('should call GET /todos/shared for getSharedTodos', () => {
+    const mockTodo: Todo = {
+      id: 1,
+      userId: 1,
+      title: 'Shared',
+      description: null,
+      completed: false,
+      priority: 'medium',
+      dueDate: null,
+      sortOrder: 0,
+      projectId: null,
+      archived: false,
+      archivedAt: null,
+      reminderEnabled: false,
+      reminderSentAt: null,
+      createdAt: '',
+      updatedAt: '',
+    }
+
+    const mockSharedTodo: SharedTodo<Todo> = {
+      ...mockTodo,
+      sharedPermission: 'view',
+    }
+
+    service.getSharedTodos().subscribe((todos) => {
+      expect(todos).toEqual([mockSharedTodo])
+      expect(todos[0].sharedPermission).toBe('view')
+    })
+
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/shared` && r.method === 'GET')
+    req.flush([mockSharedTodo])
+  })
+
+  it('should call DELETE /shares/:id for deleteShare', () => {
+    const shareId = 123
+    service.deleteShare(shareId).subscribe()
+
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/shares/${shareId}` && r.method === 'DELETE')
+    req.flush(null)
+  })
+})
+

--- a/frontend/src/app/services/share.service.ts
+++ b/frontend/src/app/services/share.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+import type { Todo } from '../models/todo.interface'
+import type { SharedTodo, SharePermission, TodoShare } from '../models/share.interface'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ShareService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * 指定 Todo を他ユーザーへ共有する（所有者のみ）。
+   * 既に共有済みの場合は permission を更新する。
+   */
+  shareTodo(
+    todoId: number,
+    sharedWithUserId: number,
+    permission: SharePermission = 'view'
+  ): Observable<TodoShare> {
+    return this.http.post<TodoShare>(`${this.apiUrl}/todos/${todoId}/share`, {
+      sharedWithUserId,
+      permission
+    })
+  }
+
+  /**
+   * 自分が共有を受けている Todo の一覧を取得する。
+   * 返却データは `sharedPermission` を含む。
+   */
+  getSharedTodos(): Observable<SharedTodo<Todo>[]> {
+    return this.http.get<SharedTodo<Todo>[]>(`${this.apiUrl}/todos/shared`)
+  }
+
+  /**
+   * 指定 share を解除する（Todo 所有者のみ）。
+   */
+  deleteShare(shareId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/shares/${shareId}`)
+  }
+}
+


### PR DESCRIPTION
## Summary
- `frontend/src/app/services/share.service.ts` を追加（共有作成/共有一覧/共有解除）
- `frontend/src/app/services/share.service.spec.ts` を追加
- `docs/TODO_FEATURE_11_20.md` の 11.8 を完了に更新

## Test plan
- `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)