### PR TITLE
feat(backend): Todo の循環参照バリデーションを追加

### DIFF
--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -94,6 +94,38 @@ module.exports = (sequelize) => {
       tableName: 'todos',
       timestamps: true,
       underscored: true,
+      validate: {
+        async hasNoCircularParentReference() {
+          if (!this.parentId || !this.id) {
+            return;
+          }
+
+          if (this.parentId === this.id) {
+            throw new Error('親Todoに自分自身は指定できません。');
+          }
+
+          const seenTodoIds = new Set([this.id]);
+          const TodoModel = this.sequelize.models.Todo;
+          let currentParentId = this.parentId;
+
+          while (currentParentId) {
+            if (seenTodoIds.has(currentParentId)) {
+              throw new Error('親子関係が循環するため保存できません。');
+            }
+
+            seenTodoIds.add(currentParentId);
+            const parentTodo = await TodoModel.findByPk(currentParentId, {
+              attributes: ['id', 'parentId'],
+            });
+
+            if (!parentTodo) {
+              break;
+            }
+
+            currentParentId = parentTodo.parentId;
+          }
+        },
+      },
     }
   );
 

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -100,6 +100,10 @@ module.exports = (sequelize) => {
             return;
           }
 
+          if (!this.changed('parentId')) {
+            return;
+          }
+
           if (this.parentId === this.id) {
             throw new Error('親Todoに自分自身は指定できません。');
           }

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -50,7 +50,7 @@ GET /api/todos/:id/progress
 
 - [x] 5.2.1: parentId フィールド追加
 - [x] 5.2.2: 自己関連付け定義（hasMany, belongsTo）
-- [ ] 5.2.3: バリデーション（循環参照チェック）
+- [x] 5.2.3: バリデーション（循環参照チェック）
 
 ### Task 5.3: TodoService にサブタスク機能追加
 


### PR DESCRIPTION
## Summary
- Task 5.2.3 として `Todo` モデルに循環参照チェックを追加
- `parentId` 更新時に親チェーンをたどり、自己参照/循環参照を保存前に拒否
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.2.3 を `[x]` に更新

## Test plan
- [x] 実装差分確認（自己参照と循環検知の分岐）
- [ ] Task 5.3 実装時に循環参照パターン（A→B→A）を統合テストで検証

Made with [Cursor](https://cursor.com)