### PR TITLE
feat(frontend): add CalendarView component for feature 12.5

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -39,7 +39,7 @@
 
 ### Frontend タスク（12タスク）
 - [x] 12.4: FullCalendar インストール
-- [ ] 12.5: CalendarView コンポーネント作成
+- [x] 12.5: CalendarView コンポーネント作成
 - [ ] 12.6: Todo を FullCalendar イベントに変換
 - [ ] 12.7: イベントクリックで Todo 詳細表示
 - [ ] 12.8: ドラッグ&ドロップで期限変更

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.html
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.html
@@ -1,0 +1,15 @@
+<div class="calendar-wrapper">
+  @if (error) {
+    <div class="alert alert-danger mb-3" role="alert">{{ error }}</div>
+  }
+
+  @if (loading) {
+    <div class="text-center py-4">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">読み込み中...</span>
+      </div>
+    </div>
+  } @else {
+    <full-calendar [options]="calendarOptions" [events]="events"></full-calendar>
+  }
+</div>

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.scss
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.scss
@@ -1,0 +1,3 @@
+.calendar-wrapper {
+  min-height: 360px;
+}

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { EventInput } from '@fullcalendar/core'
+import { CalendarViewComponent } from './calendar-view.component'
+
+describe('CalendarViewComponent', () => {
+  let component: CalendarViewComponent
+  let fixture: ComponentFixture<CalendarViewComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CalendarViewComponent]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(CalendarViewComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should emit dateRangeChange when datesSet is called', () => {
+    const emitSpy = spyOn(component.dateRangeChange, 'emit')
+    const start = new Date('2026-03-01T00:00:00.000Z')
+    const end = new Date('2026-04-01T00:00:00.000Z')
+
+    component.onDatesSet({ start, end } as any)
+
+    expect(emitSpy).toHaveBeenCalledWith({
+      startDate: '2026-03-01',
+      endDate: '2026-03-31'
+    })
+  })
+
+  it('should emit todoClick when event has todoId', () => {
+    const emitSpy = spyOn(component.todoClick, 'emit')
+    component.onEventClick({
+      event: {
+        extendedProps: { todoId: 42 }
+      }
+    } as any)
+
+    expect(emitSpy).toHaveBeenCalledWith(42)
+  })
+
+  it('should render calendar events', () => {
+    const events: EventInput[] = [{ title: 'test', start: '2026-03-20', extendedProps: { todoId: 1 } }]
+    component.events = events
+    fixture.detectChanges()
+    expect(component.events.length).toBe(1)
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.spec.ts
@@ -22,8 +22,8 @@ describe('CalendarViewComponent', () => {
 
   it('should emit dateRangeChange when datesSet is called', () => {
     const emitSpy = spyOn(component.dateRangeChange, 'emit')
-    const start = new Date('2026-03-01T00:00:00.000Z')
-    const end = new Date('2026-04-01T00:00:00.000Z')
+    const start = new Date(2026, 2, 1)
+    const end = new Date(2026, 3, 1)
 
     component.onDatesSet({ start, end } as any)
 

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.ts
@@ -1,0 +1,66 @@
+import { CommonModule } from '@angular/common'
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { FullCalendarModule } from '@fullcalendar/angular'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import type { DatesSetArg, EventClickArg, EventInput } from '@fullcalendar/core'
+import { CalendarOptions } from '@fullcalendar/core'
+
+export interface CalendarDateRange {
+  startDate: string
+  endDate: string
+}
+
+export interface CalendarTodoMoveEvent {
+  todoId: number
+  dueDate: string | null
+}
+
+@Component({
+  selector: 'app-calendar-view',
+  standalone: true,
+  imports: [CommonModule, FullCalendarModule],
+  templateUrl: './calendar-view.component.html',
+  styleUrls: ['./calendar-view.component.scss']
+})
+export class CalendarViewComponent {
+  @Input() events: EventInput[] = []
+  @Input() loading = false
+  @Input() error: string | null = null
+
+  @Output() dateRangeChange = new EventEmitter<CalendarDateRange>()
+  @Output() todoClick = new EventEmitter<number>()
+  @Output() todoMove = new EventEmitter<CalendarTodoMoveEvent>()
+
+  readonly calendarOptions: CalendarOptions = {
+    plugins: [dayGridPlugin],
+    initialView: 'dayGridMonth',
+    locale: 'ja',
+    height: 'auto',
+    editable: false,
+    dayMaxEvents: true,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'dayGridMonth,dayGridWeek'
+    },
+    datesSet: (arg) => this.onDatesSet(arg),
+    eventClick: (arg) => this.onEventClick(arg)
+  }
+
+  onDatesSet(arg: DatesSetArg): void {
+    this.dateRangeChange.emit({
+      startDate: this.toIsoDate(arg.start),
+      endDate: this.toIsoDate(new Date(arg.end.getTime() - 1))
+    })
+  }
+
+  onEventClick(arg: EventClickArg): void {
+    const todoId = Number(arg.event.extendedProps['todoId'])
+    if (!Number.isFinite(todoId)) return
+    this.todoClick.emit(todoId)
+  }
+
+  private toIsoDate(value: Date): string {
+    return value.toISOString().slice(0, 10)
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-view/calendar-view.component.ts
@@ -1,9 +1,9 @@
-import { CommonModule } from '@angular/common'
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { FullCalendarModule } from '@fullcalendar/angular'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import type { DatesSetArg, EventClickArg, EventInput } from '@fullcalendar/core'
 import { CalendarOptions } from '@fullcalendar/core'
+import jaLocale from '@fullcalendar/core/locales/ja'
 
 export interface CalendarDateRange {
   startDate: string
@@ -18,9 +18,9 @@ export interface CalendarTodoMoveEvent {
 @Component({
   selector: 'app-calendar-view',
   standalone: true,
-  imports: [CommonModule, FullCalendarModule],
+  imports: [FullCalendarModule],
   templateUrl: './calendar-view.component.html',
-  styleUrls: ['./calendar-view.component.scss']
+  styleUrl: './calendar-view.component.scss'
 })
 export class CalendarViewComponent {
   @Input() events: EventInput[] = []
@@ -29,12 +29,13 @@ export class CalendarViewComponent {
 
   @Output() dateRangeChange = new EventEmitter<CalendarDateRange>()
   @Output() todoClick = new EventEmitter<number>()
+  // 12.8 でドラッグ&ドロップによる期限変更を実装する際に使用する
   @Output() todoMove = new EventEmitter<CalendarTodoMoveEvent>()
 
   readonly calendarOptions: CalendarOptions = {
     plugins: [dayGridPlugin],
     initialView: 'dayGridMonth',
-    locale: 'ja',
+    locale: jaLocale,
     height: 'auto',
     editable: false,
     dayMaxEvents: true,
@@ -61,6 +62,9 @@ export class CalendarViewComponent {
   }
 
   private toIsoDate(value: Date): string {
-    return value.toISOString().slice(0, 10)
+    const y = value.getFullYear()
+    const m = String(value.getMonth() + 1).padStart(2, '0')
+    const d = String(value.getDate()).padStart(2, '0')
+    return `${y}-${m}-${d}`
   }
 }


### PR DESCRIPTION
## Summary
- FullCalendar を使った standalone の `CalendarViewComponent` を追加し、月/週ビューの表示基盤を実装
- 表示期間変更 (`dateRangeChange`) とイベントクリック (`todoClick`) の出力を実装し、後続タスク（12.6以降）で再利用できる形に整理
- `docs/TODO_FEATURE_11_20.md` の `12.5` を `[x]` に更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`
- [ ] `CalendarPage` への統合動作確認（12.9 実装時に実施）


Made with [Cursor](https://cursor.com)