### PR TITLE
feat(frontend): SubtaskList コンポーネントを追加

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -95,11 +95,11 @@ GET /api/todos/:id/progress
 
 ### Task 5.9: SubtaskList コンポーネント作成
 
-- [ ] 5.9.1: `ng generate component components/subtask-list` 実行
-- [ ] 5.9.2: サブタスク一覧表示実装
-- [ ] 5.9.3: サブタスク追加ボタン実装
-- [ ] 5.9.4: @Input() parentId: number 実装
-- [ ] 5.9.5: インデント表示実装
+- [x] 5.9.1: `ng generate component components/subtask-list` 実行
+- [x] 5.9.2: サブタスク一覧表示実装
+- [x] 5.9.3: サブタスク追加ボタン実装
+- [x] 5.9.4: @Input() parentId: number 実装
+- [x] 5.9.5: インデント表示実装
 
 ### Task 5.10: ProgressBar コンポーネント作成
 

--- a/frontend/src/app/components/subtask-list/subtask-list.component.html
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.html
@@ -31,7 +31,7 @@
             [checked]="subtask.completed"
             (change)="toggle(subtask.id)"
           />
-          <span class="subtask-title" [class.text-decoration-line]="subtask.completed">
+          <span class="subtask-title" [class.text-decoration-line-through]="subtask.completed">
             {{ subtask.title }}
           </span>
         </div>
@@ -52,10 +52,17 @@
         />
 
         <div class="subtask-add-actions">
-          <button type="submit" class="btn btn-sm btn-primary" data-testid="subtask-add-submit">
+          <button
+            type="submit"
+            class="btn btn-sm btn-primary"
+            data-testid="subtask-add-submit"
+            [disabled]="creating"
+          >
             作成
           </button>
-          <button type="button" class="btn btn-sm btn-outline-secondary" (click)="cancelAdd()">キャンセル</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" [disabled]="creating" (click)="cancelAdd()">
+            キャンセル
+          </button>
         </div>
       </form>
     }

--- a/frontend/src/app/components/subtask-list/subtask-list.component.html
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.html
@@ -1,0 +1,64 @@
+<div class="subtask-list-root">
+  <div class="d-flex align-items-center justify-content-between mb-2">
+    <div class="d-flex align-items-center gap-2">
+      <span class="fw-semibold">Subtasks</span>
+      <span class="text-muted small">({{ subtasks.length }})</span>
+    </div>
+
+    <button
+      type="button"
+      class="btn btn-outline-primary btn-sm"
+      data-testid="subtask-add-toggle"
+      (click)="onAddClick()"
+    >
+      追加
+    </button>
+  </div>
+
+  @if (loading) {
+    <div class="text-muted small">読み込み中...</div>
+  } @else {
+    @if (error) {
+      <div class="text-danger small mb-2">{{ error }}</div>
+    }
+
+    <div class="subtask-indent">
+      @for (subtask of subtasks; track subtask.id) {
+        <div class="subtask-row">
+          <input
+            type="checkbox"
+            class="form-check-input"
+            [checked]="subtask.completed"
+            (change)="toggle(subtask.id)"
+          />
+          <span class="subtask-title" [class.text-decoration-line]="subtask.completed">
+            {{ subtask.title }}
+          </span>
+        </div>
+      }
+    </div>
+
+    @if (adding) {
+      <form class="subtask-add-form" (ngSubmit)="create()">
+        <input
+          type="text"
+          class="form-control form-control-sm"
+          name="title"
+          data-testid="subtask-title-input"
+          [(ngModel)]="newTitle"
+          placeholder="サブタスクタイトル"
+          required
+          maxlength="255"
+        />
+
+        <div class="subtask-add-actions">
+          <button type="submit" class="btn btn-sm btn-primary" data-testid="subtask-add-submit">
+            作成
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" (click)="cancelAdd()">キャンセル</button>
+        </div>
+      </form>
+    }
+  }
+</div>
+

