### PR TITLE
feat(backend): サブタスク一覧取得サービスを追加

### DIFF
--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -148,6 +148,8 @@ async function getTodoById(fastify, todoId, userId) {
 
 /**
  * 指定 Todo のサブタスク一覧を取得する（親 Todo を閲覧可能なユーザーのみ）
+ * 現段階では 1 階層の子 Todo のみを返し、孫以降は含めない。
+ * 共有経由で親 Todo を閲覧可能な場合も、配下サブタスクは userId で絞らず全件返す。
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - 親 Todo ID
  * @param {number} userId - ユーザー ID

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -147,6 +147,27 @@ async function getTodoById(fastify, todoId, userId) {
 }
 
 /**
+ * 指定 Todo のサブタスク一覧を取得する（親 Todo を閲覧可能なユーザーのみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} todoId - 親 Todo ID
+ * @param {number} userId - ユーザー ID
+ * @returns {Promise<object[]|null>} サブタスク配列。親 Todo が見つからない/閲覧不可なら null
+ */
+async function getSubtasks(fastify, todoId, userId) {
+  const parentTodo = await getTodoById(fastify, todoId, userId);
+  if (!parentTodo) return null;
+
+  return fastify.models.Todo.findAll({
+    where: {
+      parentId: todoId,
+      archived: false,
+    },
+    include: buildTodoInclude(fastify),
+    order: [['createdAt', 'ASC']],
+  });
+}
+
+/**
  * アーカイブ有無を問わず Todo を 1 件取得する（archive/unarchive 専用）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
@@ -571,6 +592,7 @@ module.exports = {
   getTodosByUserId,
   getTodosByProjectId,
   getTodoById,
+  getSubtasks,
   updateTodo,
   deleteTodo,
   toggleComplete,

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -54,7 +54,7 @@ GET /api/todos/:id/progress
 
 ### Task 5.3: TodoService にサブタスク機能追加
 
-- [ ] 5.3.1: `getSubtasks(todoId, userId)` 実装
+- [x] 5.3.1: `getSubtasks(todoId, userId)` 実装
 - [ ] 5.3.2: `createSubtask(parentId, userId, todoData)` 実装
 - [ ] 5.3.3: `getProgress(todoId, userId)` 実装（完了率計算）
 - [ ] 5.3.4: `getTodosByUserId` でサブタスクを除外（parentId IS NULL）


### PR DESCRIPTION
## Summary
- Task 5.3.1 として `todoService.getSubtasks(todoId, userId)` を追加
- 親 Todo の参照可否を `getTodoById` で検証し、未アーカイブの子 Todo を作成日昇順で返却
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.3.1 を `[x]` に更新

## Test plan
- [x] サービス実装差分確認（権限チェック + 条件 + ソート）
- [ ] Task 5.4/5.5 実装後に GET /api/todos/:id/subtasks のAPI疎通確認

Made with [Cursor](https://cursor.com)