### PR TITLE
feat(backend): AnalyticsService（13.1-13.6）と Backend テスト（13.9）

### DIFF
--- a/backend/models/tag.js
+++ b/backend/models/tag.js
@@ -47,7 +47,12 @@ module.exports = (sequelize) => {
 
   Tag.associate = function (models) {
     Tag.belongsTo(models.User, { foreignKey: 'userId' });
-    Tag.belongsToMany(models.Todo, { through: models.TodoTag, foreignKey: 'tagId', otherKey: 'todoId' });
+    Tag.belongsToMany(models.Todo, {
+      through: models.TodoTag,
+      foreignKey: 'tagId',
+      otherKey: 'todoId',
+      as: 'Todos',
+    });
   };
 
   return Tag;

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -92,7 +92,12 @@ module.exports = (sequelize) => {
   Todo.associate = function (models) {
     Todo.belongsTo(models.User, { foreignKey: 'userId' });
     Todo.belongsTo(models.Project, { foreignKey: 'projectId' });
-    Todo.belongsToMany(models.Tag, { through: models.TodoTag, foreignKey: 'todoId', otherKey: 'tagId' });
+    Todo.belongsToMany(models.Tag, {
+      through: models.TodoTag,
+      foreignKey: 'todoId',
+      otherKey: 'tagId',
+      as: 'Tags',
+    });
     Todo.hasMany(models.TodoShare, { foreignKey: 'todoId' });
   };
 

--- a/backend/services/analyticsService.js
+++ b/backend/services/analyticsService.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const { Op, fn, col } = require('sequelize');
+
+/** 完了率の期間（日数）。all はフィルタなし */
+const PERIOD_DAYS = {
+  week: 7,
+  month: 30,
+  year: 365,
+};
+
+/**
+ * 期間指定の開始日時（UTC 0:00 基準）。all / 不正値は null。
+ * @param {string} period
+ * @returns {Date | null}
+ */
+function startOfPeriodUtc(period) {
+  if (period == null || period === 'all') return null;
+  const days = PERIOD_DAYS[period];
+  if (days == null) return null;
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() - days);
+  return d;
+}
+
+/**
+ * 正規化した period ラベル（API 応答用）
+ * @param {string} period
+ * @returns {string}
+ */
+function normalizePeriod(period) {
+  if (period == null || period === 'all' || PERIOD_DAYS[period] == null) return 'all';
+  return period;
+}
+
+/**
+ * アーカイブ除外・ユーザー単位の Todo に対する完了率（期間内に更新があったものに限定）
+ * @param {object} fastify
+ * @param {number} userId
+ * @param {string} [period='all'] - week | month | year | all
+ * @returns {Promise<{ period: string, total: number, completed: number, rate: number }>}
+ */
+async function getCompletionRate(fastify, userId, period = 'all') {
+  const where = { userId, archived: false };
+  const start = startOfPeriodUtc(period);
+  if (start) {
+    where.updatedAt = { [Op.gte]: start };
+  }
+  const rows = await fastify.models.Todo.findAll({
+    where,
+    attributes: ['completed'],
+    raw: true,
+  });
+  const total = rows.length;
+  const completed = rows.filter((r) => r.completed).length;
+  return {
+    period: normalizePeriod(period),
+    total,
+    completed,
+    rate: total === 0 ? 0 : completed / total,
+  };
+}
+
+/**
+ * 優先度別 Todo 件数（アーカイブ除外）
+ * @param {object} fastify
+ * @param {number} userId
+ * @returns {Promise<{ low: number, medium: number, high: number }>}
+ */
+async function getTodosByPriority(fastify, userId) {
+  const rows = await fastify.models.Todo.findAll({
+    where: { userId, archived: false },
+    attributes: ['priority', [fn('COUNT', col('id')), 'count']],
+    group: ['priority'],
+    raw: true,
+  });
+  const out = { low: 0, medium: 0, high: 0 };
+  for (const r of rows) {
+    const c = Number(r.count);
+    if (r.priority === 'low') out.low = c;
+    else if (r.priority === 'medium') out.medium = c;
+    else if (r.priority === 'high') out.high = c;
+  }
+  return out;
+}
+
+/**
+ * タグ別 Todo 件数（タグ未使用は含めない。0件のタグも列挙）
+ * @param {object} fastify
+ * @param {number} userId
+ * @returns {Promise<Array<{ tagId: number, name: string, color: string, count: number }>>}
+ */
+async function getTodosByTag(fastify, userId) {
+  const tags = await fastify.models.Tag.findAll({
+    where: { userId },
+    include: [
+      {
+        model: fastify.models.Todo,
+        as: 'Todos',
+        where: { archived: false },
+        required: false,
+        through: { attributes: [] },
+      },
+    ],
+    order: [['name', 'ASC']],
+  });
+  return tags.map((t) => {
+    const plain = t.toJSON();
+    const count = Array.isArray(plain.Todos) ? plain.Todos.length : 0;
+    return { tagId: t.id, name: t.name, color: t.color, count };
+  });
+}
+
+/**
+ * プロジェクト別 Todo 件数（プロジェクトなしは projectId: null / name: 未分類）
+ * @param {object} fastify
+ * @param {number} userId
+ * @returns {Promise<Array<{ projectId: number | null, name: string, count: number }>>}
+ */
+async function getTodosByProject(fastify, userId) {
+  const rows = await fastify.models.Todo.findAll({
+    where: { userId, archived: false },
+    attributes: ['projectId', [fn('COUNT', col('id')), 'count']],
+    group: ['projectId'],
+    raw: true,
+  });
+  const ids = rows.map((r) => r.projectId).filter((id) => id != null);
+  const projects =
+    ids.length === 0
+      ? []
+      : await fastify.models.Project.findAll({
+          where: { userId, id: { [Op.in]: ids } },
+          attributes: ['id', 'name'],
+          raw: true,
+        });
+  const nameById = new Map(projects.map((p) => [p.id, p.name]));
+  return rows.map((r) => {
+    const pid = r.projectId;
+    const count = Number(r.count);
+    if (pid == null) {
+      return { projectId: null, name: '未分類', count };
+    }
+    return {
+      projectId: pid,
+      name: nameById.get(pid) ?? '不明',
+      count,
+    };
+  });
+}
+
+/**
+ * 直近7日（UTC 日付）の作成数・完了数（その日に作成 / その日に更新され完了になった件数の近似）
+ * @param {object} fastify
+ * @param {number} userId
+ * @returns {Promise<{ days: Array<{ date: string, created: number, completed: number }> }>}
+ */
+async function getWeeklyStats(fastify, userId) {
+  const days = [];
+  for (let i = 6; i >= 0; i -= 1) {
+    const start = new Date();
+    start.setUTCHours(0, 0, 0, 0);
+    start.setUTCDate(start.getUTCDate() - i);
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 1);
+    const dateStr = start.toISOString().slice(0, 10);
+    const [created, completed] = await Promise.all([
+      fastify.models.Todo.count({
+        where: {
+          userId,
+          archived: false,
+          createdAt: { [Op.gte]: start, [Op.lt]: end },
+        },
+      }),
+      fastify.models.Todo.count({
+        where: {
+          userId,
+          archived: false,
+          completed: true,
+          updatedAt: { [Op.gte]: start, [Op.lt]: end },
+        },
+      }),
+    ]);
+    days.push({ date: dateStr, created, completed });
+  }
+  return { days };
+}
+
+module.exports = {
+  getCompletionRate,
+  getTodosByPriority,
+  getTodosByTag,
+  getTodosByProject,
+  getWeeklyStats,
+};

