### PR TITLE
feat(9): Todo コメント API・一覧 UI（todo-item 折りたたみ）

### DIFF
--- a/backend/controllers/commentController.js
+++ b/backend/controllers/commentController.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const commentService = require('../services/commentService');
+
+function handleError(fastify, reply, error, clientMessage, statusCode = 500) {
+  fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, clientMessage);
+  reply.code(statusCode).send({ error: clientMessage });
+}
+
+function parseId(param) {
+  const id = parseInt(param, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+async function getCommentsForTodo(fastify, req, reply) {
+  try {
+    const todoId = parseId(req.params.todoId);
+    if (todoId === null) return reply.code(400).send({ error: 'Invalid todo id' });
+    const list = await commentService.getCommentsByTodoId(fastify, todoId, req.user.id);
+    if (list === null) return reply.code(403).send({ error: 'Forbidden' });
+    reply.code(200).send(list);
+  } catch (error) {
+    handleError(fastify, reply, error, 'Failed to get comments');
+  }
+}
+
+async function postComment(fastify, req, reply) {
+  try {
+    const todoId = parseId(req.params.todoId);
+    if (todoId === null) return reply.code(400).send({ error: 'Invalid todo id' });
+    const result = await commentService.createComment(fastify, todoId, req.user.id, req.body.content);
+    if (result === null) return reply.code(403).send({ error: 'Forbidden' });
+    if (result.invalid) return reply.code(400).send({ error: result.message });
+    reply.code(201).send(result);
+  } catch (error) {
+    handleError(fastify, reply, error, 'Failed to create comment');
+  }
+}
+
+async function putComment(fastify, req, reply) {
+  try {
+    const commentId = parseId(req.params.id);
+    if (commentId === null) return reply.code(400).send({ error: 'Invalid comment id' });
+    const result = await commentService.updateComment(fastify, commentId, req.user.id, req.body.content);
+    if (result === null) return reply.code(404).send({ error: 'Not found' });
+    if (result === false) return reply.code(403).send({ error: 'Forbidden' });
+    if (result.invalid) return reply.code(400).send({ error: result.message });
+    reply.code(200).send(result);
+  } catch (error) {
+    handleError(fastify, reply, error, 'Failed to update comment');
+  }
+}
+
+async function deleteComment(fastify, req, reply) {
+  try {
+    const commentId = parseId(req.params.id);
+    if (commentId === null) return reply.code(400).send({ error: 'Invalid comment id' });
+    const result = await commentService.deleteComment(fastify, commentId, req.user.id);
+    if (result === null) return reply.code(404).send({ error: 'Not found' });
+    if (result === false) return reply.code(403).send({ error: 'Forbidden' });
+    reply.code(204).send();
+  } catch (error) {
+    handleError(fastify, reply, error, 'Failed to delete comment');
+  }
+}
+
+module.exports = {
+  getCommentsForTodo,
+  postComment,
+  putComment,
+  deleteComment,
+};

--- a/backend/migrations/20260322180000-create-comments.js
+++ b/backend/migrations/20260322180000-create-comments.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('comments', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      todo_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      content: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+    await queryInterface.addIndex('comments', ['todo_id']);
+    await queryInterface.addIndex('comments', ['user_id']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('comments');
+  },
+};

--- a/backend/models/comment.js
+++ b/backend/models/comment.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { DataTypes } = require('sequelize');
+
+/**
+ * Todo に紐づくコメント（機能9）。作成者は userId、閲覧は共有の view / 作成は edit 以上。
+ */
+module.exports = (sequelize) => {
+  const Comment = sequelize.define(
+    'Comment',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      todoId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'todo_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'user_id',
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      content: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: 'comments',
+      timestamps: true,
+      underscored: true,
+    }
+  );
+
+  Comment.associate = function (models) {
+    Comment.belongsTo(models.Todo, { foreignKey: 'todoId' });
+    Comment.belongsTo(models.User, { foreignKey: 'userId', as: 'Author' });
+  };
+
+  return Comment;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -8,6 +8,7 @@ const TodoTag = require('./todoTag')
 const Project = require('./project')
 const TodoTemplate = require('./todoTemplate')
 const TodoShare = require('./todoShare')
+const Comment = require('./comment')
 
 module.exports = fp(async function (fastify, opts) {
   const sequelize = fastify.sequelize
@@ -20,6 +21,7 @@ module.exports = fp(async function (fastify, opts) {
     Project: Project(sequelize),
     TodoTemplate: TodoTemplate(sequelize),
     TodoShare: TodoShare(sequelize),
+    Comment: Comment(sequelize),
   }
 
   Object.keys(models).forEach((name) => {

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -99,6 +99,7 @@ module.exports = (sequelize) => {
       as: 'Tags',
     });
     Todo.hasMany(models.TodoShare, { foreignKey: 'todoId' });
+    Todo.hasMany(models.Comment, { foreignKey: 'todoId' });
   };
 
   return Todo;

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -31,6 +31,7 @@ module.exports = (sequelize) => {
     User.hasMany(models.Tag, { foreignKey: 'userId' });
     User.hasMany(models.Project, { foreignKey: 'userId' });
     User.hasMany(models.TodoShare, { foreignKey: 'sharedWithUserId' });
+    User.hasMany(models.Comment, { foreignKey: 'userId' });
   };
 
   return User;

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -53,6 +53,12 @@ const { exportTodos } = require('../../../controllers/exportController');
 const { importTodos } = require('../../../controllers/importController');
 const { shareTodo, getSharedTodos, deleteShare } = require('../../../controllers/shareController');
 const {
+  getCommentsForTodo,
+  postComment,
+  putComment,
+  deleteComment,
+} = require('../../../controllers/commentController');
+const {
   getCompletionRate,
   getTodosByPriority: getAnalyticsByPriority,
   getTodosByTag: getAnalyticsByTag,
@@ -535,6 +541,70 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => removeTagFromTodo(fastify, request, reply),
+  });
+  fastify.get('/todos/:todoId/comments', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['todoId'],
+        properties: { todoId: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      response: {
+        200: {
+          type: 'array',
+          items: { type: 'object', additionalProperties: true },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getCommentsForTodo(fastify, request, reply),
+  });
+  fastify.post('/todos/:todoId/comments', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['todoId'],
+        properties: { todoId: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        required: ['content'],
+        properties: {
+          content: { type: 'string', minLength: 1, maxLength: 8000 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => postComment(fastify, request, reply),
+  });
+  fastify.put('/comments/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        required: ['content'],
+        properties: {
+          content: { type: 'string', minLength: 1, maxLength: 8000 },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => putComment(fastify, request, reply),
+  });
+  fastify.delete('/comments/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => deleteComment(fastify, request, reply),
   });
   fastify.get('/todos/:id', {
     schema: {

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -66,6 +66,23 @@ const {
   getWeeklyStats,
 } = require('../../../controllers/analyticsController');
 
+/** コメント API の 201/200 本文。serialization で意図しないフィールドが漏れないよう明示する */
+const commentApiResponseSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'todoId', 'userId', 'content', 'authorName', 'isMine', 'createdAt', 'updatedAt'],
+  properties: {
+    id: { type: 'integer' },
+    todoId: { type: 'integer' },
+    userId: { type: 'integer' },
+    content: { type: 'string' },
+    authorName: { type: 'string' },
+    isMine: { type: 'boolean' },
+    createdAt: { type: 'string' },
+    updatedAt: { type: 'string' },
+  },
+};
+
 module.exports = async function (fastify, opts) {
   /**
    * Auth
@@ -573,6 +590,9 @@ module.exports = async function (fastify, opts) {
           content: { type: 'string', minLength: 1, maxLength: 8000 },
         },
       },
+      response: {
+        201: commentApiResponseSchema,
+      },
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => postComment(fastify, request, reply),
@@ -590,6 +610,9 @@ module.exports = async function (fastify, opts) {
         properties: {
           content: { type: 'string', minLength: 1, maxLength: 8000 },
         },
+      },
+      response: {
+        200: commentApiResponseSchema,
       },
     },
     preHandler: [fastify.authenticate],

--- a/backend/services/commentService.js
+++ b/backend/services/commentService.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const shareService = require('./shareService');
+
+const MAX_CONTENT = 8000;
+
+/**
+ * API 応答用: 作成者名と「表示中ユーザーが作成者か」を付与
+ * @param {import('sequelize').Model} row
+ * @param {number} viewerId
+ */
+function toApiShape(row, viewerId) {
+  const j = row.toJSON();
+  const authorName = j.Author?.name ?? '';
+  const uid = j.userId;
+  delete j.Author;
+  return { ...j, authorName, isMine: uid === viewerId };
+}
+
+/**
+ * @param {object} fastify
+ * @param {number} commentId
+ */
+async function findCommentForUser(fastify, commentId) {
+  return fastify.models.Comment.findByPk(commentId, {
+    include: [
+      { model: fastify.models.User, as: 'Author', attributes: ['id', 'name'] },
+      { model: fastify.models.Todo, attributes: ['id'] },
+    ],
+  });
+}
+
+/**
+ * 閲覧可能な Todo のコメント一覧（古い順）
+ * @returns {Promise<object[]|null>} 権限なしは null
+ */
+async function getCommentsByTodoId(fastify, todoId, userId) {
+  const can = await shareService.canView(fastify, todoId, userId);
+  if (!can) return null;
+  const rows = await fastify.models.Comment.findAll({
+    where: { todoId },
+    include: [{ model: fastify.models.User, as: 'Author', attributes: ['id', 'name'] }],
+    order: [['createdAt', 'ASC']],
+  });
+  return rows.map((r) => toApiShape(r, userId));
+}
+
+/**
+ * 編集権限のあるユーザーがコメント投稿
+ * @returns {Promise<object|null>} 権限なしは null、本文不正は { invalid: true }
+ */
+async function createComment(fastify, todoId, userId, content) {
+  const can = await shareService.canEdit(fastify, todoId, userId);
+  if (!can) return null;
+  const text = String(content ?? '').trim();
+  if (!text) return { invalid: true, message: 'Content is required' };
+  if (text.length > MAX_CONTENT) return { invalid: true, message: 'Content too long' };
+  const row = await fastify.models.Comment.create({ todoId, userId, content: text });
+  const full = await fastify.models.Comment.findByPk(row.id, {
+    include: [{ model: fastify.models.User, as: 'Author', attributes: ['id', 'name'] }],
+  });
+  return toApiShape(full, userId);
+}
+
+/**
+ * 作成者のみ、かつ Todo 編集権限あり
+ * @returns {Promise<object|null|false>} null=不在、false=権限なし、object=更新後
+ */
+async function updateComment(fastify, commentId, userId, content) {
+  const row = await findCommentForUser(fastify, commentId);
+  if (!row) return null;
+  if (row.userId !== userId) return false;
+  const can = await shareService.canEdit(fastify, row.todoId, userId);
+  if (!can) return false;
+  const text = String(content ?? '').trim();
+  if (!text) return { invalid: true, message: 'Content is required' };
+  if (text.length > MAX_CONTENT) return { invalid: true, message: 'Content too long' };
+  row.content = text;
+  await row.save();
+  const reloaded = await findCommentForUser(fastify, commentId);
+  return toApiShape(reloaded, userId);
+}
+
+/**
+ * 作成者のみ削除
+ * @returns {Promise<boolean|null>} true 削除、false 権限なし、null 不在
+ */
+async function deleteComment(fastify, commentId, userId) {
+  const row = await findCommentForUser(fastify, commentId);
+  if (!row) return null;
+  if (row.userId !== userId) return false;
+  const can = await shareService.canEdit(fastify, row.todoId, userId);
+  if (!can) return false;
+  await row.destroy();
+  return true;
+}
+
+module.exports = {
+  getCommentsByTodoId,
+  createComment,
+  updateComment,
+  deleteComment,
+  MAX_CONTENT,
+};

--- a/backend/test/routes/comments.test.js
+++ b/backend/test/routes/comments.test.js
@@ -1,0 +1,237 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { build } = require('../helper');
+
+function uniqueSuffix() {
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function tokenUserId(token) {
+  const payload = token.split('.')[1];
+  return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')).id;
+}
+
+async function setupOwnerViewEdit(t, app) {
+  const suffix = uniqueSuffix();
+  const owner = { name: `cmt-o-${suffix}`, email: `cmt-o-${suffix}@test.local`, password: 'pass123' };
+  const viewUser = { name: `cmt-v-${suffix}`, email: `cmt-v-${suffix}@test.local`, password: 'pass123' };
+  const editUser = { name: `cmt-e-${suffix}`, email: `cmt-e-${suffix}@test.local`, password: 'pass123' };
+  for (const u of [owner, viewUser, editUser]) {
+    await app.inject({ method: 'POST', url: '/api/v1/register', payload: u });
+  }
+  const ownerLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: owner.email, password: owner.password } });
+  const viewLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: viewUser.email, password: viewUser.password } });
+  const editLogin = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: editUser.email, password: editUser.password } });
+  const ownerToken = JSON.parse(ownerLogin.payload).token;
+  const viewToken = JSON.parse(viewLogin.payload).token;
+  const editToken = JSON.parse(editLogin.payload).token;
+  const viewId = tokenUserId(viewToken);
+  const editId = tokenUserId(editToken);
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { title: 'Comment test todo' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/share`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { sharedWithUserId: viewId, permission: 'view' },
+  });
+  await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/share`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { sharedWithUserId: editId, permission: 'edit' },
+  });
+  return { todo, ownerToken, viewToken, editToken };
+}
+
+test('GET /api/v1/todos/:todoId/comments without auth returns 401', async (t) => {
+  const app = await build(t);
+  const res = await app.inject({ method: 'GET', url: '/api/v1/todos/1/comments' });
+  assert.strictEqual(res.statusCode, 401);
+});
+
+test('POST /api/v1/todos/:todoId/comments without auth returns 401', async (t) => {
+  const app = await build(t);
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/1/comments',
+    payload: { content: 'hello' },
+  });
+  assert.strictEqual(res.statusCode, 401);
+});
+
+test('comments CRUD: owner creates, lists, updates, deletes; isMine on list', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `cmt-crud-${suffix}`, email: `cmt-crud-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const userId = tokenUserId(token);
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'My todo' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+
+  const postRes = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { content: '  first note  ' },
+  });
+  assert.strictEqual(postRes.statusCode, 201);
+  const created = JSON.parse(postRes.payload);
+  assert.strictEqual(created.content, 'first note');
+  assert.strictEqual(created.isMine, true);
+  assert.strictEqual(created.userId, userId);
+
+  const listRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(listRes.statusCode, 200);
+  const list = JSON.parse(listRes.payload);
+  assert.strictEqual(list.length, 1);
+  assert.strictEqual(list[0].isMine, true);
+  assert.ok(list[0].authorName);
+
+  const putRes = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/comments/${created.id}`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { content: 'updated body' },
+  });
+  assert.strictEqual(putRes.statusCode, 200);
+  const updated = JSON.parse(putRes.payload);
+  assert.strictEqual(updated.content, 'updated body');
+
+  const delRes = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/comments/${created.id}`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(delRes.statusCode, 204);
+
+  const listAfter = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(JSON.parse(listAfter.payload).length, 0);
+});
+
+test('POST comment: view-only share returns 403', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEdit(t, app);
+  const res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${viewToken}` },
+    payload: { content: 'no' },
+  });
+  assert.strictEqual(res.statusCode, 403);
+});
+
+test('GET comments: view-only share returns 200 (empty or list)', async (t) => {
+  const app = await build(t);
+  const { todo, viewToken } = await setupOwnerViewEdit(t, app);
+  const res = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${viewToken}` },
+  });
+  assert.strictEqual(res.statusCode, 200);
+  assert.ok(Array.isArray(JSON.parse(res.payload)));
+});
+
+test('POST comment: edit share succeeds; GET list shows isMine false for other author', async (t) => {
+  const app = await build(t);
+  const { todo, ownerToken, editToken } = await setupOwnerViewEdit(t, app);
+  const postRes = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { content: 'from editor' },
+  });
+  assert.strictEqual(postRes.statusCode, 201);
+
+  const ownerList = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+  });
+  const list = JSON.parse(ownerList.payload);
+  assert.strictEqual(list.length, 1);
+  assert.strictEqual(list[0].content, 'from editor');
+  assert.strictEqual(list[0].isMine, false);
+});
+
+test('PUT /comments/:id by non-author returns 403', async (t) => {
+  const app = await build(t);
+  const { todo, ownerToken, editToken } = await setupOwnerViewEdit(t, app);
+  const postRes = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { content: 'owner wrote' },
+  });
+  const c = JSON.parse(postRes.payload);
+  const putRes = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/comments/${c.id}`,
+    headers: { authorization: `Bearer ${editToken}` },
+    payload: { content: 'hijack' },
+  });
+  assert.strictEqual(putRes.statusCode, 403);
+});
+
+test('POST comment empty content returns 400', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `cmt-bad-${suffix}`, email: `cmt-bad-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const todoRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 't' },
+  });
+  const todo = JSON.parse(todoRes.payload);
+  const res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { content: '   ' },
+  });
+  assert.strictEqual(res.statusCode, 400);
+});
+
+test('PUT /comments/:id invalid id returns 400', async (t) => {
+  const app = await build(t);
+  const suffix = uniqueSuffix();
+  const user = { name: `cmt-id-${suffix}`, email: `cmt-id-${suffix}@test.local`, password: 'pass123' };
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user });
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } });
+  const token = JSON.parse(loginRes.payload).token;
+  const res = await app.inject({
+    method: 'PUT',
+    url: '/api/v1/comments/abc',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { content: 'x' },
+  });
+  assert.strictEqual(res.statusCode, 400);
+});

--- a/backend/test/routes/comments.test.js
+++ b/backend/test/routes/comments.test.js
@@ -197,6 +197,24 @@ test('PUT /comments/:id by non-author returns 403', async (t) => {
   assert.strictEqual(putRes.statusCode, 403);
 });
 
+test('DELETE /comments/:id by non-author returns 403', async (t) => {
+  const app = await build(t);
+  const { todo, ownerToken, editToken } = await setupOwnerViewEdit(t, app);
+  const postRes = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${todo.id}/comments`,
+    headers: { authorization: `Bearer ${ownerToken}` },
+    payload: { content: 'owner wrote' },
+  });
+  const c = JSON.parse(postRes.payload);
+  const delRes = await app.inject({
+    method: 'DELETE',
+    url: `/api/v1/comments/${c.id}`,
+    headers: { authorization: `Bearer ${editToken}` },
+  });
+  assert.strictEqual(delRes.statusCode, 403);
+});
+
 test('POST comment empty content returns 400', async (t) => {
   const app = await build(t);
   const suffix = uniqueSuffix();

--- a/docs/TODO_FEATURE_09_COMMENTS.md
+++ b/docs/TODO_FEATURE_09_COMMENTS.md
@@ -25,11 +25,13 @@ Todo にメモ・コメントを追加し、タイムライン形式で表示。
 
 ## 🔌 API エンドポイント
 
+実装は `/api/v1` プレフィックス（他 API と同様）。
+
 ```
-POST /api/todos/:todoId/comments
-GET /api/todos/:todoId/comments
-PUT /api/comments/:id
-DELETE /api/comments/:id
+POST   /api/v1/todos/:todoId/comments
+GET    /api/v1/todos/:todoId/comments
+PUT    /api/v1/comments/:id
+DELETE /api/v1/comments/:id
 ```
 
 ---
@@ -37,71 +39,71 @@ DELETE /api/comments/:id
 ## ✅ Backend 実装タスク
 
 ### Task 9.1: Comment モデル作成
-- [ ] 9.1.1: マイグレーション生成 `create-comments`
-- [ ] 9.1.2: comments テーブル定義
-- [ ] 9.1.3: インデックス追加（todoId, userId）
-- [ ] 9.1.4: 外部キー制約追加
-- [ ] 9.1.5: `backend/models/Comment.js` 作成
-- [ ] 9.1.6: Comment モデル定義
-- [ ] 9.1.7: Todo, User との関連付け
-- [ ] 9.1.8: マイグレーション実行
+- [x] 9.1.1: マイグレーション生成 `create-comments`
+- [x] 9.1.2: comments テーブル定義
+- [x] 9.1.3: インデックス追加（todoId, userId）
+- [x] 9.1.4: 外部キー制約追加
+- [x] 9.1.5: `backend/models/comment.js` 作成
+- [x] 9.1.6: Comment モデル定義
+- [x] 9.1.7: Todo, User との関連付け
+- [x] 9.1.8: マイグレーション実行
 
 ### Task 9.2: CommentService 作成
-- [ ] 9.2.1: `backend/services/CommentService.js` 作成
-- [ ] 9.2.2: `createComment(todoId, userId, content)` 実装
-- [ ] 9.2.3: `getCommentsByTodoId(todoId, userId)` 実装
-- [ ] 9.2.4: `updateComment(commentId, userId, content)` 実装
-- [ ] 9.2.5: `deleteComment(commentId, userId)` 実装
+- [x] 9.2.1: `backend/services/commentService.js` 作成
+- [x] 9.2.2: `createComment(todoId, userId, content)` 実装
+- [x] 9.2.3: `getCommentsByTodoId(todoId, userId)` 実装
+- [x] 9.2.4: `updateComment(commentId, userId, content)` 実装
+- [x] 9.2.5: `deleteComment(commentId, userId)` 実装
 
 ### Task 9.3: CommentController 作成
-- [ ] 9.3.1: `backend/controllers/CommentController.js` 作成
-- [ ] 9.3.2: 各ハンドラ実装
-- [ ] 9.3.3: エラーハンドリング
+- [x] 9.3.1: `backend/controllers/commentController.js` 作成
+- [x] 9.3.2: 各ハンドラ実装
+- [x] 9.3.3: エラーハンドリング
 
 ### Task 9.4: Comment ルート作成
-- [ ] 9.4.1: `backend/routes/api/comments.js` 作成
-- [ ] 9.4.2: 各エンドポイントの JSON Schema 定義
-- [ ] 9.4.3: JWT 認証 preHandler 適用
+- [x] 9.4.1: `backend/routes/api/v1/index.js` にコメントルートを追加
+- [x] 9.4.2: 各エンドポイントの JSON Schema 定義
+- [x] 9.4.3: JWT 認証 preHandler 適用
 
 ### Task 9.5: Backend テスト
-- [ ] 9.5.1: CommentService のテスト
-- [ ] 9.5.2: Comment API のテスト
+- [x] 9.5.1: CommentService のテスト（ルート結合テストで権限・CRUD をカバー）
+- [x] 9.5.2: Comment API のテスト（`test/routes/comments.test.js`）
 
 ---
 
 ## ✅ Frontend 実装タスク
 
 ### Task 9.6: Comment インターフェース定義
-- [ ] 9.6.1: `frontend/src/app/models/comment.interface.ts` 作成
-- [ ] 9.6.2: Comment, CreateCommentDto, UpdateCommentDto 定義
+- [x] 9.6.1: `frontend/src/app/models/comment.interface.ts` 作成
+- [x] 9.6.2: Comment, CreateCommentDto, UpdateCommentDto 定義
 
 ### Task 9.7: CommentService 作成
-- [ ] 9.7.1: `frontend/src/app/services/comment.service.ts` 作成
-- [ ] 9.7.2: CRUD メソッド実装
+- [x] 9.7.1: `frontend/src/app/services/comment.service.ts` 作成
+- [x] 9.7.2: CRUD メソッド実装
 
 ### Task 9.8: CommentList コンポーネント作成
-- [ ] 9.8.1: `ng generate component components/comment-list` 実行
-- [ ] 9.8.2: コメント一覧をタイムライン形式で表示
-- [ ] 9.8.3: 編集・削除ボタン実装
-- [ ] 9.8.4: @Input() todoId: number 実装
+- [x] 9.8.1: `comment-list` コンポーネント（standalone）を `dashboard/todo/comment-list` に配置
+- [x] 9.8.2: コメント一覧をタイムライン形式で表示
+- [x] 9.8.3: 編集・削除ボタン実装（`isMine` 時）
+- [x] 9.8.4: `@Input() comments` 実装（todoId は親セクションが保持）
 
 ### Task 9.9: CommentForm コンポーネント作成
-- [ ] 9.9.1: `ng generate component components/comment-form` 実装
-- [ ] 9.9.2: テキストエリア実装
-- [ ] 9.9.3: 送信ボタン実装
-- [ ] 9.9.4: @Output() submitted 実装
+- [x] 9.9.1: `comment-form` コンポーネント（standalone）を `dashboard/todo/comment-form` に配置
+- [x] 9.9.2: テキストエリア実装
+- [x] 9.9.3: 送信ボタン実装
+- [x] 9.9.4: `@Output() submitted` 実装
 
-### Task 9.10: TodoDetail にコメント機能追加
-- [ ] 9.10.1: CommentList コンポーネント追加
-- [ ] 9.10.2: CommentForm コンポーネント追加
+### Task 9.10: Todo 詳細相当 UI にコメント機能追加
+- [x] 9.10.1: `todo-comments-section` + `todo-item` に CommentList を組み込み
+- [x] 9.10.2: 同上に CommentForm を組み込み（折りたたみで表示）
 
 ### Task 9.11: スタイリング
-- [ ] 9.11.1: タイムラインのスタイル
-- [ ] 9.11.2: コメントバブルのスタイル
+- [x] 9.11.1: タイムラインのスタイル
+- [x] 9.11.2: コメントバブルのスタイル
 
 ### Task 9.12: Frontend テスト
-- [ ] 9.12.1: CommentService のテスト
-- [ ] 9.12.2: 各コンポーネントのテスト
+- [x] 9.12.1: CommentService のテスト
+- [x] 9.12.2: comment-form / comment-list のユニットテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.html
@@ -1,0 +1,22 @@
+<form class="comment-form" (ngSubmit)="onSubmit()">
+  <label class="form-label visually-hidden" for="comment-draft">コメント</label>
+  <textarea
+    id="comment-draft"
+    name="draft"
+    class="form-control form-control-sm"
+    rows="2"
+    [(ngModel)]="draft"
+    [disabled]="disabled || submitting"
+    placeholder="コメントを入力…"
+    maxlength="8000"
+  ></textarea>
+  <div class="d-flex justify-content-end mt-1">
+    <button type="submit" class="btn btn-sm btn-primary" [disabled]="disabled || submitting || !draft.trim()">
+      @if (submitting) {
+        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+      } @else {
+        投稿
+      }
+    </button>
+  </div>
+</form>

--- a/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.scss
@@ -1,0 +1,4 @@
+.comment-form textarea {
+  resize: vertical;
+  min-height: 2.5rem;
+}

--- a/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { FormsModule } from '@angular/forms'
+import { CommentFormComponent } from './comment-form.component'
+
+describe('CommentFormComponent (9.12)', () => {
+  let component: CommentFormComponent
+  let fixture: ComponentFixture<CommentFormComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommentFormComponent, FormsModule],
+    }).compileComponents()
+    fixture = TestBed.createComponent(CommentFormComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should emit trimmed content on submit', () => {
+    const emitted: string[] = []
+    component.submitted.subscribe((s) => emitted.push(s))
+    component.draft = '  hi  '
+    component.onSubmit()
+    expect(emitted).toEqual(['hi'])
+  })
+
+  it('reset should clear draft', () => {
+    component.draft = 'x'
+    component.reset()
+    expect(component.draft).toBe('')
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-form/comment-form.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+
+@Component({
+  selector: 'app-comment-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './comment-form.component.html',
+  styleUrls: ['./comment-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CommentFormComponent {
+  @Input() disabled = false
+  @Input() submitting = false
+  @Output() submitted = new EventEmitter<string>()
+
+  draft = ''
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  onSubmit(): void {
+    if (this.disabled || this.submitting) return
+    const text = this.draft.trim()
+    if (!text) return
+    this.submitted.emit(text)
+  }
+
+  /** 親が投稿成功後に呼び出す */
+  reset(): void {
+    this.draft = ''
+    this.cdr.markForCheck()
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.html
@@ -1,0 +1,33 @@
+@if (comments.length === 0) {
+  <p class="text-muted small mb-0">まだコメントはありません。</p>
+} @else {
+  <ul class="comment-timeline list-unstyled mb-0">
+    @for (c of comments; track c.id) {
+      <li class="comment-timeline-item">
+        <div class="comment-bubble">
+          <div class="d-flex flex-wrap align-items-baseline gap-2 small text-muted mb-1">
+            <span class="fw-semibold text-body">{{ c.authorName || 'ユーザー' }}</span>
+            <span>{{ c.createdAt | date: 'short' }}</span>
+          </div>
+          @if (editingId === c.id) {
+            <textarea class="form-control form-control-sm" rows="3" [(ngModel)]="editDraft" maxlength="8000"></textarea>
+            <div class="btn-group btn-group-sm mt-1">
+              <button type="button" class="btn btn-primary" [disabled]="busyCommentId === c.id || !editDraft.trim()" (click)="saveEdit()">
+                保存
+              </button>
+              <button type="button" class="btn btn-outline-secondary" [disabled]="busyCommentId === c.id" (click)="cancelEdit()">キャンセル</button>
+            </div>
+          } @else {
+            <div class="comment-body text-break">{{ c.content }}</div>
+            @if (c.isMine) {
+              <div class="btn-group btn-group-sm mt-2">
+                <button type="button" class="btn btn-outline-secondary" [disabled]="busyCommentId === c.id" (click)="startEdit(c)">編集</button>
+                <button type="button" class="btn btn-outline-danger" [disabled]="busyCommentId === c.id" (click)="onDelete(c.id)">削除</button>
+              </div>
+            }
+          }
+        </div>
+      </li>
+    }
+  </ul>
+}

--- a/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.scss
@@ -1,0 +1,19 @@
+.comment-timeline {
+  border-left: 2px solid var(--bs-border-color, #dee2e6);
+  margin-left: 0.5rem;
+  padding-left: 0.75rem;
+}
+
+.comment-timeline-item + .comment-timeline-item {
+  margin-top: 0.75rem;
+}
+
+.comment-bubble {
+  background: var(--bs-tertiary-bg, #f8f9fa);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.comment-body {
+  white-space: pre-wrap;
+}

--- a/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { FormsModule } from '@angular/forms'
+import { CommentListComponent } from './comment-list.component'
+import type { Comment } from '../../../../../models/comment.interface'
+
+describe('CommentListComponent (9.12)', () => {
+  let component: CommentListComponent
+  let fixture: ComponentFixture<CommentListComponent>
+
+  const sample: Comment = {
+    id: 1,
+    todoId: 1,
+    userId: 1,
+    content: 'text',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    authorName: 'User',
+    isMine: true,
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommentListComponent, FormsModule],
+    }).compileComponents()
+    fixture = TestBed.createComponent(CommentListComponent)
+    component = fixture.componentInstance
+    component.comments = [sample]
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('saveEdit should emit and clear editing', () => {
+    const out: { id: number; content: string }[] = []
+    component.saved.subscribe((e) => out.push(e))
+    component.startEdit(sample)
+    component.editDraft = 'new'
+    component.saveEdit()
+    expect(out).toEqual([{ id: 1, content: 'new' }])
+    expect(component.editingId).toBeNull()
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/comment-list/comment-list.component.ts
@@ -1,0 +1,60 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+} from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import type { Comment } from '../../../../../models/comment.interface'
+
+@Component({
+  selector: 'app-comment-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './comment-list.component.html',
+  styleUrls: ['./comment-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CommentListComponent implements OnChanges {
+  @Input() comments: Comment[] = []
+  @Input() busyCommentId: number | null = null
+  @Output() deleted = new EventEmitter<number>()
+  @Output() saved = new EventEmitter<{ id: number; content: string }>()
+
+  editingId: number | null = null
+  editDraft = ''
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['comments'] && this.editingId !== null) {
+      const exists = this.comments.some((c) => c.id === this.editingId)
+      if (!exists) this.cancelEdit()
+    }
+  }
+
+  startEdit(c: Comment): void {
+    this.editingId = c.id
+    this.editDraft = c.content
+  }
+
+  cancelEdit(): void {
+    this.editingId = null
+    this.editDraft = ''
+  }
+
+  saveEdit(): void {
+    if (this.editingId === null) return
+    const text = this.editDraft.trim()
+    if (!text) return
+    const id = this.editingId
+    this.saved.emit({ id, content: text })
+    this.cancelEdit()
+  }
+
+  onDelete(id: number): void {
+    this.deleted.emit(id)
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-comments-section/todo-comments-section.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-comments-section/todo-comments-section.component.html
@@ -1,0 +1,25 @@
+<div class="todo-comments-section border-top pt-2 mt-2">
+  <button type="button" class="btn btn-link btn-sm p-0 text-decoration-none" (click)="toggle()" [attr.aria-expanded]="expanded">
+    {{ expanded ? '▼' : '▶' }} コメント
+  </button>
+  @if (expanded) {
+    @if (error) {
+      <div class="alert alert-warning py-1 px-2 small mt-2" role="alert">{{ error }}</div>
+    }
+    @if (loading) {
+      <div class="small text-muted mt-2">読み込み中…</div>
+    } @else {
+      <div class="mt-2">
+        <app-comment-list
+          [comments]="comments"
+          [busyCommentId]="busyCommentId"
+          (deleted)="onDelete($event)"
+          (saved)="onSaved($event)"
+        />
+      </div>
+    }
+    <div class="mt-2">
+      <app-comment-form [submitting]="submitting" (submitted)="onFormSubmit($event)" />
+    </div>
+  }
+</div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-comments-section/todo-comments-section.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-comments-section/todo-comments-section.component.scss
@@ -1,0 +1,3 @@
+.todo-comments-section {
+  width: 100%;
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-comments-section/todo-comments-section.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-comments-section/todo-comments-section.component.ts
@@ -1,0 +1,131 @@
+import { Component, Input, OnChanges, SimpleChanges, ViewChild, inject } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { finalize, take } from 'rxjs/operators'
+import { CommentService } from '../../../../../services/comment.service'
+import type { Comment } from '../../../../../models/comment.interface'
+import { CommentFormComponent } from '../comment-form/comment-form.component'
+import { CommentListComponent } from '../comment-list/comment-list.component'
+
+@Component({
+  selector: 'app-todo-comments-section',
+  standalone: true,
+  imports: [CommonModule, CommentFormComponent, CommentListComponent],
+  templateUrl: './todo-comments-section.component.html',
+  styleUrls: ['./todo-comments-section.component.scss'],
+})
+export class TodoCommentsSectionComponent implements OnChanges {
+  private commentService = inject(CommentService)
+
+  @ViewChild(CommentFormComponent) private formRef?: CommentFormComponent
+
+  @Input({ required: true }) todoId!: number
+
+  expanded = false
+  comments: Comment[] = []
+  loading = false
+  submitting = false
+  busyCommentId: number | null = null
+  error: string | null = null
+
+  private loadedForTodoId: number | null = null
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['todoId'] && !changes['todoId'].firstChange) {
+      this.loadedForTodoId = null
+      this.comments = []
+      if (this.expanded) {
+        this.loadComments()
+      }
+    }
+  }
+
+  toggle(): void {
+    this.expanded = !this.expanded
+    if (this.expanded && this.loadedForTodoId !== this.todoId) {
+      this.loadComments()
+    }
+  }
+
+  loadComments(): void {
+    this.loading = true
+    this.error = null
+    this.commentService
+      .listByTodo(this.todoId)
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.loading = false
+        }),
+      )
+      .subscribe({
+        next: (list) => {
+          this.comments = list
+          this.loadedForTodoId = this.todoId
+        },
+        error: () => {
+          this.error = 'コメントの読み込みに失敗しました。'
+        },
+      })
+  }
+
+  onFormSubmit(content: string): void {
+    this.submitting = true
+    this.error = null
+    this.commentService
+      .create(this.todoId, { content })
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.submitting = false
+        }),
+      )
+      .subscribe({
+        next: () => {
+          this.formRef?.reset()
+          this.loadComments()
+        },
+        error: () => {
+          this.error = '投稿に失敗しました。'
+        },
+      })
+  }
+
+  onDelete(commentId: number): void {
+    if (!window.confirm('このコメントを削除しますか？')) return
+    this.busyCommentId = commentId
+    this.error = null
+    this.commentService
+      .delete(commentId)
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.busyCommentId = null
+        }),
+      )
+      .subscribe({
+        next: () => this.loadComments(),
+        error: () => {
+          this.error = '削除に失敗しました。'
+        },
+      })
+  }
+
+  onSaved(payload: { id: number; content: string }): void {
+    this.busyCommentId = payload.id
+    this.error = null
+    this.commentService
+      .update(payload.id, { content: payload.content })
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.busyCommentId = null
+        }),
+      )
+      .subscribe({
+        next: () => this.loadComments(),
+        error: () => {
+          this.error = '更新に失敗しました。'
+        },
+      })
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -1,3 +1,4 @@
+<div class="todo-item-block w-100">
 <div class="d-flex flex-wrap align-items-center gap-2 py-2 border-bottom todo-item" [class.completed]="todo.completed">
   <input
     type="checkbox"
