### PR TITLE
feat(frontend): Todo インターフェースに親子情報と進捗を追加

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -85,7 +85,7 @@ GET /api/todos/:id/progress
 
 ### Task 5.7: Todo インターフェース更新
 
-- [ ] 5.7.1: Todo インターフェースに parentId, subtasks, progress 追加
+- [x] 5.7.1: Todo インターフェースに parentId, subtasks, progress 追加
 
 ### Task 5.8: TodoService にサブタスク機能追加
 

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -6,6 +6,12 @@ import type { Tag } from './tag.interface'
  */
 export type TodoPriority = 'low' | 'medium' | 'high'
 
+export interface TodoProgress {
+  completed: number
+  total: number
+  percentage: number
+}
+
 /**
  * API から返却される Todo 型（タグ付き）
  */
@@ -19,6 +25,8 @@ export interface Todo {
   dueDate: string | null
   sortOrder: number
   projectId: number | null
+  /** 親 Todo を持つ場合はその ID（親なしは null） */
+  parentId?: number | null
   archived: boolean
   archivedAt: string | null
   reminderEnabled: boolean
@@ -27,6 +35,10 @@ export interface Todo {
   updatedAt: string
   Tags?: Tag[]
   Project?: Project
+  /** 1階層分のみ返る想定（再帰的に表現するため型は Todo[]） */
+  subtasks?: Todo[]
+  /** GET /api/todos/:id/progress の結果 */
+  progress?: TodoProgress
 }
 
 /**


### PR DESCRIPTION
## Summary
- `frontend/src/app/models/todo.interface.ts` の `Todo` に `parentId`・`subtasks`・`progress`（completed/total/percentage）を追加
- `docs/TODO_FEATURE_05_SUBTASKS.md` の Task 5.7.1 を `[x]` に更新

## Test plan
- [x] `docker compose run --rm frontend ng build`
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)