### PR TITLE
feat: implement todo date range query endpoint (12.2)

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -38,6 +38,8 @@ async function getTodos(fastify, req, reply) {
       sortOrder: req.query.sortOrder,
       tagIds: parseTagIdsQuery(req.query.tags),
       projectId: req.query.projectId,
+      startDate: req.query.startDate,
+      endDate: req.query.endDate,
     };
     const todos = await todoService.getTodosByUserId(fastify, userId, options);
     reply.code(200).send(todos.map((t) => t.toJSON()));

--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -31,6 +31,9 @@ function parseTagIdsQuery(q) {
 async function getTodos(fastify, req, reply) {
   try {
     const userId = req.user.id;
+    if (req.query.startDate && req.query.endDate && req.query.startDate > req.query.endDate) {
+      return reply.code(400).send({ error: 'startDate must be less than or equal to endDate' });
+    }
     const options = {
       completed: req.query.completed === 'true' ? true : req.query.completed === 'false' ? false : undefined,
       priority: req.query.priority,

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -361,6 +361,8 @@ module.exports = async function (fastify, opts) {
           sortOrder: { type: 'string', enum: ['asc', 'desc'] },
           tags: { type: 'string' },
           projectId: { type: 'string', pattern: '^[0-9]+$' },
+          startDate: { type: 'string', format: 'date' },
+          endDate: { type: 'string', format: 'date' },
         },
       },
     },

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -624,6 +624,56 @@ test('GET /api/v1/todos with sortBy and sortOrder returns sorted list', async (t
   }
 })
 
+test('GET /api/v1/todos with startDate and endDate returns todos in range', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `dr-${suffix}`, email: `dr-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'in-range', dueDate: '2026-03-15' }
+  })
+  await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'out-of-range', dueDate: '2026-04-01' }
+  })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    query: { startDate: '2026-03-01', endDate: '2026-03-31' }
+  })
+  assert.strictEqual(res.statusCode, 200)
+  const todos = JSON.parse(res.payload)
+  assert(todos.some((todo) => todo.title === 'in-range'))
+  assert(!todos.some((todo) => todo.title === 'out-of-range'))
+})
+
+test('GET /api/v1/todos with startDate > endDate returns 400', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `drinv-${suffix}`, email: `drinv-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    query: { startDate: '2026-04-01', endDate: '2026-03-01' }
+  })
+  assert.strictEqual(res.statusCode, 400)
+})
+
 test('PUT /api/v1/todos/reorder without auth returns 401', async (t) => {
   const app = await build(t)
   const res = await app.inject({

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -34,7 +34,7 @@
 
 ### Backend タスク（5タスク）
 - [x] 12.1: TodoService に日付範囲フィルタ追加
-- [ ] 12.2: GET /api/todos?startDate=&endDate= 実装
+- [x] 12.2: GET /api/todos?startDate=&endDate= 実装
 - [ ] 12.3: Backend テスト
 
 ### Frontend タスク（12タスク）

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -35,7 +35,7 @@
 ### Backend タスク（5タスク）
 - [x] 12.1: TodoService に日付範囲フィルタ追加
 - [x] 12.2: GET /api/todos?startDate=&endDate= 実装
-- [ ] 12.3: Backend テスト
+- [x] 12.3: Backend テスト
 
 ### Frontend タスク（12タスク）
 - [ ] 12.4: FullCalendar インストール


### PR DESCRIPTION
## Summary
- GET `/api/todos` の query schema に `startDate` / `endDate` を追加
- Todo コントローラーで `startDate` / `endDate` を service options に渡すよう修正
- `docs/TODO_FEATURE_11_20.md` の `12.2` を `[x]` に更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)