### PR TITLE
feat(backend): サブタスク作成ハンドラとPOSTルートを追加

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -95,7 +95,7 @@ async function createSubtask(fastify, req, reply) {
     }
     reply.code(201).send(subtask.toJSON());
   } catch (error) {
-    if (error?.message === '親子関係が循環しているためサブタスクを作成できません。') {
+    if (error?.code === 'CIRCULAR_REFERENCE') {
       return reply.code(400).send({ error: error.message });
     }
     handleTodoError(fastify, reply, error, 'Failed to create subtask');

--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -83,6 +83,25 @@ async function getSubtasks(fastify, req, reply) {
   }
 }
 
+async function createSubtask(fastify, req, reply) {
+  try {
+    const parentId = parseTodoId(req.params.id);
+    if (parentId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id' });
+    }
+    const subtask = await todoService.createSubtask(fastify, parentId, req.user.id, req.body);
+    if (!subtask) {
+      return reply.code(404).send({ error: 'Not found' });
+    }
+    reply.code(201).send(subtask.toJSON());
+  } catch (error) {
+    if (error?.message === '親子関係が循環しているためサブタスクを作成できません。') {
+      return reply.code(400).send({ error: error.message });
+    }
+    handleTodoError(fastify, reply, error, 'Failed to create subtask');
+  }
+}
+
 async function updateTodo(fastify, req, reply) {
   try {
     const todoId = parseTodoId(req.params.id);
@@ -321,6 +340,7 @@ module.exports = {
   getTodos,
   getTodoById,
   getSubtasks,
+  createSubtask,
   updateTodo,
   deleteTodo,
   toggleComplete,

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -7,6 +7,7 @@ const {
   getTodos,
   getTodoById,
   getSubtasks,
+  createSubtask,
   updateTodo,
   deleteTodo,
   toggleComplete,
@@ -651,6 +652,28 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => getSubtasks(fastify, request, reply),
+  });
+  fastify.post('/todos/:id/subtasks', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      body: {
+        type: 'object',
+        required: ['title'],
+        properties: {
+          title: { type: 'string', maxLength: 255 },
+          description: { type: 'string' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+          dueDate: { type: 'string', format: 'date' },
+          projectId: { type: 'integer' },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => createSubtask(fastify, request, reply),
   });
   fastify.put('/todos/:id', {
     schema: {

--- a/backend/services/todoService.js
+++ b/backend/services/todoService.js
@@ -56,7 +56,9 @@ async function assertNoCircularParentChain(fastify, startParentId) {
 
   while (currentParentId) {
     if (seenTodoIds.has(currentParentId)) {
-      throw new Error('親子関係が循環しているためサブタスクを作成できません。');
+      const err = new Error('親子関係が循環しているためサブタスクを作成できません。');
+      err.code = 'CIRCULAR_REFERENCE';
+      throw err;
     }
     seenTodoIds.add(currentParentId);
 

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -698,7 +698,7 @@ test('POST /api/v1/todos/:id/subtasks with unknown id returns 404', async (t) =>
   assert.strictEqual(createRes.statusCode, 404)
 })
 
-test.skip('GET /api/v1/todos does not include subtasks (parentId not null)', async (t) => {
+test('GET /api/v1/todos does not include subtasks (parentId not null)', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()
   const user = { name: `sublist-${suffix}`, email: `sublist-${suffix}@test.local`, password: 'pass123' }

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -37,6 +37,16 @@ test('GET /api/v1/todos/:id/subtasks without auth returns 401', async (t) => {
   assert.strictEqual(res.statusCode, 401)
 })
 
+test('POST /api/v1/todos/:id/subtasks without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/1/subtasks',
+    payload: { title: 'child' }
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
 test('GET /api/v1/todos/search without auth returns 401', async (t) => {
   const app = await build(t)
   const res = await app.inject({
@@ -640,6 +650,52 @@ test('GET /api/v1/todos/:id/subtasks returns empty list when no subtasks', async
   const subtasks = JSON.parse(res.payload)
   assert(Array.isArray(subtasks))
   assert.strictEqual(subtasks.length, 0)
+})
+
+test('POST /api/v1/todos/:id/subtasks creates subtask', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `subcreate-${suffix}`, email: `subcreate-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const parentRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Parent todo for child' }
+  })
+  assert.strictEqual(parentRes.statusCode, 201)
+  const parent = JSON.parse(parentRes.payload)
+
+  const createRes = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${parent.id}/subtasks`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Child todo' }
+  })
+  assert.strictEqual(createRes.statusCode, 201)
+  const subtask = JSON.parse(createRes.payload)
+  assert.strictEqual(subtask.parentId, parent.id)
+  assert.strictEqual(subtask.title, 'Child todo')
+})
+
+test('POST /api/v1/todos/:id/subtasks with unknown id returns 404', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `subcreate404-${suffix}`, email: `subcreate404-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const createRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos/99999999/subtasks',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Child todo' }
+  })
+  assert.strictEqual(createRes.statusCode, 404)
 })
 
 test.skip('GET /api/v1/todos does not include subtasks (parentId not null)', async (t) => {

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -63,7 +63,7 @@ GET /api/todos/:id/progress
 ### Task 5.4: TodoController にサブタスク機能追加
 
 - [x] 5.4.1: `getSubtasks` ハンドラ実装
-- [ ] 5.4.2: `createSubtask` ハンドラ実装
+- [x] 5.4.2: `createSubtask` ハンドラ実装
 - [ ] 5.4.3: `getProgress` ハンドラ実装
 
 ### Task 5.5: Todo ルート更新


### PR DESCRIPTION
## Summary
- Task 5.4.2 として `todoController.createSubtask` を実装
- `POST /api/v1/todos/:id/subtasks` ルートと JSON Schema（params/body）を追加
- `todos` ルートテストに 401/201/404 を追加し、`docs/TODO_FEATURE_05_SUBTASKS.md` の 5.4.2 を `[x]` に更新

## Test plan
- [x] `docker compose run --rm backend node --test test/routes/todos.test.js`

Made with [Cursor](https://cursor.com)