### PR TITLE
fix(frontend): 12.7 レビュー対応（PR #97 マージ後に取り残された差分）

### DIFF
--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-page/calendar-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-page/calendar-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks, waitForAsync } from '@angular/core/testing'
+import { Subject } from 'rxjs'
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { MatDialog, MatDialogModule } from '@angular/material/dialog'
@@ -87,12 +88,44 @@ describe('CalendarPageComponent', () => {
     expect(component.todos).toEqual([])
   }))
 
+  it('should set error when API fails', fakeAsync(() => {
+    component.onDateRangeChange({ startDate: '2026-03-01', endDate: '2026-03-31' })
+    flushMicrotasks()
+
+    const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos` && r.method === 'GET')
+    req.flush({ message: '取得に失敗しました' }, { status: 500, statusText: 'Server Error' })
+    flushMicrotasks()
+
+    expect(component.error).toContain('取得に失敗しました')
+    expect(component.loading).toBe(false)
+  }))
+
   it('should open todo detail dialog on todoClick', () => {
-    const openSpy = spyOn(dialog, 'open')
+    const afterClosed$ = new Subject<void>()
+    const dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['afterClosed'])
+    dialogRefSpy.afterClosed.and.returnValue(afterClosed$.asObservable())
+    const openSpy = spyOn(dialog, 'open').and.returnValue(dialogRefSpy)
+
     component.onTodoClick(42)
     expect(openSpy).toHaveBeenCalledWith(TodoCalendarDetailDialogComponent, {
       width: '440px',
       data: { todoId: 42 }
     })
+  })
+
+  it('should not open a second dialog while the first is still open', () => {
+    const afterClosed$ = new Subject<void>()
+    const dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['afterClosed'])
+    dialogRefSpy.afterClosed.and.returnValue(afterClosed$.asObservable())
+    spyOn(dialog, 'open').and.returnValue(dialogRefSpy)
+
+    component.onTodoClick(1)
+    component.onTodoClick(2)
+    expect(dialog.open).toHaveBeenCalledTimes(1)
+
+    afterClosed$.next()
+    afterClosed$.complete()
+    component.onTodoClick(2)
+    expect(dialog.open).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/src/app/components/pages/dashboard/calendar/calendar-page/calendar-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/calendar-page/calendar-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core'
-import { MatDialog } from '@angular/material/dialog'
+import { MatDialog, MatDialogRef } from '@angular/material/dialog'
 import { Subject, takeUntil } from 'rxjs'
 import type { EventInput } from '@fullcalendar/core'
 import { CardComponent } from '../../../../../theme/shared/components/card/card.component'
@@ -27,6 +27,7 @@ export default class CalendarPageComponent implements OnDestroy {
 
   private range: CalendarDateRange | null = null
   private destroy$ = new Subject<void>()
+  private detailDialogRef: MatDialogRef<TodoCalendarDetailDialogComponent> | null = null
 
   constructor(
     private todoService: TodoService,
@@ -49,9 +50,13 @@ export default class CalendarPageComponent implements OnDestroy {
   }
 
   onTodoClick(todoId: number): void {
-    this.dialog.open(TodoCalendarDetailDialogComponent, {
+    if (this.detailDialogRef) return
+    this.detailDialogRef = this.dialog.open(TodoCalendarDetailDialogComponent, {
       width: '440px',
       data: { todoId }
+    })
+    this.detailDialogRef.afterClosed().pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.detailDialogRef = null
     })
   }
 

--- a/frontend/src/app/components/pages/dashboard/calendar/todo-calendar-detail-dialog/todo-calendar-detail-dialog.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/todo-calendar-detail-dialog/todo-calendar-detail-dialog.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog'
 import { environment } from '../../../../../../environments/environment'
 import { NetworkStatusService } from '../../../../../services/network-status.service'
@@ -39,7 +40,7 @@ describe('TodoCalendarDetailDialogComponent', () => {
     offlineStorage.saveTodos.and.returnValue(Promise.resolve())
 
     await TestBed.configureTestingModule({
-      imports: [TodoCalendarDetailDialogComponent, HttpClientTestingModule],
+      imports: [TodoCalendarDetailDialogComponent, HttpClientTestingModule, NoopAnimationsModule],
       providers: [
         TodoService,
         { provide: NetworkStatusService, useValue: networkStatus },

--- a/frontend/src/app/components/pages/dashboard/calendar/todo-calendar-detail-dialog/todo-calendar-detail-dialog.component.ts
+++ b/frontend/src/app/components/pages/dashboard/calendar/todo-calendar-detail-dialog/todo-calendar-detail-dialog.component.ts
@@ -41,7 +41,7 @@ export class TodoCalendarDetailDialogComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>()
 
   constructor(
-    public dialogRef: MatDialogRef<TodoCalendarDetailDialogComponent>,
+    private readonly dialogRef: MatDialogRef<TodoCalendarDetailDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: TodoCalendarDetailDialogData,
     private todoService: TodoService
   ) {}
@@ -56,7 +56,7 @@ export class TodoCalendarDetailDialogComponent implements OnInit, OnDestroy {
           this.loading = false
         },
         error: (err) => {
-          this.error = err?.error?.message ?? err?.message ?? '取得に失敗しました。'
+          this.error = err?.error?.message ?? err?.message ?? '取得に失敗しました'
           this.loading = false
         }
       })


### PR DESCRIPTION
## 背景
PR #97 マージ後にローカルにのみ存在していたレビュー対応コミットを `main` へ取り込む。

## 内容
- 詳細ダイアログ連打時の多重オープン防止（`detailDialogRef` + `afterClosed` を `takeUntil(destroy$)` で購読）
- `CalendarPageComponent` の API 失敗時 spec
- `TodoCalendarDetailDialogComponent` spec に `NoopAnimationsModule`
- `dialogRef` を `private readonly` に、エラー文言の句読点統一

## 備考
cherry-pick によりコミットハッシュのみ変化（内容は同一）。

Made with [Cursor](https://cursor.com)