### PR TITLE
feat(backend): サブタスク進捗取得ハンドラとルートを追加

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -102,6 +102,24 @@ async function createSubtask(fastify, req, reply) {
   }
 }
 
+async function getProgress(fastify, req, reply) {
+  try {
+    const todoId = parseTodoId(req.params.id);
+    if (todoId === null) {
+      return reply.code(400).send({ error: 'Invalid todo id' });
+    }
+    const progress = await todoService.getProgress(fastify, todoId, req.user.id);
+    if (!progress) {
+      return reply.code(404).send({ error: 'Not found' });
+    }
+    const { completed, total } = progress;
+    const percentage = total === 0 ? 0 : Math.round((completed / total) * 100);
+    reply.code(200).send({ completed, total, percentage });
+  } catch (error) {
+    handleTodoError(fastify, reply, error, 'Failed to get progress');
+  }
+}
+
 async function updateTodo(fastify, req, reply) {
   try {
     const todoId = parseTodoId(req.params.id);
@@ -341,6 +359,7 @@ module.exports = {
   getTodoById,
   getSubtasks,
   createSubtask,
+  getProgress,
   updateTodo,
   deleteTodo,
   toggleComplete,

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -8,6 +8,7 @@ const {
   getTodoById,
   getSubtasks,
   createSubtask,
+  getProgress,
   updateTodo,
   deleteTodo,
   toggleComplete,
@@ -674,6 +675,28 @@ module.exports = async function (fastify, opts) {
     },
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => createSubtask(fastify, request, reply),
+  });
+  fastify.get('/todos/:id/progress', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } },
+      },
+      response: {
+        200: {
+          type: 'object',
+          required: ['completed', 'total', 'percentage'],
+          properties: {
+            completed: { type: 'integer' },
+            total: { type: 'integer' },
+            percentage: { type: 'integer' },
+          },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getProgress(fastify, request, reply),
   });
   fastify.put('/todos/:id', {
     schema: {

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -776,6 +776,35 @@ test('GET /api/v1/todos/:id/progress returns completed/total/percentage', async 
   assert.strictEqual(progress.percentage, 50)
 })
 
+test('GET /api/v1/todos/:id/progress returns 0 when no subtasks', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `prog0-${suffix}`, email: `prog0-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const parentRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Parent without children' }
+  })
+  assert.strictEqual(parentRes.statusCode, 201)
+  const parent = JSON.parse(parentRes.payload)
+
+  const progressRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${parent.id}/progress`,
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(progressRes.statusCode, 200)
+  const progress = JSON.parse(progressRes.payload)
+  assert.strictEqual(progress.completed, 0)
+  assert.strictEqual(progress.total, 0)
+  assert.strictEqual(progress.percentage, 0)
+})
+
 test('GET /api/v1/todos does not include subtasks (parentId not null)', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -47,6 +47,15 @@ test('POST /api/v1/todos/:id/subtasks without auth returns 401', async (t) => {
   assert.strictEqual(res.statusCode, 401)
 })
 
+test('GET /api/v1/todos/:id/progress without auth returns 401', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/1/progress'
+  })
+  assert.strictEqual(res.statusCode, 401)
+})
+
 test('GET /api/v1/todos/search without auth returns 401', async (t) => {
   const app = await build(t)
   const res = await app.inject({
@@ -696,6 +705,75 @@ test('POST /api/v1/todos/:id/subtasks with unknown id returns 404', async (t) =>
     payload: { title: 'Child todo' }
   })
   assert.strictEqual(createRes.statusCode, 404)
+})
+
+test('GET /api/v1/todos/:id/progress with unknown id returns 404', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `prog404-${suffix}`, email: `prog404-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const progressRes = await app.inject({
+    method: 'GET',
+    url: '/api/v1/todos/99999999/progress',
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(progressRes.statusCode, 404)
+})
+
+test('GET /api/v1/todos/:id/progress returns completed/total/percentage', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `prog-${suffix}`, email: `prog-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const parentRes = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Parent progress todo' }
+  })
+  assert.strictEqual(parentRes.statusCode, 201)
+  const parent = JSON.parse(parentRes.payload)
+
+  const child1Res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${parent.id}/subtasks`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Child done' }
+  })
+  assert.strictEqual(child1Res.statusCode, 201)
+  const child1 = JSON.parse(child1Res.payload)
+
+  const child2Res = await app.inject({
+    method: 'POST',
+    url: `/api/v1/todos/${parent.id}/subtasks`,
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'Child open' }
+  })
+  assert.strictEqual(child2Res.statusCode, 201)
+
+  const toggleRes = await app.inject({
+    method: 'PATCH',
+    url: `/api/v1/todos/${child1.id}/toggle`,
+    headers: { authorization: `Bearer ${token}` }
+  })
+  assert.strictEqual(toggleRes.statusCode, 200)
+
+  const progressRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/todos/${parent.id}/progress`,
+    headers: { authorization: `Bearer ${token}` },
+  })
+  assert.strictEqual(progressRes.statusCode, 200)
+  const progress = JSON.parse(progressRes.payload)
+  assert.strictEqual(progress.completed, 1)
+  assert.strictEqual(progress.total, 2)
+  assert.strictEqual(progress.percentage, 50)
 })
 
 test('GET /api/v1/todos does not include subtasks (parentId not null)', async (t) => {

--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -64,7 +64,7 @@ GET /api/todos/:id/progress
 
 - [x] 5.4.1: `getSubtasks` ハンドラ実装
 - [x] 5.4.2: `createSubtask` ハンドラ実装
-- [ ] 5.4.3: `getProgress` ハンドラ実装
+- [x] 5.4.3: `getProgress` ハンドラ実装
 
 ### Task 5.5: Todo ルート更新
 


### PR DESCRIPTION
## Summary
- Task 5.4.3 として `todoController.getProgress` を追加
- `GET /api/v1/todos/:id/progress` ルートと response schema（completed/total/percentage）を追加
- `todos` ルートテストに 401/404/200（percentage含む）を追加し、`docs/TODO_FEATURE_05_SUBTASKS.md` の 5.4.3 を `[x]` に更新

## Test plan
- [x] `docker compose run --rm backend node --test test/routes/todos.test.js`

Made with [Cursor](https://cursor.com)