### PR TITLE
test(frontend): SharedTodosPage テスト追加 (11.12)

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -22,7 +22,7 @@
 - [x] 11.9: ShareDialog コンポーネント作成（ユーザー検索、権限選択）
 - [x] 11.10: TodoItem に共有ボタン追加
 - [x] 11.11: SharedTodosPage 作成
-- [ ] 11.12: Frontend テスト
+- [x] 11.12: Frontend テスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.spec.ts
@@ -70,6 +70,16 @@ describe('SharedTodosPageComponent (11.12)', () => {
     expect(component.loading).toBe(false)
   })
 
+  it('should keep empty todos when getSharedTodos returns empty array', () => {
+    shareService.getSharedTodos.and.returnValue(of([]))
+
+    component.ngOnInit()
+
+    expect(component.todos).toEqual([])
+    expect(component.loading).toBe(false)
+    expect(component.error).toBeNull()
+  })
+
   it('permissionLabel should map permission labels', () => {
     expect(component.permissionLabel('view')).toBe('閲覧のみ')
     expect(component.permissionLabel('edit')).toBe('編集可')
@@ -77,5 +87,12 @@ describe('SharedTodosPageComponent (11.12)', () => {
 
   it('formatDueDate should return fallback for null', () => {
     expect(component.formatDueDate(null)).toBe('期限なし')
+  })
+
+  it('formatDueDate should format a date string', () => {
+    const result = component.formatDueDate('2026-03-20T10:00:00.000Z')
+
+    expect(result).not.toBe('期限なし')
+    expect(result.length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/shared-todos/shared-todos-page.component.spec.ts
@@ -1,0 +1,81 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { of, throwError } from 'rxjs'
+import SharedTodosPageComponent from './shared-todos-page.component'
+import { ShareService } from '../../../../services/share.service'
+import type { SharedTodo } from '../../../../models/share.interface'
+import type { Todo } from '../../../../models/todo.interface'
+
+describe('SharedTodosPageComponent (11.12)', () => {
+  let component: SharedTodosPageComponent
+  let fixture: ComponentFixture<SharedTodosPageComponent>
+  let shareService: jasmine.SpyObj<ShareService>
+
+  const sharedTodos: SharedTodo<Todo>[] = [
+    {
+      id: 11,
+      userId: 1,
+      title: 'Shared task',
+      description: 'from owner',
+      completed: false,
+      priority: 'high',
+      dueDate: '2026-03-20T10:00:00.000Z',
+      sortOrder: 1,
+      projectId: null,
+      archived: false,
+      archivedAt: null,
+      reminderEnabled: false,
+      reminderSentAt: null,
+      createdAt: '2026-03-19T10:00:00.000Z',
+      updatedAt: '2026-03-19T10:00:00.000Z',
+      sharedPermission: 'edit'
+    }
+  ]
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('ShareService', ['getSharedTodos'])
+    spy.getSharedTodos.and.returnValue(of(sharedTodos))
+
+    await TestBed.configureTestingModule({
+      imports: [SharedTodosPageComponent],
+      providers: [
+        { provide: ShareService, useValue: spy },
+        provideNoopAnimations()
+      ]
+    }).compileComponents()
+
+    shareService = TestBed.inject(ShareService) as jasmine.SpyObj<ShareService>
+    fixture = TestBed.createComponent(SharedTodosPageComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should load shared todos on init', () => {
+    expect(shareService.getSharedTodos).toHaveBeenCalled()
+    expect(component.todos).toEqual(sharedTodos)
+    expect(component.loading).toBe(false)
+    expect(component.error).toBeNull()
+  })
+
+  it('should set error when getSharedTodos fails', () => {
+    shareService.getSharedTodos.and.returnValue(throwError(() => ({ error: { message: 'load failed' } })))
+
+    component.ngOnInit()
+
+    expect(component.error).toBe('load failed')
+    expect(component.loading).toBe(false)
+  })
+
+  it('permissionLabel should map permission labels', () => {
+    expect(component.permissionLabel('view')).toBe('閲覧のみ')
+    expect(component.permissionLabel('edit')).toBe('編集可')
+  })
+
+  it('formatDueDate should return fallback for null', () => {
+    expect(component.formatDueDate(null)).toBe('期限なし')
+  })
+})


### PR DESCRIPTION
## Summary
- `SharedTodosPageComponent` のユニットテストを追加
- 取得成功/失敗、表示用メソッドの基本ケースを検証
- `docs/TODO_FEATURE_11_20.md` の `11.12` を `[x]` 更新

## Test plan
- `docker compose run --rm frontend ng test --watch=false`
  - TOTAL: 280 SUCCESS

Made with [Cursor](https://cursor.com)