### PR TITLE
Revert #87: TodoItem share button (11.10)

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -20,7 +20,7 @@
 - [x] 11.7: Share インターフェース定義
 - [x] 11.8: ShareService 作成
 - [x] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
-- [x] 11.10: TodoItem に共有ボタン追加
+- [ ] 11.10: TodoItem に共有ボタン追加
 - [ ] 11.11: SharedTodosPage 作成
 - [ ] 11.12: Frontend テスト
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -64,15 +64,6 @@
     >
       <i class="feather icon-bell" aria-hidden="true"></i>
     </button>
-    <button
-      type="button"
-      class="btn btn-outline-secondary"
-      (click)="onShare()"
-      [attr.aria-label]="'Todo を共有: ' + todo.title"
-      title="共有"
-    >
-      <i class="feather icon-share-2" aria-hidden="true"></i>
-    </button>
     <button type="button" class="btn btn-outline-primary" (click)="onEdit()">編集</button>
     <button type="button" class="btn btn-outline-danger" (click)="onDelete()">削除</button>
   </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
@@ -87,12 +87,5 @@ describe('TodoItemComponent (2.12.2)', () => {
 
     expect(emitted).toEqual([{ todoId: mockTodo.id, enabled: true }])
   })
-
-  it('onShare should emit todoId', () => {
-    const emitted: number[] = []
-    component.share.subscribe((id) => emitted.push(id))
-    component.onShare()
-    expect(emitted).toEqual([mockTodo.id])
-  })
 })
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -26,7 +26,6 @@ export class TodoItemComponent implements OnChanges {
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
-  @Output() share = new EventEmitter<number>()
   @Output() reminderToggled = new EventEmitter<ReminderToggleEvent>()
   @Output() tagRemoved = new EventEmitter<{ todoId: number; tag: Tag }>()
   @Output() tagAdded = new EventEmitter<{ todoId: number; tagId: number }>()
@@ -55,10 +54,6 @@ export class TodoItemComponent implements OnChanges {
 
   onArchive(): void {
     this.archive.emit(this.todo.id)
-  }
-
-  onShare(): void {
-    this.share.emit(this.todo.id)
   }
 
   onToggleReminder(): void {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.html
@@ -34,7 +34,6 @@
           (edit)="edit.emit($event)"
           (delete)="delete.emit($event)"
           (archive)="archive.emit($event)"
-          (share)="share.emit($event)"
           (reminderToggled)="reminderToggled.emit($event)"
           (tagRemoved)="tagRemoved.emit($event)"
           (tagAdded)="tagAdded.emit($event)"

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.ts
@@ -27,7 +27,6 @@ export class TodoListComponent {
   @Output() edit = new EventEmitter<Todo>()
   @Output() delete = new EventEmitter<number>()
   @Output() archive = new EventEmitter<number>()
-  @Output() share = new EventEmitter<number>()
   @Output() reminderToggled = new EventEmitter<ReminderToggleEvent>()
   @Output() reorder = new EventEmitter<number[]>()
   @Output() tagRemoved = new EventEmitter<{ todoId: number; tag: Tag }>()

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.html
@@ -129,7 +129,6 @@
         (edit)="onEdit($event)"
         (delete)="onDelete($event)"
         (archive)="onArchived($event)"
-        (share)="onShare($event)"
         (reorder)="onReorder($event)"
         (tagRemoved)="onTagRemoved($event)"
         (tagAdded)="onTagAdded($event)"

--- a/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-page/todo-page.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core'
 import { CommonModule } from '@angular/common'
-import { EMPTY, Subject, switchMap, takeUntil } from 'rxjs'
+import { Subject, takeUntil } from 'rxjs'
 import { MatDialog } from '@angular/material/dialog'
 import { TodoService, type TodoListFilters } from '../../../../../services/todo.service'
 import { TagService } from '../../../../../services/tag.service'
 import { ProjectService } from '../../../../../services/project.service'
 import { TemplateService } from '../../../../../services/template.service'
-import { ShareService } from '../../../../../services/share.service'
 import { TodoListComponent } from '../todo-list/todo-list.component'
 import { TodoFormComponent } from '../todo-form/todo-form.component'
 import { SearchBarComponent } from '../search-bar/search-bar.component'
@@ -18,7 +17,6 @@ import {
   type AdvancedSearchDialogData
 } from '../advanced-search-dialog/advanced-search-dialog.component'
 import { ImportDialogComponent } from '../import-dialog/import-dialog.component'
-import { ShareDialogComponent } from '../share-dialog/share-dialog.component'
 import { ExportService } from '../../../../../services/export.service'
 import { KeyboardShortcutService } from '../../../../../services/keyboard-shortcut.service'
 import type { ReminderToggleEvent } from '../todo-item/todo-item.component'
@@ -26,9 +24,9 @@ import type { Todo, TodoCreateUpdate, TodoPriority } from '../../../../../models
 import type { Tag } from '../../../../../models/tag.interface'
 import type { Project } from '../../../../../models/project.interface'
 import type { Template } from '../../../../../models/template.interface'
-import type { SharePermission } from '../../../../../models/share.interface'
 import type { SortBy, SortOrder } from '../../../../../models/sort-options.interface'
 import type { SearchParams } from '../../../../../models/search-params.interface'
+
 @Component({
   selector: 'app-todo-page',
   standalone: true,
@@ -73,7 +71,6 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
     private templateService: TemplateService,
     private exportService: ExportService,
     private shortcutService: KeyboardShortcutService,
-    private shareService: ShareService,
     private dialog: MatDialog
   ) {}
 
@@ -210,30 +207,6 @@ export default class TodoPageComponent implements OnInit, OnDestroy {
       this.selectedIds = []
       this.loadTodos()
     })
-  }
-
-  onShare(todoId: number): void {
-    const ref = this.dialog.open(ShareDialogComponent, {
-      width: '420px',
-      data: { todoId }
-    })
-
-    type ShareDialogResult = { sharedWithUserId: number; permission: SharePermission }
-
-    ref.afterClosed()
-      .pipe(
-        takeUntil(this.destroy$),
-        switchMap((result: ShareDialogResult | undefined) => {
-          if (!result) return EMPTY
-          return this.shareService.shareTodo(todoId, result.sharedWithUserId, result.permission)
-        })
-      )
-      .subscribe({
-        next: () => {},
-        error: (err) => {
-          this.error = err?.error?.message ?? err?.message ?? '共有に失敗しました'
-        }
-      })
   }
 
   onFiltersChange(): void {


### PR DESCRIPTION
## Summary
- This PR reverts the merge of #87 (TodoItem share button) to undo the unintended merge.

## Notes
- Re-apply/merge should be done only after you explicitly request it.

Made with [Cursor](https://cursor.com)