### PR TITLE
feat(frontend): TodoService getSubtasks 実装

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -89,7 +89,7 @@ GET /api/todos/:id/progress
 
 ### Task 5.8: TodoService にサブタスク機能追加
 
-- [ ] 5.8.1: `getSubtasks(todoId: number): Observable<Todo[]>` 実装
+- [x] 5.8.1: `getSubtasks(todoId: number): Observable<Todo[]>` 実装
 - [ ] 5.8.2: `createSubtask(parentId: number, todo: CreateTodoDto): Observable<Todo>` 実装
 - [ ] 5.8.3: `getProgress(todoId: number): Observable<{completed: number, total: number}>` 実装
 

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -212,6 +212,18 @@ describe('TodoService', () => {
     })
   })
 
+  describe('subtasks (5.8.1)', () => {
+    it('should call GET /todos/:id/subtasks and return Todo[]', () => {
+      const todoId = 1
+      const mockSubtasks: Todo[] = [{ ...mockTodo, id: 10, parentId: todoId, title: 'child' }]
+
+      service.getSubtasks(todoId).subscribe((res) => expect(res).toEqual(mockSubtasks))
+
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${todoId}/subtasks` && r.method === 'GET')
+      req.flush(mockSubtasks)
+    })
+  })
+
   describe('bulk (15.17)', () => {
     it('should call POST /todos/bulk-complete with todoIds in body', () => {
       const todoIds = [1, 2, 3]

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -147,4 +147,12 @@ export class TodoService {
   removeTagFromTodo(todoId: number, tagId: number): Observable<void> {
     return this.http.delete<void>(`${this.apiUrl}/todos/${todoId}/tags/${tagId}`)
   }
+
+  /**
+   * 指定 Todo のサブタスク一覧を取得する。
+   * Backend は `GET /api/todos/:id/subtasks` で parentId を持つ Todo のみ返す。
+   */
+  getSubtasks(todoId: number): Observable<Todo[]> {
+    return this.http.get<Todo[]>(`${this.apiUrl}/todos/${todoId}/subtasks`)
+  }
 }

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -150,7 +150,7 @@ export class TodoService {
 
   /**
    * 指定 Todo のサブタスク一覧を取得する。
-   * Backend は `GET /api/todos/:id/subtasks` で parentId を持つ Todo のみ返す。
+   * Backend は `GET /api/v1/todos/:id/subtasks` で `parentId === todoId` の Todo を返す。
    */
   getSubtasks(todoId: number): Observable<Todo[]> {
     return this.http.get<Todo[]>(`${this.apiUrl}/todos/${todoId}/subtasks`)


### PR DESCRIPTION
## Summary
- `TodoService.getSubtasks(todoId)` を追加
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.8.1 を `[x]` に更新

## API
- `GET /api/v1/todos/:id/subtasks`

## Test plan
- [x] `docker compose run --rm frontend ng build`
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)