--- a/frontend/src/app/components/subtask-list/subtask-list.component.scss
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.scss
@@ -1,0 +1,33 @@
+.subtask-list-root {
+  width: 100%;
+}
+
+.subtask-indent {
+  margin-left: 1rem;
+  border-left: 1px solid rgba(0, 0, 0, 0.08);
+  padding-left: 0.75rem;
+}
+
+.subtask-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.subtask-title {
+  font-size: 0.875rem;
+}
+
+.subtask-add-form {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.subtask-add-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+

--- a/frontend/src/app/components/subtask-list/subtask-list.component.spec.ts
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.spec.ts
@@ -1,0 +1,120 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SimpleChange } from '@angular/core'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { TodoService } from '../../services/todo.service'
+import { NetworkStatusService } from '../../services/network-status.service'
+import { OfflineStorageService } from '../../services/offline-storage.service'
+import SubtaskListComponent from './subtask-list.component'
+import { take } from 'rxjs'
+import type { Todo } from '../../models/todo.interface'
+
+describe('SubtaskListComponent', () => {
+  let fixture: ComponentFixture<SubtaskListComponent>
+  let component: SubtaskListComponent
+  let httpMock: HttpTestingController
+
+  const mockTodo: Todo = {
+    id: 1,
+    userId: 1,
+    title: 'T',
+    description: null,
+    completed: false,
+    priority: 'medium',
+    dueDate: null,
+    sortOrder: 0,
+    projectId: null,
+    archived: false,
+    archivedAt: null,
+    reminderEnabled: false,
+    reminderSentAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  }
+
+  beforeEach(async () => {
+    const networkStatus = jasmine.createSpyObj('NetworkStatusService', [], { isOnline: true })
+    const offlineStorage = jasmine.createSpyObj('OfflineStorageService', ['getTodos', 'saveTodos'])
+    offlineStorage.saveTodos.and.returnValue(Promise.resolve())
+    offlineStorage.getTodos.and.returnValue(Promise.resolve([]))
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, SubtaskListComponent],
+      providers: [
+        TodoService,
+        { provide: NetworkStatusService, useValue: networkStatus },
+        { provide: OfflineStorageService, useValue: offlineStorage }
+      ]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(SubtaskListComponent)
+    component = fixture.componentInstance
+    httpMock = TestBed.inject(HttpTestingController)
+
+    // テンプレートの初期レンダリングだけ行い、HTTP 発火は各テストで ngOnChanges を明示呼び出しする。
+    fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should load subtasks by parentId', (done) => {
+    const expected: Todo[] = [{ ...mockTodo, id: 10, parentId: 1, title: 'child' }]
+
+    component.subtasksUpdated.pipe(take(1)).subscribe((list) => {
+      expect(list.length).toBe(1)
+      expect(list[0].title).toBe('child')
+      done()
+    })
+
+    component.parentId = 1
+    component.ngOnChanges({
+      parentId: new SimpleChange(undefined, 1, true)
+    })
+
+    const req = httpMock.expectOne((r) => r.method === 'GET')
+    req.flush(expected)
+  })
+
+  it('should create subtask and append to list', () => {
+    const created: Todo = { ...mockTodo, id: 11, parentId: 1, title: 'new child' }
+
+    component.parentId = 1
+    component.ngOnChanges({
+      parentId: new SimpleChange(undefined, 1, true)
+    })
+
+    httpMock.expectOne((r) => r.method === 'GET').flush([])
+
+    component.onAddClick()
+    component.newTitle = 'new child'
+
+    component.create()
+
+    const postReq = httpMock.expectOne((r) => r.method === 'POST')
+    postReq.flush(created)
+
+    expect(component.subtasks.some((t) => t.id === 11 && t.title === 'new child')).toBe(true)
+  })
+
+  it('should toggle subtask completion', (done) => {
+    const initial: Todo[] = [{ ...mockTodo, id: 20, parentId: 1, title: 'child', completed: false }]
+    const updated: Todo = { ...initial[0], completed: true }
+
+    component.parentId = 1
+    component.ngOnChanges({
+      parentId: new SimpleChange(undefined, 1, true)
+    })
+    httpMock.expectOne((r) => r.method === 'GET').flush(initial)
+
+    component.subtasksUpdated.pipe(take(1)).subscribe((list) => {
+      expect(list[0].completed).toBe(true)
+      done()
+    })
+
+    component.toggle(20)
+    const patchReq = httpMock.expectOne((r) => r.method === 'PATCH')
+    patchReq.flush(updated)
+  })
+})
+

