### PR TITLE
feat(frontend): TodoService getProgress 実装

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -91,7 +91,7 @@ GET /api/todos/:id/progress
 
 - [x] 5.8.1: `getSubtasks(todoId: number): Observable<Todo[]>` 実装
 - [x] 5.8.2: `createSubtask(parentId: number, todo: CreateTodoDto): Observable<Todo>` 実装
-- [ ] 5.8.3: `getProgress(todoId: number): Observable<{completed: number, total: number}>` 実装
+- [x] 5.8.3: `getProgress(todoId: number): Observable<{completed: number, total: number}>` 実装
 
 ### Task 5.9: SubtaskList コンポーネント作成
 

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -9,7 +9,8 @@ export type TodoPriority = 'low' | 'medium' | 'high'
 export interface TodoProgress {
   completed: number
   total: number
-  percentage: number
+  /** 進捗率（%）。UI 実装が未使用の場合もあるため任意にする */
+  percentage?: number
 }
 
 /**

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -240,6 +240,21 @@ describe('TodoService', () => {
     })
   })
 
+  describe('progress (5.8.3)', () => {
+    it('should call GET /todos/:id/progress and return completed/total', () => {
+      const todoId = 1
+      const backendRes = { completed: 2, total: 5, percentage: 40 }
+      const expected = { completed: 2, total: 5 }
+
+      service.getProgress(todoId).subscribe((res) => expect(res).toEqual(expected))
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${apiUrl}/todos/${todoId}/progress` && r.method === 'GET'
+      )
+      req.flush(backendRes)
+    })
+  })
+
   describe('bulk (15.17)', () => {
     it('should call POST /todos/bulk-complete with todoIds in body', () => {
       const todoIds = [1, 2, 3]

--- a/frontend/src/app/services/todo.service.ts
+++ b/frontend/src/app/services/todo.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { Observable, from } from 'rxjs'
-import { tap } from 'rxjs/operators'
+import { map, tap } from 'rxjs/operators'
 import { environment } from '../../environments/environment'
 import type { Todo, TodoCreateUpdate, TodoPriority, CreateTodoDto } from '../models/todo.interface'
 import type { SearchParams } from '../models/search-params.interface'
@@ -162,5 +162,15 @@ export class TodoService {
    */
   createSubtask(parentId: number, todo: CreateTodoDto): Observable<Todo> {
     return this.http.post<Todo>(`${this.apiUrl}/todos/${parentId}/subtasks`, todo)
+  }
+
+  /**
+   * 指定 Todo のサブタスク進捗（completed/total）。
+   * Backend は percentage も返すが、UI 側では未使用のため正規化して返す。
+   */
+  getProgress(todoId: number): Observable<{ completed: number; total: number }> {
+    return this.http
+      .get<{ completed: number; total: number; percentage?: number }>(`${this.apiUrl}/todos/${todoId}/progress`)
+      .pipe(map(({ completed, total }) => ({ completed, total })))
   }
 }


### PR DESCRIPTION
## Summary
- `TodoService.getProgress(todoId)` を追加し、`GET /api/v1/todos/:id/progress` から `completed/total` を返す
- `docs/TODO_FEATURE_05_SUBTASKS.md` の `5.8.3` を `[x]` に更新
- unit test 追加

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`（TOTAL: 360 SUCCESS）

Made with [Cursor](https://cursor.com)