### PR TITLE
feat(backend): 13.7/13.8 Analytics API ルート追加

### DIFF
--- a/backend/controllers/analyticsController.js
+++ b/backend/controllers/analyticsController.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const analyticsService = require('../services/analyticsService');
+
+function handleAnalyticsError(fastify, reply, error, clientMessage, statusCode = 500) {
+  fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, clientMessage);
+  reply.code(statusCode).send({ error: clientMessage });
+}
+
+async function getCompletionRate(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const period = req.query.period;
+    const data = await analyticsService.getCompletionRate(fastify, userId, period);
+    reply.code(200).send(data);
+  } catch (error) {
+    handleAnalyticsError(fastify, reply, error, 'Failed to get completion rate');
+  }
+}
+
+async function getTodosByPriority(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const data = await analyticsService.getTodosByPriority(fastify, userId);
+    reply.code(200).send(data);
+  } catch (error) {
+    handleAnalyticsError(fastify, reply, error, 'Failed to get todos by priority');
+  }
+}
+
+async function getTodosByTag(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const data = await analyticsService.getTodosByTag(fastify, userId);
+    reply.code(200).send(data);
+  } catch (error) {
+    handleAnalyticsError(fastify, reply, error, 'Failed to get todos by tag');
+  }
+}
+
+async function getTodosByProject(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const data = await analyticsService.getTodosByProject(fastify, userId);
+    reply.code(200).send(data);
+  } catch (error) {
+    handleAnalyticsError(fastify, reply, error, 'Failed to get todos by project');
+  }
+}
+
+async function getWeeklyStats(fastify, req, reply) {
+  try {
+    const userId = req.user.id;
+    const data = await analyticsService.getWeeklyStats(fastify, userId);
+    reply.code(200).send(data);
+  } catch (error) {
+    handleAnalyticsError(fastify, reply, error, 'Failed to get weekly stats');
+  }
+}
+
+module.exports = {
+  getCompletionRate,
+  getTodosByPriority,
+  getTodosByTag,
+  getTodosByProject,
+  getWeeklyStats,
+};

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -52,6 +52,13 @@ const {
 const { exportTodos } = require('../../../controllers/exportController');
 const { importTodos } = require('../../../controllers/importController');
 const { shareTodo, getSharedTodos, deleteShare } = require('../../../controllers/shareController');
+const {
+  getCompletionRate,
+  getTodosByPriority: getAnalyticsByPriority,
+  getTodosByTag: getAnalyticsByTag,
+  getTodosByProject: getAnalyticsByProject,
+  getWeeklyStats,
+} = require('../../../controllers/analyticsController');
 
 module.exports = async function (fastify, opts) {
   /**
@@ -652,5 +659,37 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => deleteShare(fastify, request, reply),
+  });
+
+  /**
+   * Analytics（JWT 必須）— 既存 API と同様に /api/v1 配下
+   */
+  fastify.get('/analytics/completion-rate', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          period: { type: 'string', enum: ['week', 'month', 'year', 'all'] },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getCompletionRate(fastify, request, reply),
+  });
+  fastify.get('/analytics/by-priority', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getAnalyticsByPriority(fastify, request, reply),
+  });
+  fastify.get('/analytics/by-tag', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getAnalyticsByTag(fastify, request, reply),
+  });
+  fastify.get('/analytics/by-project', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getAnalyticsByProject(fastify, request, reply),
+  });
+  fastify.get('/analytics/weekly', {
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getWeeklyStats(fastify, request, reply),
   });
 }

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -664,31 +664,106 @@ module.exports = async function (fastify, opts) {
   /**
    * Analytics（JWT 必須）— 既存 API と同様に /api/v1 配下
    */
+  const analyticsCompletionRateResponse = {
+    type: 'object',
+    required: ['period', 'total', 'completed', 'rate'],
+    properties: {
+      period: { type: 'string' },
+      total: { type: 'number' },
+      completed: { type: 'number' },
+      rate: { type: 'number' },
+    },
+  };
+  const analyticsByPriorityResponse = {
+    type: 'object',
+    required: ['low', 'medium', 'high'],
+    properties: {
+      low: { type: 'number' },
+      medium: { type: 'number' },
+      high: { type: 'number' },
+    },
+  };
+  const analyticsByTagResponse = {
+    type: 'array',
+    items: {
+      type: 'object',
+      required: ['tagId', 'name', 'color', 'count'],
+      properties: {
+        tagId: { type: 'integer' },
+        name: { type: 'string' },
+        color: { type: 'string' },
+        count: { type: 'number' },
+      },
+    },
+  };
+  const analyticsByProjectResponse = {
+    type: 'array',
+    items: {
+      type: 'object',
+      required: ['projectId', 'name', 'count'],
+      properties: {
+        projectId: { type: ['integer', 'null'] },
+        name: { type: 'string' },
+        count: { type: 'number' },
+      },
+    },
+  };
+  const analyticsWeeklyResponse = {
+    type: 'object',
+    required: ['days'],
+    properties: {
+      days: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['date', 'created', 'completed'],
+          properties: {
+            date: { type: 'string' },
+            created: { type: 'number' },
+            completed: { type: 'number' },
+          },
+        },
+      },
+    },
+  };
   fastify.get('/analytics/completion-rate', {
     schema: {
       querystring: {
         type: 'object',
         properties: {
-          period: { type: 'string', enum: ['week', 'month', 'year', 'all'] },
+          period: { type: 'string', enum: ['week', 'month', 'year', 'all'], default: 'all' },
         },
       },
+      response: { 200: analyticsCompletionRateResponse },
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getCompletionRate(fastify, request, reply),
   });
   fastify.get('/analytics/by-priority', {
+    schema: {
+      response: { 200: analyticsByPriorityResponse },
+    },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getAnalyticsByPriority(fastify, request, reply),
   });
   fastify.get('/analytics/by-tag', {
+    schema: {
+      response: { 200: analyticsByTagResponse },
+    },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getAnalyticsByTag(fastify, request, reply),
   });
   fastify.get('/analytics/by-project', {
+    schema: {
+      response: { 200: analyticsByProjectResponse },
+    },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getAnalyticsByProject(fastify, request, reply),
   });
   fastify.get('/analytics/weekly', {
+    schema: {
+      response: { 200: analyticsWeeklyResponse },
+    },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getWeeklyStats(fastify, request, reply),
   });

--- a/backend/test/routes/analytics.test.js
+++ b/backend/test/routes/analytics.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { build } = require('../helper');
+
+function uniqueSuffix() {
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+async function registerAndLogin(app) {
+  const suffix = uniqueSuffix();
+  const user = { name: `u-${suffix}`, email: `u-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/login',
+    payload: { email: user.email, password: user.password },
+  });
+  assert.strictEqual(loginRes.statusCode, 200);
+  return JSON.parse(loginRes.payload).token;
+}
+
+const analyticsPaths = [
+  '/api/v1/analytics/completion-rate',
+  '/api/v1/analytics/by-priority',
+  '/api/v1/analytics/by-tag',
+  '/api/v1/analytics/by-project',
+  '/api/v1/analytics/weekly',
+];
+
+for (const path of analyticsPaths) {
+  test(`GET ${path} without auth returns 401`, async (t) => {
+    const app = await build(t);
+    const res = await app.inject({ method: 'GET', url: path });
+    assert.strictEqual(res.statusCode, 401);
+  });
+}
+
+test('GET /api/v1/analytics/completion-rate invalid period returns 400', async (t) => {
+  const app = await build(t);
+  const token = await registerAndLogin(app);
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/analytics/completion-rate',
+    query: { period: 'invalid' },
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(res.statusCode, 400);
+});
+
+test('GET /api/v1/analytics/* with auth returns expected JSON shapes', async (t) => {
+  const app = await build(t);
+  const token = await registerAndLogin(app);
+  const auth = { authorization: `Bearer ${token}` };
+
+  const cr = await app.inject({
+    method: 'GET',
+    url: '/api/v1/analytics/completion-rate',
+    query: { period: 'all' },
+    headers: auth,
+  });
+  assert.strictEqual(cr.statusCode, 200);
+  const crBody = JSON.parse(cr.payload);
+  assert.strictEqual(crBody.period, 'all');
+  assert.strictEqual(typeof crBody.total, 'number');
+  assert.strictEqual(typeof crBody.completed, 'number');
+  assert.strictEqual(typeof crBody.rate, 'number');
+
+  const pr = await app.inject({ method: 'GET', url: '/api/v1/analytics/by-priority', headers: auth });
+  assert.strictEqual(pr.statusCode, 200);
+  const prBody = JSON.parse(pr.payload);
+  assert.strictEqual(typeof prBody.low, 'number');
+  assert.strictEqual(typeof prBody.medium, 'number');
+  assert.strictEqual(typeof prBody.high, 'number');
+
+  const tg = await app.inject({ method: 'GET', url: '/api/v1/analytics/by-tag', headers: auth });
+  assert.strictEqual(tg.statusCode, 200);
+  assert.ok(Array.isArray(JSON.parse(tg.payload)));
+
+  const pj = await app.inject({ method: 'GET', url: '/api/v1/analytics/by-project', headers: auth });
+  assert.strictEqual(pj.statusCode, 200);
+  assert.ok(Array.isArray(JSON.parse(pj.payload)));
+
+  const wk = await app.inject({ method: 'GET', url: '/api/v1/analytics/weekly', headers: auth });
+  assert.strictEqual(wk.statusCode, 200);
+  const wkBody = JSON.parse(wk.payload);
+  assert.ok(Array.isArray(wkBody.days));
+  assert.strictEqual(wkBody.days.length, 7);
+  assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(wkBody.days[0].date));
+  assert.strictEqual(typeof wkBody.days[0].created, 'number');
+  assert.strictEqual(typeof wkBody.days[0].completed, 'number');
+});

--- a/backend/test/routes/analytics.test.js
+++ b/backend/test/routes/analytics.test.js
@@ -5,6 +5,16 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const { build } = require('../helper');
 
+const analyticsServiceResolved = require.resolve('../../services/analyticsService.js');
+const analyticsControllerResolved = require.resolve('../../controllers/analyticsController.js');
+const analyticsRoutesResolved = require.resolve('../../routes/api/v1/index.js');
+
+function bustAnalyticsRouteCache() {
+  delete require.cache[analyticsServiceResolved];
+  delete require.cache[analyticsControllerResolved];
+  delete require.cache[analyticsRoutesResolved];
+}
+
 function uniqueSuffix() {
   return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
 }
@@ -91,4 +101,43 @@ test('GET /api/v1/analytics/* with auth returns expected JSON shapes', async (t)
   assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(wkBody.days[0].date));
   assert.strictEqual(typeof wkBody.days[0].created, 'number');
   assert.strictEqual(typeof wkBody.days[0].completed, 'number');
+});
+
+test('GET /api/v1/analytics/completion-rate omits period → 200 and period all (schema default)', async (t) => {
+  const app = await build(t);
+  const token = await registerAndLogin(app);
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/analytics/completion-rate',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(JSON.parse(res.payload).period, 'all');
+});
+
+test('GET /api/v1/analytics/completion-rate service throws → 500 and { error: string }', async (t) => {
+  bustAnalyticsRouteCache();
+  const real = require('../../services/analyticsService');
+  require.cache[analyticsServiceResolved].exports = {
+    ...real,
+    getCompletionRate: async () => {
+      throw new Error('simulated service failure');
+    },
+  };
+  t.after(() => {
+    bustAnalyticsRouteCache();
+  });
+
+  const app = await build(t);
+  const token = await registerAndLogin(app);
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/analytics/completion-rate',
+    query: { period: 'all' },
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(res.statusCode, 500);
+  const body = JSON.parse(res.payload);
+  assert.strictEqual(typeof body.error, 'string');
+  assert.ok(body.error.length > 0);
 });

--- a/docs/TODO_FEATURE_11_20.md
+++ b/docs/TODO_FEATURE_11_20.md
@@ -62,8 +62,8 @@
 - [x] 13.4: `getTodosByTag(userId)` 実装
 - [x] 13.5: `getTodosByProject(userId)` 実装
 - [x] 13.6: `getWeeklyStats(userId)` 実装
-- [ ] 13.7: AnalyticsController 作成
-- [ ] 13.8: Analytics ルート作成（GET /api/analytics/*)
+- [x] 13.7: AnalyticsController 作成
+- [x] 13.8: Analytics ルート作成（GET /api/v1/analytics/*)
 - [x] 13.9: Backend テスト
 
 ### Frontend タスク（15タスク）


### PR DESCRIPTION
## 概要
機能13のバックエンド続きとして、AnalyticsController と `/api/v1/analytics/*` の GET ルートを追加します（既存 API と同様に v1 プレフィックス）。

## 変更内容
- `backend/controllers/analyticsController.js` … `analyticsService` を薄くラップ。エラー時はログと `{ error }` 応答。
- `backend/routes/api/v1/index.js` … 以下を JWT 必須で登録
  - `GET /analytics/completion-rate`（クエリ `period` は列挙でバリデーション）
  - `GET /analytics/by-priority` / `by-tag` / `by-project` / `weekly`
- `backend/test/routes/analytics.test.js` … 未認証 401、不正 period 400、認証時の JSON 形の確認

## テスト
`docker compose run --rm backend npm run test` で全件パス済み。

## TODO
`docs/TODO_FEATURE_11_20.md` の 13.7・13.8 を `[x]` に更新（13.8 のパス表記は実装に合わせ `/api/v1/analytics/*`）。

## レビュー依頼
内容・命名・スキーマの付け方など、ご指摘あればお願いします。マージ後は 13.10 以降（フロント）に進めます。

Made with [Cursor](https://cursor.com)