### PR TITLE
feat(backend): Todo の自己関連付けを定義

### DIFF
--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -100,13 +100,13 @@ module.exports = (sequelize) => {
   Todo.associate = function (models) {
     Todo.belongsTo(models.User, { foreignKey: 'userId' });
     Todo.belongsTo(models.Project, { foreignKey: 'projectId' });
-    Todo.hasMany(models.Todo, {
-      foreignKey: 'parentId',
-      as: 'subtasks',
-    });
     Todo.belongsTo(models.Todo, {
       foreignKey: 'parentId',
       as: 'parent',
+    });
+    Todo.hasMany(models.Todo, {
+      foreignKey: 'parentId',
+      as: 'subtasks',
     });
     Todo.belongsToMany(models.Tag, {
       through: models.TodoTag,

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -100,6 +100,14 @@ module.exports = (sequelize) => {
   Todo.associate = function (models) {
     Todo.belongsTo(models.User, { foreignKey: 'userId' });
     Todo.belongsTo(models.Project, { foreignKey: 'projectId' });
+    Todo.hasMany(models.Todo, {
+      foreignKey: 'parentId',
+      as: 'subtasks',
+    });
+    Todo.belongsTo(models.Todo, {
+      foreignKey: 'parentId',
+      as: 'parent',
+    });
     Todo.belongsToMany(models.Tag, {
       through: models.TodoTag,
       foreignKey: 'todoId',

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -49,7 +49,7 @@ GET /api/todos/:id/progress
 ### Task 5.2: Todo モデル更新
 
 - [x] 5.2.1: parentId フィールド追加
-- [ ] 5.2.2: 自己関連付け定義（hasMany, belongsTo）
+- [x] 5.2.2: 自己関連付け定義（hasMany, belongsTo）
 - [ ] 5.2.3: バリデーション（循環参照チェック）
 
 ### Task 5.3: TodoService にサブタスク機能追加


### PR DESCRIPTION
## Summary
- Task 5.2.2 として `Todo` モデルに自己参照関連を追加
- `hasMany(models.Todo, { as: 'subtasks', foreignKey: 'parentId' })` を定義
- `belongsTo(models.Todo, { as: 'parent', foreignKey: 'parentId' })` を定義
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.2.2 を `[x]` に更新

## Test plan
- [x] モデル定義の差分確認（関連名・外部キー名）
- [ ] Task 5.3 実装時に `include: [{ as: 'subtasks' }]` と `include: [{ as: 'parent' }]` の取得確認

Made with [Cursor](https://cursor.com)