@@ -76,4 +77,6 @@
     <button type="button" class="btn btn-outline-primary" (click)="onEdit()">編集</button>
     <button type="button" class="btn btn-outline-danger" (click)="onDelete()">削除</button>
   </div>
+</div>
+<app-todo-comments-section [todoId]="todo.id" />
 </div>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { TodoItemComponent } from './todo-item.component'
 import type { ReminderToggleEvent } from './todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
@@ -28,7 +29,7 @@ describe('TodoItemComponent (2.12.2)', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TodoItemComponent],
+      imports: [TodoItemComponent, HttpClientTestingModule],
     }).compileComponents()
 
     fixture = TestBed.createComponent(TodoItemComponent)

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -4,6 +4,7 @@ import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/n
 import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
 import { TagChipComponent } from '../tag-chip/tag-chip.component'
+import { TodoCommentsSectionComponent } from '../todo-comments-section/todo-comments-section.component'
 
 export interface ReminderToggleEvent {
   todoId: number
@@ -13,7 +14,7 @@ export interface ReminderToggleEvent {
 @Component({
   selector: 'app-todo-item',
   standalone: true,
-  imports: [CommonModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, TagChipComponent],
+  imports: [CommonModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, TagChipComponent, TodoCommentsSectionComponent],
   templateUrl: './todo-item.component.html',
   styleUrls: ['./todo-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { CdkDragDrop } from '@angular/cdk/drag-drop'
 import { TodoListComponent } from './todo-list.component'
 import type { Todo } from '../../../../../models/todo.interface'
@@ -16,7 +17,7 @@ describe('TodoListComponent (3.13.3)', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TodoListComponent],
+      imports: [TodoListComponent, HttpClientTestingModule],
     }).compileComponents()
 
     fixture = TestBed.createComponent(TodoListComponent)

--- a/frontend/src/app/models/comment.interface.ts
+++ b/frontend/src/app/models/comment.interface.ts
@@ -1,0 +1,19 @@
+/** API GET/POST/PUT のコメント本文（Todo 9.6） */
+export interface Comment {
+  id: number
+  todoId: number
+  userId: number
+  content: string
+  createdAt: string
+  updatedAt: string
+  authorName: string
+  isMine: boolean
+}
+
+export interface CreateCommentDto {
+  content: string
+}
+
+export interface UpdateCommentDto {
+  content: string
+}

--- a/frontend/src/app/services/comment.service.spec.ts
+++ b/frontend/src/app/services/comment.service.spec.ts
@@ -55,6 +55,25 @@ describe('CommentService (9.12)', () => {
     req.flush(mock)
   })
 
+  it('update should PUT /comments/:id', () => {
+    const body = { content: 'updated' }
+    const mock: Comment = {
+      id: 2,
+      todoId: 1,
+      userId: 1,
+      content: 'updated',
+      createdAt: '',
+      updatedAt: '',
+      authorName: 'A',
+      isMine: true,
+    }
+    service.update(2, body).subscribe((c) => expect(c).toEqual(mock))
+    const req = httpMock.expectOne(`${apiUrl}/comments/2`)
+    expect(req.request.method).toBe('PUT')
+    expect(req.request.body).toEqual(body)
+    req.flush(mock)
+  })
+
   it('delete should DELETE /comments/:id', () => {
     service.delete(9).subscribe(() => undefined)
     const req = httpMock.expectOne(`${apiUrl}/comments/9`)

--- a/frontend/src/app/services/comment.service.spec.ts
+++ b/frontend/src/app/services/comment.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { environment } from '../../environments/environment'
+import { CommentService } from './comment.service'
+import type { Comment } from '../models/comment.interface'
+
+describe('CommentService (9.12)', () => {
+  let service: CommentService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [CommentService],
+    })
+    service = TestBed.inject(CommentService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('listByTodo should GET /todos/:id/comments', () => {
+    const todoId = 5
+    const mock: Comment[] = []
+    service.listByTodo(todoId).subscribe((list) => expect(list).toEqual(mock))
+    const req = httpMock.expectOne(`${apiUrl}/todos/${todoId}/comments`)
+    expect(req.request.method).toBe('GET')
+    req.flush(mock)
+  })
+
+  it('create should POST body', () => {
+    const todoId = 3
+    const body = { content: 'hello' }
+    const mock: Comment = {
+      id: 1,
+      todoId,
+      userId: 1,
+      content: 'hello',
+      createdAt: '',
+      updatedAt: '',
+      authorName: 'A',
+      isMine: true,
+    }
+    service.create(todoId, body).subscribe((c) => expect(c).toEqual(mock))
+    const req = httpMock.expectOne(`${apiUrl}/todos/${todoId}/comments`)
+    expect(req.request.method).toBe('POST')
+    expect(req.request.body).toEqual(body)
+    req.flush(mock)
+  })
+
+  it('delete should DELETE /comments/:id', () => {
+    service.delete(9).subscribe(() => undefined)
+    const req = httpMock.expectOne(`${apiUrl}/comments/9`)
+    expect(req.request.method).toBe('DELETE')
+    req.flush(null, { status: 204, statusText: 'No Content' })
+  })
+})

--- a/frontend/src/app/services/comment.service.ts
+++ b/frontend/src/app/services/comment.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { environment } from '../../environments/environment'
+import type { Comment, CreateCommentDto, UpdateCommentDto } from '../models/comment.interface'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CommentService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  listByTodo(todoId: number): Observable<Comment[]> {
+    return this.http.get<Comment[]>(`${this.apiUrl}/todos/${todoId}/comments`)
+  }
+
+  create(todoId: number, body: CreateCommentDto): Observable<Comment> {
+    return this.http.post<Comment>(`${this.apiUrl}/todos/${todoId}/comments`, body)
+  }
+
+  update(commentId: number, body: UpdateCommentDto): Observable<Comment> {
+    return this.http.put<Comment>(`${this.apiUrl}/comments/${commentId}`, body)
+  }
+
+  delete(commentId: number): Observable<void> {
+    return this.http.delete(`${this.apiUrl}/comments/${commentId}`, { observe: 'response' }).pipe(map(() => undefined))
+  }
+}


### PR DESCRIPTION
## 概要

機能9（コメント）を実装しました。Todo 詳細ページが無いため、ダッシュボードの `todo-item` 直下に折りたたみのコメント欄を追加しています。

## 変更内容

- **Backend**: `comments` テーブル（マイグレーション）、Sequelize モデル、`commentService` / `commentController`、`/api/v1` 配下の GET・POST（`/todos/:todoId/comments`）および PUT・DELETE（`/comments/:id`）。共有権限は `shareService.canView` / `canEdit` に準拠。一覧・作成・更新レスポンスに `isMine` を付与。
- **Frontend**: `CommentService`、`comment-list` / `comment-form`、`todo-comments-section`、`todo-item` への組み込み。
- **Tests**: `backend/test/routes/comments.test.js`、フロントの service / コンポーネント spec、`todo-item`・`todo-list` spec に `HttpClientTestingModule` 追加。
- **Docs**: `docs/TODO_FEATURE_09_COMMENTS.md` を完了に更新。

## マイグレーション

本番・他環境では `docker compose run --rm backend npx sequelize-cli db:migrate` の実行が必要です。

## 確認

- `docker compose run --rm backend npm run test`
- `docker compose run --rm frontend ng build`
- `docker compose run --rm frontend ng test --watch=false`


Made with [Cursor](https://cursor.com)