### PR TITLE
feat(frontend): Todo を FullCalendar イベントに変換 (12.6)

### DIFF
--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -40,7 +40,7 @@
 ### Frontend タスク（12タスク）
 - [x] 12.4: FullCalendar インストール
 - [x] 12.5: CalendarView コンポーネント作成
-- [ ] 12.6: Todo を FullCalendar イベントに変換
+- [x] 12.6: Todo を FullCalendar イベントに変換
 - [ ] 12.7: イベントクリックで Todo 詳細表示
 - [ ] 12.8: ドラッグ&ドロップで期限変更
 - [ ] 12.9: CalendarPage 作成

--- a/frontend/src/app/utils/todo-calendar-events.spec.ts
+++ b/frontend/src/app/utils/todo-calendar-events.spec.ts
@@ -66,12 +66,24 @@ describe('todoToCalendarEvent', () => {
   it('should apply completed styling', () => {
     const ev = todoToCalendarEvent(makeTodo({ completed: true }))
     expect(ev?.classNames).toEqual(['calendar-todo--completed'])
-    expect(ev?.textColor).toBeDefined()
+    expect(ev?.textColor).toBe('#546e7a')
   })
 
   it('should apply high priority colors when not completed', () => {
     const ev = todoToCalendarEvent(makeTodo({ priority: 'high', completed: false }))
     expect(ev?.borderColor).toBe('#e53935')
+  })
+
+  it('should apply medium priority colors', () => {
+    const ev = todoToCalendarEvent(makeTodo({ priority: 'medium', completed: false }))
+    expect(ev?.borderColor).toBe('#ffa000')
+    expect(ev?.backgroundColor).toBe('#fff8e1')
+  })
+
+  it('should apply low priority colors', () => {
+    const ev = todoToCalendarEvent(makeTodo({ priority: 'low', completed: false }))
+    expect(ev?.borderColor).toBe('#43a047')
+    expect(ev?.backgroundColor).toBe('#e8f5e9')
   })
 })
 

--- a/frontend/src/app/utils/todo-calendar-events.spec.ts
+++ b/frontend/src/app/utils/todo-calendar-events.spec.ts
@@ -1,0 +1,89 @@
+import type { Todo } from '../models/todo.interface'
+import {
+  normalizeTodoDueDateForCalendar,
+  todoToCalendarEvent,
+  todosToCalendarEvents
+} from './todo-calendar-events'
+
+function makeTodo(overrides: Partial<Todo> = {}): Todo {
+  return {
+    id: 1,
+    userId: 1,
+    title: 'Test',
+    description: null,
+    completed: false,
+    priority: 'medium',
+    dueDate: '2026-03-20',
+    sortOrder: 0,
+    projectId: null,
+    archived: false,
+    archivedAt: null,
+    reminderEnabled: false,
+    reminderSentAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('normalizeTodoDueDateForCalendar', () => {
+  it('should return YYYY-MM-DD from DATEONLY string', () => {
+    expect(normalizeTodoDueDateForCalendar('2026-03-20')).toBe('2026-03-20')
+  })
+
+  it('should take first 10 chars from ISO datetime', () => {
+    expect(normalizeTodoDueDateForCalendar('2026-03-20T00:00:00.000Z')).toBe('2026-03-20')
+  })
+})
+
+describe('todoToCalendarEvent', () => {
+  it('should return null when dueDate is null', () => {
+    expect(todoToCalendarEvent(makeTodo({ dueDate: null }))).toBeNull()
+  })
+
+  it('should return null when dueDate is empty', () => {
+    expect(todoToCalendarEvent(makeTodo({ dueDate: '' }))).toBeNull()
+  })
+
+  it('should map todo to all-day event with todoId in extendedProps', () => {
+    const ev = todoToCalendarEvent(makeTodo({ id: 42, title: 'Buy milk', dueDate: '2026-04-01' }))
+    expect(ev).toEqual(
+      jasmine.objectContaining({
+        id: '42',
+        title: 'Buy milk',
+        start: '2026-04-01',
+        allDay: true,
+        extendedProps: jasmine.objectContaining({
+          todoId: 42,
+          completed: false,
+          priority: 'medium'
+        })
+      })
+    )
+    expect(ev?.classNames).toBeUndefined()
+  })
+
+  it('should apply completed styling', () => {
+    const ev = todoToCalendarEvent(makeTodo({ completed: true }))
+    expect(ev?.classNames).toEqual(['calendar-todo--completed'])
+    expect(ev?.textColor).toBeDefined()
+  })
+
+  it('should apply high priority colors when not completed', () => {
+    const ev = todoToCalendarEvent(makeTodo({ priority: 'high', completed: false }))
+    expect(ev?.borderColor).toBe('#e53935')
+  })
+})
+
+describe('todosToCalendarEvents', () => {
+  it('should filter out todos without due date', () => {
+    const list = [
+      makeTodo({ id: 1, dueDate: '2026-03-01' }),
+      makeTodo({ id: 2, dueDate: null }),
+      makeTodo({ id: 3, dueDate: '2026-03-02' })
+    ]
+    const events = todosToCalendarEvents(list)
+    expect(events.length).toBe(2)
+    expect(events.map((e) => e.extendedProps?.['todoId'])).toEqual([1, 3])
+  })
+})

--- a/frontend/src/app/utils/todo-calendar-events.ts
+++ b/frontend/src/app/utils/todo-calendar-events.ts
@@ -44,8 +44,7 @@ export function todoToCalendarEvent(todo: Todo): EventInput | null {
       todoId: todo.id,
       completed: todo.completed,
       priority: todo.priority
-    },
-    ...(todo.completed ? { classNames: ['calendar-todo--completed'] } : {})
+    }
   }
 
   if (todo.completed) {
@@ -53,7 +52,8 @@ export function todoToCalendarEvent(todo: Todo): EventInput | null {
       ...base,
       backgroundColor: COMPLETED_COLORS.backgroundColor,
       borderColor: COMPLETED_COLORS.borderColor,
-      textColor: COMPLETED_COLORS.textColor
+      textColor: COMPLETED_COLORS.textColor,
+      classNames: ['calendar-todo--completed']
     }
   }
 

