### PR TITLE
feat(frontend): ShareDialog for todo sharing (11.9)

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -19,7 +19,7 @@
 ### Frontend タスク（10タスク）
 - [x] 11.7: Share インターフェース定義
 - [x] 11.8: ShareService 作成
-- [ ] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
+- [x] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
 - [ ] 11.10: TodoItem に共有ボタン追加
 - [ ] 11.11: SharedTodosPage 作成
 - [ ] 11.12: Frontend テスト

--- a/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.html
@@ -1,0 +1,72 @@
+<h2 mat-dialog-title>Todo を共有</h2>
+<mat-dialog-content>
+  <div class="d-flex flex-column gap-3">
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>ユーザー検索</mat-label>
+      <input
+        matInput
+        [formControl]="searchControl"
+        placeholder="名前または email"
+      />
+    </mat-form-field>
+
+    @if (loading) {
+      <div class="d-flex align-items-center gap-2">
+        <mat-spinner diameter="24"></mat-spinner>
+        <span class="small">読み込み中...</span>
+      </div>
+    }
+
+    @if (error) {
+      <p class="text-danger small mb-0">{{ error }}</p>
+    }
+
+    @if (!loading && !error) {
+      <div class="d-flex flex-column gap-2">
+        @if (filteredUsers.length === 0) {
+          <p class="small text-muted mb-0">該当するユーザーが見つかりません。</p>
+        } @else {
+          <div class="d-flex flex-column gap-1">
+            @for (u of filteredUsers; track u.id) {
+              <button
+                type="button"
+                class="list-group-item list-group-item-action d-flex flex-column align-items-start"
+                [class.active]="u.id === selectedUserId"
+                (click)="selectUser(u.id)"
+              >
+                <span class="fw-semibold">{{ u.name }}</span>
+                <span class="small text-muted">{{ u.email }}</span>
+              </button>
+            }
+          </div>
+        }
+
+        <mat-form-field appearance="outline" class="w-100 mt-2">
+          <mat-label>権限</mat-label>
+          <mat-select
+            [value]="permission"
+            [disabled]="selectedUserId == null"
+            (selectionChange)="permission = $event.value"
+          >
+            @for (opt of permissionOptions; track opt.value) {
+              <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </div>
+    }
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">キャンセル</button>
+  <button
+    mat-flat-button
+    color="primary"
+    [disabled]="!canShare()"
+    (click)="share()"
+  >
+    共有する
+  </button>
+</mat-dialog-actions>
+

--- a/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.scss
@@ -1,0 +1,6 @@
+/* Shared dialog local styles */
+.list-group-item.small {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+

--- a/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog'
+import { of } from 'rxjs'
+import { ShareDialogComponent, type ShareDialogData } from './share-dialog.component'
+import { UserService } from '../../../../../services/user.service'
+import type { UserListResponse } from '../../../../../models/user.interface'
+import type { User } from '../../../../../models/user.interface'
+import type { SharePermission } from '../../../../../models/share.interface'
+
+describe('ShareDialogComponent (11.9)', () => {
+  let component: ShareDialogComponent
+  let fixture: ComponentFixture<ShareDialogComponent>
+  let dialogRef: jasmine.SpyObj<MatDialogRef<ShareDialogComponent>>
+  let userService: jasmine.SpyObj<UserService>
+
+  const baseData: ShareDialogData = { todoId: 1, initialPermission: 'view' }
+
+  const mockUsers: User[] = [
+    { id: 1, name: 'Alice', email: 'alice@test.local' },
+    { id: 2, name: 'Bob', email: 'bob@test.local' }
+  ]
+
+  const listResponse: UserListResponse<User> = {
+    users: mockUsers,
+    totalItems: 2,
+    currentPage: 1,
+    limit: 50,
+    totalPages: 1
+  }
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close'])
+    userService = jasmine.createSpyObj('UserService', ['list'])
+    userService.list.and.returnValue(of(listResponse))
+
+    await TestBed.configureTestingModule({
+      imports: [ShareDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: baseData },
+        { provide: UserService, useValue: userService }
+      ]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ShareDialogComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should load users on init', () => {
+    expect(userService.list).toHaveBeenCalled()
+    expect(component.users.length).toBe(2)
+  })
+
+  it('should filter users by search term', () => {
+    component.searchControl.setValue('alice')
+    expect(component.filteredUsers.length).toBe(1)
+    expect(component.filteredUsers[0].id).toBe(1)
+  })
+
+  it('should close with shared user and permission on share()', () => {
+    component.selectedUserId = 2
+    component.permission = 'edit' as SharePermission
+    component.share()
+
+    expect(dialogRef.close).toHaveBeenCalledWith({
+      sharedWithUserId: 2,
+      permission: 'edit'
+    })
+  })
+
+  it('should close without payload on cancel()', () => {
+    component.cancel()
+    expect(dialogRef.close).toHaveBeenCalledWith()
+  })
+})
+

--- a/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { ShareDialogComponent, type ShareDialogData } from './share-dialog.component'
 import { UserService } from '../../../../../services/user.service'
 import type { UserListResponse } from '../../../../../models/user.interface'
@@ -64,6 +64,12 @@ describe('ShareDialogComponent (11.9)', () => {
     expect(component.filteredUsers[0].id).toBe(1)
   })
 
+  it('should filter users by email too', () => {
+    component.searchControl.setValue('bob@test.local')
+    expect(component.filteredUsers.length).toBe(1)
+    expect(component.filteredUsers[0].email).toBe('bob@test.local')
+  })
+
   it('should close with shared user and permission on share()', () => {
     component.selectedUserId = 2
     component.permission = 'edit' as SharePermission
@@ -73,6 +79,24 @@ describe('ShareDialogComponent (11.9)', () => {
       sharedWithUserId: 2,
       permission: 'edit'
     })
+  })
+
+  it('should not close when selectedUserId is null (share disabled)', () => {
+    component.selectedUserId = null
+    component.share()
+    expect(component.canShare()).toBe(false)
+    expect(dialogRef.close).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({ sharedWithUserId: jasmine.any(Number) })
+    )
+  })
+
+  it('should set error when userService.list fails', () => {
+    userService.list.and.returnValue(throwError(() => ({ error: { message: 'User list failed' } })))
+    component.ngOnInit()
+    fixture.detectChanges()
+
+    expect(component.error).toBe('User list failed')
+    expect(component.loading).toBe(false)
   })
 
   it('should close without payload on cancel()', () => {

--- a/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.ts
@@ -7,7 +7,7 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog'
 import { MatButtonModule } from '@angular/material/button'
-import { MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog'
+import { MatDialogTitle, MatDialogContent, MatDialogActions } from '@angular/material/dialog'
 import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatInputModule } from '@angular/material/input'
 import { MatSelectModule } from '@angular/material/select'
@@ -31,7 +31,6 @@ export interface ShareDialogData {
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
-    MatDialogClose,
     MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
@@ -44,8 +43,8 @@ export interface ShareDialogData {
 })
 export class ShareDialogComponent implements OnInit, OnDestroy {
   readonly permissionOptions: Array<{ value: SharePermission; label: string }> = [
-    { value: 'view', label: 'view' },
-    { value: 'edit', label: 'edit' }
+    { value: 'view', label: '閲覧のみ' },
+    { value: 'edit', label: '編集可' }
   ]
 
   searchControl = new FormControl<string>('', { nonNullable: true })

--- a/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/share-dialog/share-dialog.component.ts
@@ -1,0 +1,123 @@
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormControl, ReactiveFormsModule } from '@angular/forms'
+import { Subscription } from 'rxjs'
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+} from '@angular/material/dialog'
+import { MatButtonModule } from '@angular/material/button'
+import { MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
+import { MatSelectModule } from '@angular/material/select'
+import { MatOptionModule } from '@angular/material/core'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { SharePermission } from '../../../../../models/share.interface'
+import { UserService } from '../../../../../services/user.service'
+import type { User } from '../../../../../models/user.interface'
+
+export interface ShareDialogData {
+  todoId: number
+  initialPermission?: SharePermission
+}
+
+@Component({
+  selector: 'app-share-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatOptionModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './share-dialog.component.html',
+  styleUrl: './share-dialog.component.scss'
+})
+export class ShareDialogComponent implements OnInit, OnDestroy {
+  readonly permissionOptions: Array<{ value: SharePermission; label: string }> = [
+    { value: 'view', label: 'view' },
+    { value: 'edit', label: 'edit' }
+  ]
+
+  searchControl = new FormControl<string>('', { nonNullable: true })
+  permission: SharePermission
+  selectedUserId: number | null = null
+
+  loading = false
+  error: string | null = null
+  users: User[] = []
+
+  private sub = new Subscription()
+
+  constructor(
+    public dialogRef: MatDialogRef<ShareDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ShareDialogData,
+    private userService: UserService
+  ) {
+    this.permission = data.initialPermission ?? 'view'
+  }
+
+  ngOnInit(): void {
+    this.loadUsers()
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe()
+  }
+
+  get normalizedSearch(): string {
+    return (this.searchControl.value ?? '').trim().toLowerCase()
+  }
+
+  get filteredUsers(): User[] {
+    const q = this.normalizedSearch
+    if (!q) return this.users
+    return this.users.filter((u) => `${u.name} ${u.email}`.toLowerCase().includes(q))
+  }
+
+  selectUser(userId: number): void {
+    this.selectedUserId = userId
+  }
+
+  private loadUsers(): void {
+    this.loading = true
+    this.error = null
+    const s = this.userService.list(1, 50).subscribe({
+      next: (res) => {
+        this.users = res.users ?? []
+        this.loading = false
+      },
+      error: (err) => {
+        this.error = err?.error?.message ?? err?.message ?? 'ユーザー一覧の取得に失敗しました'
+        this.loading = false
+      }
+    })
+    this.sub.add(s)
+  }
+
+  canShare(): boolean {
+    return this.selectedUserId != null
+  }
+
+  share(): void {
+    if (!this.canShare() || this.selectedUserId == null) return
+    this.dialogRef.close({
+      sharedWithUserId: this.selectedUserId,
+      permission: this.permission
+    })
+  }
+
+  cancel(): void {
+    this.dialogRef.close()
+  }
+}
+

--- a/frontend/src/app/models/user.interface.ts
+++ b/frontend/src/app/models/user.interface.ts
@@ -1,0 +1,21 @@
+export interface User {
+  id: number
+  name: string
+  email: string
+  /**
+   * API レスポンスには含まれるが、フロント側では共有機能に不要。
+   * 型だけ許容しておく（API が変更されてもコンパイルを壊しにくくするため）。
+   */
+  password?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface UserListResponse<TUser = User> {
+  users: TUser[]
+  totalItems: number
+  currentPage: number
+  limit: number
+  totalPages: number
+}
+

--- a/frontend/src/app/models/user.interface.ts
+++ b/frontend/src/app/models/user.interface.ts
@@ -2,11 +2,6 @@ export interface User {
   id: number
   name: string
   email: string
-  /**
-   * API レスポンスには含まれるが、フロント側では共有機能に不要。
-   * 型だけ許容しておく（API が変更されてもコンパイルを壊しにくくするため）。
-   */
-  password?: string
   createdAt?: string
   updatedAt?: string
 }

--- a/frontend/src/app/services/user.service.spec.ts
+++ b/frontend/src/app/services/user.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
+import { UserService } from './user.service'
+import type { User, UserListResponse } from '../models/user.interface'
+
+describe('UserService (11.9)', () => {
+  let service: UserService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  const mockResponse: UserListResponse<User> = {
+    users: [
+      { id: 1, name: 'Alice', email: 'alice@test.local', createdAt: '', updatedAt: '' }
+    ],
+    totalItems: 1,
+    currentPage: 1,
+    limit: 50,
+    totalPages: 1
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [UserService],
+    })
+    service = TestBed.inject(UserService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('should call GET /users with default page/limit for list()', () => {
+    service.list().subscribe((res) => expect(res.users[0].id).toBe(1))
+
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/users` && r.method === 'GET')
+    expect(req.request.params.get('page')).toBe('1')
+    expect(req.request.params.get('limit')).toBe('50')
+    req.flush(mockResponse)
+  })
+
+  it('should call GET /users with page/limit for list(page, limit)', () => {
+    service.list(2, 10).subscribe((res) => expect(res.totalItems).toBe(1))
+
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/users` && r.method === 'GET')
+    expect(req.request.params.get('page')).toBe('2')
+    expect(req.request.params.get('limit')).toBe('10')
+    req.flush({ ...mockResponse, currentPage: 2, limit: 10, totalPages: 1 })
+  })
+})
+

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { environment } from '../../environments/environment'
+import type { User, UserListResponse } from '../models/user.interface'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  list(page: number = 1, limit: number = 50): Observable<UserListResponse<User>> {
+    return this.http.get<UserListResponse<User>>(`${this.apiUrl}/users`, {
+      params: { page: String(page), limit: String(limit) }
+    })
+  }
+}
+


### PR DESCRIPTION
## Summary
- `ShareDialogComponent` を追加し、共有先ユーザーの検索と権限（view/edit）選択を実装しました。
- 共有先ユーザー一覧取得のため、`UserService` と `User` 型を追加しました。
- `docs/TODO_FEATURE_11_20.md` の 11.9 を `[x]` に更新しました。

## Test plan
- `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)