### PR TITLE
feat(backend): Todo モデルに parentId フィールドを追加

### DIFF
--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -73,14 +73,6 @@ module.exports = (sequelize) => {
         allowNull: true,
         field: 'reminder_sent_at',
       },
-      parentId: {
-        type: DataTypes.INTEGER,
-        allowNull: true,
-        field: 'parent_id',
-        references: { model: 'todos', key: 'id' },
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-      },
       projectId: {
         type: DataTypes.INTEGER,
         allowNull: true,
@@ -88,6 +80,14 @@ module.exports = (sequelize) => {
         references: { model: 'projects', key: 'id' },
         onUpdate: 'CASCADE',
         onDelete: 'SET NULL',
+      },
+      parentId: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        field: 'parent_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
     },
     {

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -73,6 +73,14 @@ module.exports = (sequelize) => {
         allowNull: true,
         field: 'reminder_sent_at',
       },
+      parentId: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        field: 'parent_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
       projectId: {
         type: DataTypes.INTEGER,
         allowNull: true,

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -48,7 +48,7 @@ GET /api/todos/:id/progress
 
 ### Task 5.2: Todo モデル更新
 
-- [ ] 5.2.1: parentId フィールド追加
+- [x] 5.2.1: parentId フィールド追加
 - [ ] 5.2.2: 自己関連付け定義（hasMany, belongsTo）
 - [ ] 5.2.3: バリデーション（循環参照チェック）
 


### PR DESCRIPTION
## Summary
- Task 5.2.1 として `backend/models/todo.js` に `parentId` フィールドを追加
- `parent_id` カラムへのマッピングと自己参照 FK メタデータをモデル定義に反映
- `docs/TODO_FEATURE_05_SUBTASKS.md` の `5.2.1` を `[x]` に更新

## Test plan
- [x] 変更差分を確認（モデル定義と TODO 更新の整合性）
- [ ] Task 5.2.2（自己関連付け）実装後に Todo CRUD + サブタスク API を結合確認

Made with [Cursor](https://cursor.com)