### PR TITLE
feat(frontend): SharedTodosPage を追加 (11.11)

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -21,7 +21,7 @@
 - [x] 11.8: ShareService 作成
 - [x] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
 - [x] 11.10: TodoItem に共有ボタン追加
-- [ ] 11.11: SharedTodosPage 作成
+- [x] 11.11: SharedTodosPage 作成
 - [ ] 11.12: Frontend テスト
 
 ---

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -18,6 +18,10 @@ const routes: Routes = [
         loadComponent: () => import('./archived-todos/archived-todos-page.component')
       },
       {
+        path: 'shared',
+        loadComponent: () => import('./shared-todos/shared-todos-page.component')
+      },
+      {
         path: 'tags',
         loadComponent: () => import('./tags/tags-page.component')
       },

--- a/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.html
@@ -1,0 +1,54 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="共有された Todo（{{ todos.length }} 件）">
+      @if (error) {
+        <div class="alert alert-danger" role="alert">{{ error }}</div>
+      }
+
+      @if (loading) {
+        <div class="text-center py-4">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">読み込み中...</span>
+          </div>
+        </div>
+      } @else if (todos.length === 0) {
+        <p class="text-muted py-3">共有されている Todo はありません。</p>
+      } @else {
+        <div class="shared-list">
+          @for (todo of todos; track todo.id) {
+            <div class="shared-item border rounded p-3 mb-2">
+              <div class="d-flex align-items-start justify-content-between gap-2">
+                <div>
+                  <h6 class="mb-1">
+                    {{ todo.title }}
+                    @if (todo.completed) {
+                      <span class="badge text-bg-success ms-2">完了</span>
+                    }
+                  </h6>
+                  @if (todo.description) {
+                    <p class="mb-2 text-muted small">{{ todo.description }}</p>
+                  }
+                </div>
+                <span
+                  class="badge"
+                  [class.text-bg-warning]="todo.sharedPermission === 'edit'"
+                  [class.text-bg-secondary]="todo.sharedPermission === 'view'"
+                >
+                  {{ permissionLabel(todo.sharedPermission) }}
+                </span>
+              </div>
+
+              <div class="small text-muted d-flex flex-wrap gap-3">
+                <span>期限: {{ formatDueDate(todo.dueDate) }}</span>
+                <span>優先度: {{ todo.priority }}</span>
+                @if (todo.Project) {
+                  <span>プロジェクト: {{ todo.Project.name }}</span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </app-card>
+  </div>
+</div>

--- a/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.scss
+++ b/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.scss
@@ -1,0 +1,8 @@
+.shared-list {
+  max-height: 65vh;
+  overflow: auto;
+}
+
+.shared-item h6 {
+  word-break: break-word;
+}

--- a/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Subject, takeUntil } from 'rxjs'
+import { ShareService } from '../../../../services/share.service'
+import { CardComponent } from '../../../../theme/shared/components/card/card.component'
+import type { Todo } from '../../../../models/todo.interface'
+import type { SharedTodo, SharePermission } from '../../../../models/share.interface'
+
+@Component({
+  selector: 'app-shared-todos-page',
+  standalone: true,
+  imports: [CommonModule, CardComponent],
+  templateUrl: './shared-todos-page.component.html',
+  styleUrls: ['./shared-todos-page.component.scss']
+})
+export default class SharedTodosPageComponent implements OnInit, OnDestroy {
+  todos: SharedTodo<Todo>[] = []
+  loading = false
+  error: string | null = null
+
+  private destroy$ = new Subject<void>()
+
+  constructor(private shareService: ShareService) {}
+
+  ngOnInit(): void {
+    this.loadSharedTodos()
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  loadSharedTodos(): void {
+    this.loading = true
+    this.error = null
+
+    this.shareService
+      .getSharedTodos()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (list) => {
+          this.todos = list
+          this.loading = false
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '共有 Todo の取得に失敗しました'
+          this.loading = false
+        }
+      })
+  }
+
+  permissionLabel(permission: SharePermission): string {
+    return permission === 'edit' ? '編集可' : '閲覧のみ'
+  }
+
+  formatDueDate(dueDate: string | null): string {
+    if (!dueDate) return '期限なし'
+    return new Date(dueDate).toLocaleString('ja-JP')
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.ts
@@ -11,7 +11,7 @@ import type { SharedTodo, SharePermission } from '../../../../models/share.inter
   standalone: true,
   imports: [CommonModule, CardComponent],
   templateUrl: './shared-todos-page.component.html',
-  styleUrls: ['./shared-todos-page.component.scss']
+  styleUrl: './shared-todos-page.component.scss'
 })
 export default class SharedTodosPageComponent implements OnInit, OnDestroy {
   todos: SharedTodo<Todo>[] = []
@@ -31,7 +31,7 @@ export default class SharedTodosPageComponent implements OnInit, OnDestroy {
     this.destroy$.complete()
   }
 
-  loadSharedTodos(): void {
+  private loadSharedTodos(): void {
     this.loading = true
     this.error = null
 

--- a/frontend/src/app/theme/layout/admin/navigation/navigation.ts
+++ b/frontend/src/app/theme/layout/admin/navigation/navigation.ts
@@ -53,6 +53,14 @@ const NavigationItems = [
         classes: 'nav-item'
       },
       {
+        id: 'shared',
+        title: '共有Todo',
+        type: 'item',
+        url: '/dashboard/shared',
+        icon: 'feather icon-users',
+        classes: 'nav-item'
+      },
+      {
         id: 'projects',
         title: 'プロジェクト',
         type: 'item',


### PR DESCRIPTION
## Summary
- 共有された Todo を表示する `SharedTodosPage` を追加
- `/dashboard/shared` ルートとサイドナビ導線を追加
- `docs/TODO_FEATURE_11_20.md` の `11.11` を `[x]` に更新

## Test plan
- `docker compose run --rm frontend ng test --watch=false`
  - TOTAL: 275 SUCCESS

Made with [Cursor](https://cursor.com)