--- a/backend/services/analyticsService.js
+++ b/backend/services/analyticsService.js
@@ -2,7 +2,9 @@
 
 const { Op, fn, col } = require('sequelize');
 
-/** 完了率の期間（日数）。all はフィルタなし */
+/**
+ * 完了率の期間（日数）。month / year は近似（30 日・365 日、閏年・月末差は未考慮）。all はフィルタなし。
+ */
 const PERIOD_DAYS = {
   week: 7,
   month: 30,

--- a/backend/test/services/analyticsService.test.js
+++ b/backend/test/services/analyticsService.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert');
+const { Op } = require('sequelize');
 const analyticsService = require('../../services/analyticsService');
 
 function createMockFastify(overrides = {}) {
@@ -54,6 +55,18 @@ test('getCompletionRate: 不正 period は all として扱う', async () => {
   });
   const r = await analyticsService.getCompletionRate(fastify, 1, 'invalid');
   assert.strictEqual(r.period, 'all');
+});
+
+test('getCompletionRate: week のとき updatedAt フィルタが where に付く', async () => {
+  const fastify = createMockFastify({
+    TodoFindAll: (opts) => {
+      assert.ok(opts.where.updatedAt != null);
+      assert.ok(opts.where.updatedAt[Op.gte] instanceof Date);
+      return Promise.resolve([]);
+    },
+  });
+  const r = await analyticsService.getCompletionRate(fastify, 1, 'week');
+  assert.strictEqual(r.period, 'week');
 });
 
 test('getTodosByPriority: 集計を low/medium/high にマップ', async () => {
@@ -129,4 +142,20 @@ test('getWeeklyStats: 7 日分の count を返す', async () => {
   assert.strictEqual(r.days.length, 7);
   assert.match(r.days[0].date, /^\d{4}-\d{2}-\d{2}$/);
   assert.strictEqual(n, 14);
+});
+
+test('getWeeklyStats: 各日の created / completed が Todo.count の結果を反映', async () => {
+  const fastify = createMockFastify({
+    TodoCount: (opts) => {
+      if (opts.where.createdAt != null) return Promise.resolve(4);
+      if (opts.where.updatedAt != null && opts.where.completed === true) return Promise.resolve(2);
+      assert.fail('unexpected Todo.count where shape');
+    },
+  });
+  const r = await analyticsService.getWeeklyStats(fastify, 1);
+  assert.strictEqual(r.days.length, 7);
+  for (const day of r.days) {
+    assert.strictEqual(day.created, 4);
+    assert.strictEqual(day.completed, 2);
+  }
 });

--- a/backend/test/services/analyticsService.test.js
+++ b/backend/test/services/analyticsService.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const analyticsService = require('../../services/analyticsService');
+
+function createMockFastify(overrides = {}) {
+  const Todo = {
+    findAll: overrides.TodoFindAll ?? (() => Promise.resolve([])),
+    count: overrides.TodoCount ?? (() => Promise.resolve(0)),
+  };
+  const Tag = {
+    findAll: overrides.TagFindAll ?? (() => Promise.resolve([])),
+  };
+  const Project = {
+    findAll: overrides.ProjectFindAll ?? (() => Promise.resolve([])),
+  };
+  return {
+    models: { Todo, Tag, Project, ...overrides.models },
+  };
+}
+
+test('getCompletionRate: all のとき全件から率を計算', async () => {
+  const fastify = createMockFastify({
+    TodoFindAll: () =>
+      Promise.resolve([
+        { completed: true },
+        { completed: false },
+        { completed: true },
+      ]),
+  });
+  const r = await analyticsService.getCompletionRate(fastify, 1, 'all');
+  assert.strictEqual(r.period, 'all');
+  assert.strictEqual(r.total, 3);
+  assert.strictEqual(r.completed, 2);
+  assert.strictEqual(r.rate, 2 / 3);
+});
+
+test('getCompletionRate: 件数0なら rate は 0', async () => {
+  const fastify = createMockFastify({ TodoFindAll: () => Promise.resolve([]) });
+  const r = await analyticsService.getCompletionRate(fastify, 1, 'all');
+  assert.strictEqual(r.total, 0);
+  assert.strictEqual(r.rate, 0);
+});
+
+test('getCompletionRate: 不正 period は all として扱う', async () => {
+  const fastify = createMockFastify({
+    TodoFindAll: (opts) => {
+      assert.strictEqual(opts.where.archived, false);
+      assert.strictEqual(opts.where.userId, 1);
+      assert.strictEqual(opts.where.updatedAt, undefined);
+      return Promise.resolve([{ completed: false }]);
+    },
+  });
+  const r = await analyticsService.getCompletionRate(fastify, 1, 'invalid');
+  assert.strictEqual(r.period, 'all');
+});
+
+test('getTodosByPriority: 集計を low/medium/high にマップ', async () => {
+  const fastify = createMockFastify({
+    TodoFindAll: () =>
+      Promise.resolve([
+        { priority: 'low', count: '2' },
+        { priority: 'high', count: '1' },
+      ]),
+  });
+  const r = await analyticsService.getTodosByPriority(fastify, 1);
+  assert.deepStrictEqual(r, { low: 2, medium: 0, high: 1 });
+});
+
+test('getTodosByTag: タグごとの件数', async () => {
+  const tagA = {
+    id: 1,
+    name: 'work',
+    color: '#111111',
+    toJSON: () => ({ Todos: [{ id: 1 }, { id: 2 }] }),
+  };
+  const tagB = {
+    id: 2,
+    name: 'home',
+    color: '#222222',
+    toJSON: () => ({ Todos: [] }),
+  };
+  const fastify = createMockFastify({
+    TagFindAll: () => Promise.resolve([tagA, tagB]),
+  });
+  const r = await analyticsService.getTodosByTag(fastify, 1);
+  assert.deepStrictEqual(r, [
+    { tagId: 1, name: 'work', color: '#111111', count: 2 },
+    { tagId: 2, name: 'home', color: '#222222', count: 0 },
+  ]);
+});
+
+test('getTodosByProject: 未分類とプロジェクト名', async () => {
+  const fastify = createMockFastify({
+    TodoFindAll: () =>
+      Promise.resolve([
+        { projectId: null, count: '3' },
+        { projectId: 10, count: '1' },
+      ]),
+    ProjectFindAll: () => Promise.resolve([{ id: 10, name: 'ProjA' }]),
+  });
+  const r = await analyticsService.getTodosByProject(fastify, 1);
+  assert.strictEqual(r.length, 2);
+  const unassigned = r.find((x) => x.projectId === null);
+  const assigned = r.find((x) => x.projectId === 10);
+  assert.deepStrictEqual(unassigned, { projectId: null, name: '未分類', count: 3 });
+  assert.deepStrictEqual(assigned, { projectId: 10, name: 'ProjA', count: 1 });
+});
+
+test('getTodosByProject: プロジェクト ID があるが名称不明', async () => {
+  const fastify = createMockFastify({
+    TodoFindAll: () => Promise.resolve([{ projectId: 99, count: '1' }]),
+    ProjectFindAll: () => Promise.resolve([]),
+  });
+  const r = await analyticsService.getTodosByProject(fastify, 1);
+  assert.deepStrictEqual(r[0], { projectId: 99, name: '不明', count: 1 });
+});
+
+test('getWeeklyStats: 7 日分の count を返す', async () => {
+  let n = 0;
+  const fastify = createMockFastify({
+    TodoCount: () => {
+      n += 1;
+      return Promise.resolve(n % 2);
+    },
+  });
+  const r = await analyticsService.getWeeklyStats(fastify, 1);
+  assert.strictEqual(r.days.length, 7);
+  assert.match(r.days[0].date, /^\d{4}-\d{2}-\d{2}$/);
+  assert.strictEqual(n, 14);
+});

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -56,15 +56,15 @@
 - 既存テーブルのみ使用（集計クエリ）
 
 ### Backend タスク（10タスク）
-- [ ] 13.1: AnalyticsService 作成
-- [ ] 13.2: `getCompletionRate(userId, period)` 実装
-- [ ] 13.3: `getTodosByPriority(userId)` 実装
-- [ ] 13.4: `getTodosByTag(userId)` 実装
-- [ ] 13.5: `getTodosByProject(userId)` 実装
-- [ ] 13.6: `getWeeklyStats(userId)` 実装
+- [x] 13.1: AnalyticsService 作成
+- [x] 13.2: `getCompletionRate(userId, period)` 実装
+- [x] 13.3: `getTodosByPriority(userId)` 実装
+- [x] 13.4: `getTodosByTag(userId)` 実装
+- [x] 13.5: `getTodosByProject(userId)` 実装
+- [x] 13.6: `getWeeklyStats(userId)` 実装
 - [ ] 13.7: AnalyticsController 作成
 - [ ] 13.8: Analytics ルート作成（GET /api/analytics/*)
-- [ ] 13.9: Backend テスト
+- [x] 13.9: Backend テスト
 
 ### Frontend タスク（15タスク）
 - [ ] 13.10: AnalyticsService 作成


### PR DESCRIPTION
## 概要
機能13のバックエンドで、**集計サービス層（13.1〜13.6）** と **サービス単体テスト（13.9）** を実装しました。HTTP（**13.7 / 13.8**）は未着手のため次 PR で対応します。

## 実装（`backend/services/analyticsService.js`）
| メソッド | 内容 |
|---------|------|
| `getCompletionRate(fastify, userId, period)` | `week` / `month` / `year` / `all`（不正値は all）。期間内 `updatedAt` の非アーカイブ Todo の完了率 |
| `getTodosByPriority` | 優先度別件数 |
| `getTodosByTag` | ユーザーの全タグ＋紐づく非アーカイブ Todo 件数 |
| `getTodosByProject` | `projectId` 別件数、null は「未分類」 |
| `getWeeklyStats` | UTC で直近7日、日別の作成数・完了数（`updatedAt` ベースの完了は近似） |

## テスト
- `backend/test/services/analyticsService.test.js`（モック）
- Docker 上で `npm run test` 全件成功

## TODO
`docs/TODO_FEATURE_11_20.md` で **13.1〜13.6 / 13.9 を `[x]`**、13.7・13.8 は未チェックのまま。

## レビュー依頼
仕様・集計定義・タグ include の `as: Todos` など、ご確認ください。**レビューをお願いします。**

Made with [Cursor](https://cursor.com)