### PR TITLE
feat(frontend): createSubtask 実装

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -90,7 +90,7 @@ GET /api/todos/:id/progress
 ### Task 5.8: TodoService にサブタスク機能追加
 
 - [x] 5.8.1: `getSubtasks(todoId: number): Observable<Todo[]>` 実装
-- [ ] 5.8.2: `createSubtask(parentId: number, todo: CreateTodoDto): Observable<Todo>` 実装
+- [x] 5.8.2: `createSubtask(parentId: number, todo: CreateTodoDto): Observable<Todo>` 実装
 - [ ] 5.8.3: `getProgress(todoId: number): Observable<{completed: number, total: number}>` 実装
 
 ### Task 5.9: SubtaskList コンポーネント作成

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -51,3 +51,9 @@ export interface TodoCreateUpdate {
   dueDate?: string | null
   projectId?: number | null
 }
+
+/**
+ * サブタスク作成でも利用する DTO の別名。
+ * Todo 作成/更新と同じスキーマ（title 必須、他は任意）で扱えるためエイリアスにする。
+ */
+export type CreateTodoDto = TodoCreateUpdate

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -6,7 +6,7 @@ import { NetworkStatusService } from './network-status.service'
 import { OfflineStorageService } from './offline-storage.service'
 import type { SortOptions } from '../models/sort-options.interface'
 import type { SearchParams } from '../models/search-params.interface'
-import type { Todo } from '../models/todo.interface'
+import type { Todo, CreateTodoDto } from '../models/todo.interface'
 
 const mockTodo: Todo = {
   id: 1,
@@ -221,6 +221,22 @@ describe('TodoService', () => {
 
       const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${todoId}/subtasks` && r.method === 'GET')
       req.flush(mockSubtasks)
+    })
+  })
+
+  describe('subtasks (5.8.2)', () => {
+    it('should call POST /todos/:id/subtasks and return Todo', () => {
+      const parentId = 1
+      const payload: CreateTodoDto = { title: 'new child' }
+      const created: Todo = { ...mockTodo, id: 20, parentId, title: 'new child' }
+
+      service.createSubtask(parentId, payload).subscribe((res) => expect(res).toEqual(created))
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${apiUrl}/todos/${parentId}/subtasks` && r.method === 'POST'
+      )
+      expect(req.request.body).toEqual(payload)
+      req.flush(created)
     })
   })
 

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http'
 import { Observable, from } from 'rxjs'
 import { tap } from 'rxjs/operators'
 import { environment } from '../../environments/environment'
-import type { Todo, TodoCreateUpdate, TodoPriority } from '../models/todo.interface'
+import type { Todo, TodoCreateUpdate, TodoPriority, CreateTodoDto } from '../models/todo.interface'
 import type { SearchParams } from '../models/search-params.interface'
 import type { SortOptions } from '../models/sort-options.interface'
 import { NetworkStatusService } from './network-status.service'
@@ -154,5 +154,13 @@ export class TodoService {
    */
   getSubtasks(todoId: number): Observable<Todo[]> {
     return this.http.get<Todo[]>(`${this.apiUrl}/todos/${todoId}/subtasks`)
+  }
+
+  /**
+   * 指定 Todo（parentId）配下にサブタスクを作成する。
+   * Backend: `POST /api/v1/todos/:id/subtasks`
+   */
+  createSubtask(parentId: number, todo: CreateTodoDto): Observable<Todo> {
+    return this.http.post<Todo>(`${this.apiUrl}/todos/${parentId}/subtasks`, todo)
   }
 }


### PR DESCRIPTION
## Summary
- `TodoService.createSubtask(parentId, todo)` を追加し、`POST /api/v1/todos/:id/subtasks` を呼び出す
- 併せて unit test と `docs/TODO_FEATURE_05_SUBTASKS.md`（5.8.2）を完了に更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)