### PR TITLE
feat(backend): サブタスク作成サービスを追加

### DIFF
--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -171,11 +171,14 @@ async function getSubtasks(fastify, todoId, userId) {
 
 /**
  * 指定親 Todo 配下にサブタスクを作成する（所有者または edit 共有先のみ）
+ * view 共有のみのユーザーは編集不可のため null を返す。コントローラーで null を 404 にする既存パターンと合わせると、
+ * 403 ではなく 404 になる点に注意（存在秘匿を優先する設計）。
+ * getTodoById 内の canView と canEdit が別クエリになるため、edit 共有ユーザーでは DB 参照が複数回走る。
  * @param {object} fastify - Fastify インスタンス
  * @param {number} parentId - 親 Todo ID
  * @param {number} userId - ユーザー ID
  * @param {object} todoData - { title, description?, priority?, dueDate?, projectId? }
- * @returns {Promise<object|null>} 作成されたサブタスク。親 Todo が存在しない/編集不可なら null
+ * @returns {Promise<object|null>} 作成されたサブタスク。親 Todo が存在しない/閲覧不可/編集不可なら null
  */
 async function createSubtask(fastify, parentId, userId, todoData) {
   const parentTodo = await getTodoById(fastify, parentId, userId);

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -170,6 +170,33 @@ async function getSubtasks(fastify, todoId, userId) {
 }
 
 /**
+ * 指定親 Todo 配下にサブタスクを作成する（所有者または edit 共有先のみ）
+ * @param {object} fastify - Fastify インスタンス
+ * @param {number} parentId - 親 Todo ID
+ * @param {number} userId - ユーザー ID
+ * @param {object} todoData - { title, description?, priority?, dueDate?, projectId? }
+ * @returns {Promise<object|null>} 作成されたサブタスク。親 Todo が存在しない/編集不可なら null
+ */
+async function createSubtask(fastify, parentId, userId, todoData) {
+  const parentTodo = await getTodoById(fastify, parentId, userId);
+  if (!parentTodo) return null;
+  if (parentTodo.userId !== userId && !(await shareService.canEdit(fastify, parentId, userId))) {
+    return null;
+  }
+
+  const { title, description, priority, dueDate, projectId } = todoData;
+  return fastify.models.Todo.create({
+    userId,
+    parentId,
+    title,
+    description: description ?? null,
+    priority: priority ?? 'medium',
+    dueDate: dueDate ?? null,
+    projectId: projectId ?? null,
+  });
+}
+
+/**
  * アーカイブ有無を問わず Todo を 1 件取得する（archive/unarchive 専用）
  * @param {object} fastify - Fastify インスタンス
  * @param {number} todoId - Todo ID
@@ -595,6 +622,7 @@ module.exports = {
   getTodosByProjectId,
   getTodoById,
   getSubtasks,
+  createSubtask,
   updateTodo,
   deleteTodo,
   toggleComplete,

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -55,7 +55,7 @@ GET /api/todos/:id/progress
 ### Task 5.3: TodoService にサブタスク機能追加
 
 - [x] 5.3.1: `getSubtasks(todoId, userId)` 実装
-- [ ] 5.3.2: `createSubtask(parentId, userId, todoData)` 実装
+- [x] 5.3.2: `createSubtask(parentId, userId, todoData)` 実装
 - [ ] 5.3.3: `getProgress(todoId, userId)` 実装（完了率計算）
 - [ ] 5.3.4: `getTodosByUserId` でサブタスクを除外（parentId IS NULL）
 - [ ] 5.3.5: 循環参照チェック処理実装


### PR DESCRIPTION
## Summary
- Task 5.3.2 として `todoService.createSubtask(parentId, userId, todoData)` を追加
- 親 Todo の存在確認と編集権限（所有者または edit 共有）を満たす場合のみサブタスクを作成
- 作成時に `parentId` を保存し、title/description/priority/dueDate/projectId を通常 Todo と同様に反映
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.3.2 を `[x]` に更新

## Test plan
- [x] サービス差分確認（権限チェック + parentId 付与）
- [ ] Task 5.4/5.5 実装後に POST /api/todos/:id/subtasks のAPI疎通確認

Made with [Cursor](https://cursor.com)