--- a/frontend/src/app/components/subtask-list/subtask-list.component.ts
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.ts
@@ -10,7 +10,7 @@ import { TodoService } from '../../services/todo.service'
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './subtask-list.component.html',
-  styleUrls: ['./subtask-list.component.scss']
+  styleUrl: './subtask-list.component.scss'
 })
 export default class SubtaskListComponent implements OnChanges, OnDestroy {
   @Input({ required: true }) parentId!: number
@@ -24,6 +24,7 @@ export default class SubtaskListComponent implements OnChanges, OnDestroy {
   /** 追加フォームの表示切り替え */
   adding = false
   newTitle = ''
+  creating = false
 
   private destroy$ = new Subject<void>()
 
@@ -35,32 +36,28 @@ export default class SubtaskListComponent implements OnChanges, OnDestroy {
     }
   }
 
-  private load(): Promise<void> {
+  private load(): void {
     if (!Number.isInteger(this.parentId) || this.parentId <= 0) {
       this.subtasks = []
-      return Promise.resolve()
+      return
     }
 
     this.loading = true
     this.error = null
-    return new Promise((resolve) => {
-      this.todoService
-        .getSubtasks(this.parentId)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: (list) => {
-            this.subtasks = list
-            this.subtasksUpdated.emit(list)
-            this.loading = false
-            resolve()
-          },
-          error: (err) => {
-            this.error = err?.error?.message ?? err?.message ?? 'サブタスクの取得に失敗しました'
-            this.loading = false
-            resolve()
-          }
-        })
-    })
+    this.todoService
+      .getSubtasks(this.parentId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (list) => {
+          this.subtasks = list
+          this.subtasksUpdated.emit(list)
+          this.loading = false
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'サブタスクの取得に失敗しました'
+          this.loading = false
+        }
+      })
   }
 
   ngOnDestroy(): void {
@@ -96,9 +93,10 @@ export default class SubtaskListComponent implements OnChanges, OnDestroy {
 
   create(): void {
     const title = this.newTitle.trim()
-    if (!title) return
+    if (!title || this.creating) return
 
     const payload: CreateTodoDto = { title }
+    this.creating = true
     this.todoService
       .createSubtask(this.parentId, payload)
       .pipe(takeUntil(this.destroy$))
@@ -108,9 +106,11 @@ export default class SubtaskListComponent implements OnChanges, OnDestroy {
           this.subtasksUpdated.emit(this.subtasks)
           this.adding = false
           this.newTitle = ''
+          this.creating = false
         },
         error: (err) => {
           this.error = err?.error?.message ?? err?.message ?? 'サブタスク作成に失敗しました'
+          this.creating = false
         }
       })
   }

--- a/frontend/src/app/components/subtask-list/subtask-list.component.ts
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.ts
@@ -1,0 +1,118 @@
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import { Subject, takeUntil } from 'rxjs'
+import type { Todo, CreateTodoDto } from '../../models/todo.interface'
+import { TodoService } from '../../services/todo.service'
+
+@Component({
+  selector: 'app-subtask-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './subtask-list.component.html',
+  styleUrls: ['./subtask-list.component.scss']
+})
+export default class SubtaskListComponent implements OnChanges, OnDestroy {
+  @Input({ required: true }) parentId!: number
+
+  @Output() subtasksUpdated = new EventEmitter<Todo[]>()
+
+  subtasks: Todo[] = []
+  loading = false
+  error: string | null = null
+
+  /** 追加フォームの表示切り替え */
+  adding = false
+  newTitle = ''
+
+  private destroy$ = new Subject<void>()
+
+  constructor(private todoService: TodoService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['parentId']) {
+      void this.load()
+    }
+  }
+
+  private load(): Promise<void> {
+    if (!Number.isInteger(this.parentId) || this.parentId <= 0) {
+      this.subtasks = []
+      return Promise.resolve()
+    }
+
+    this.loading = true
+    this.error = null
+    return new Promise((resolve) => {
+      this.todoService
+        .getSubtasks(this.parentId)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (list) => {
+            this.subtasks = list
+            this.subtasksUpdated.emit(list)
+            this.loading = false
+            resolve()
+          },
+          error: (err) => {
+            this.error = err?.error?.message ?? err?.message ?? 'サブタスクの取得に失敗しました'
+            this.loading = false
+            resolve()
+          }
+        })
+    })
+  }
+
+  ngOnDestroy(): void {
+    // takeUntil を適切に完了させ、購読をクリーンアップするため。
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  toggle(subtaskId: number): void {
+    this.todoService
+      .toggleComplete(subtaskId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (updated) => {
+          this.subtasks = this.subtasks.map((t) => (t.id === updated.id ? { ...t, ...updated } : t))
+          this.subtasksUpdated.emit(this.subtasks)
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '更新に失敗しました'
+        }
+      })
+  }
+
+  onAddClick(): void {
+    this.adding = true
+    this.newTitle = ''
+  }
+
+  cancelAdd(): void {
+    this.adding = false
+    this.newTitle = ''
+  }
+
+  create(): void {
+    const title = this.newTitle.trim()
+    if (!title) return
+
+    const payload: CreateTodoDto = { title }
+    this.todoService
+      .createSubtask(this.parentId, payload)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (created) => {
+          this.subtasks = [...this.subtasks, created]
+          this.subtasksUpdated.emit(this.subtasks)
+          this.adding = false
+          this.newTitle = ''
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'サブタスク作成に失敗しました'
+        }
+      })
+  }
+}
+


### PR DESCRIPTION
## Summary
親 Todo に紐づくサブタスクの一覧表示、完了切替、追加フォームを提供するために `SubtaskListComponent` を追加しました。

- `@Input() parentId` でサブタスクを取得
- `@Output() subtasksUpdated` で更新を親へ通知

## Docs
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.9.1〜5.9.5 を完了（`[x]`）に更新

## Test plan
- `docker compose run --rm frontend ng build`
- `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)