--- a/frontend/src/app/utils/todo-calendar-events.ts
+++ b/frontend/src/app/utils/todo-calendar-events.ts
@@ -1,0 +1,75 @@
+import type { EventInput } from '@fullcalendar/core'
+import type { Todo, TodoPriority } from '../models/todo.interface'
+
+/**
+ * API の dueDate は Sequelize DATEONLY 想定だが、将来の互換のため先頭10文字を日付として扱う。
+ * FullCalendar の終日イベントはローカル日付文字列（YYYY-MM-DD）が安全。
+ */
+export function normalizeTodoDueDateForCalendar(dueDate: string): string {
+  const trimmed = dueDate.trim()
+  if (trimmed.length >= 10) {
+    return trimmed.slice(0, 10)
+  }
+  return trimmed
+}
+
+const PRIORITY_COLORS: Record<TodoPriority, { backgroundColor: string; borderColor: string }> = {
+  low: { backgroundColor: '#e8f5e9', borderColor: '#43a047' },
+  medium: { backgroundColor: '#fff8e1', borderColor: '#ffa000' },
+  high: { backgroundColor: '#ffebee', borderColor: '#e53935' }
+}
+
+const COMPLETED_COLORS = {
+  backgroundColor: '#eceff1',
+  borderColor: '#90a4ae',
+  textColor: '#546e7a'
+}
+
+/**
+ * 1件の Todo を FullCalendar 用イベントに変換する。
+ * 期限なしはカレンダーに載せない（日付軸のビューと整合させるため）。
+ */
+export function todoToCalendarEvent(todo: Todo): EventInput | null {
+  if (todo.dueDate == null || todo.dueDate === '') {
+    return null
+  }
+
+  const start = normalizeTodoDueDateForCalendar(todo.dueDate)
+  const base = {
+    id: String(todo.id),
+    title: todo.title,
+    start,
+    allDay: true,
+    extendedProps: {
+      todoId: todo.id,
+      completed: todo.completed,
+      priority: todo.priority
+    },
+    ...(todo.completed ? { classNames: ['calendar-todo--completed'] } : {})
+  }
+
+  if (todo.completed) {
+    return {
+      ...base,
+      backgroundColor: COMPLETED_COLORS.backgroundColor,
+      borderColor: COMPLETED_COLORS.borderColor,
+      textColor: COMPLETED_COLORS.textColor
+    }
+  }
+
+  const { backgroundColor, borderColor } = PRIORITY_COLORS[todo.priority]
+  return {
+    ...base,
+    backgroundColor,
+    borderColor
+  }
+}
+
+/**
+ * Todo 一覧をカレンダー表示用イベント配列へ変換（期限なしは除外）。
+ */
+export function todosToCalendarEvents(todos: Todo[]): EventInput[] {
+  return todos
+    .map((t) => todoToCalendarEvent(t))
+    .filter((e): e is EventInput => e != null)
+}


### PR DESCRIPTION
## Summary
- `Todo` を FullCalendar の `EventInput`（終日・`extendedProps.todoId`）へ変換するユーティリティを追加
- 期限なし Todo はカレンダーから除外（日付軸ビューとの整合）
- 優先度・完了状態に応じた色分けと完了時の `classNames` を付与
- `docs/TODO_FEATURE_11_20.md` のタスク 12.6 を完了に更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`


Made with [Cursor](https://cursor.com)