### PR TITLE
feat(frontend): ProgressBarコンポーネントを追加

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -103,10 +103,10 @@ GET /api/todos/:id/progress
 
 ### Task 5.10: ProgressBar コンポーネント作成
 
-- [ ] 5.10.1: `ng generate component components/progress-bar` 実行
-- [ ] 5.10.2: Angular Material Progress Bar 使用
-- [ ] 5.10.3: 進捗率表示実装
-- [ ] 5.10.4: @Input() progress: {completed: number, total: number} 実装
+- [x] 5.10.1: `ng generate component components/progress-bar` 実行
+- [x] 5.10.2: Angular Material Progress Bar 使用
+- [x] 5.10.3: 進捗率表示実装
+- [x] 5.10.4: @Input() progress: {completed: number, total: number} 実装
 
 ### Task 5.11: TodoItem に進捗バー追加
 

--- a/frontend/src/app/components/progress-bar/progress-bar.component.html
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.html
@@ -1,0 +1,9 @@
+<div class="progress-bar-root">
+  <div class="progress-meta">
+    <span class="progress-label">進捗</span>
+    <span class="progress-value">{{ completed }}/{{ total }} ({{ percentage }}%)</span>
+  </div>
+
+  <mat-progress-bar mode="determinate" [value]="percentage" aria-label="サブタスク進捗バー" />
+</div>
+

--- a/frontend/src/app/components/progress-bar/progress-bar.component.scss
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.scss
@@ -1,0 +1,19 @@
+.progress-bar-root {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.progress-label {
+  font-weight: 600;
+  color: #495057;
+}
+

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ProgressBarComponent } from './progress-bar.component'
+
+describe('ProgressBarComponent (5.10)', () => {
+  let fixture: ComponentFixture<ProgressBarComponent>
+  let component: ProgressBarComponent
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProgressBarComponent]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ProgressBarComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+})
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should calculate percentage from progress input', () => {
+    component.progress = { completed: 2, total: 5 }
+    fixture.detectChanges()
+
+    expect(component.percentage).toBe(40)
+  })
+
+  it('should return 0 percentage when total is zero', () => {
+    component.progress = { completed: 3, total: 0 }
+    fixture.detectChanges()
+
+    expect(component.percentage).toBe(0)
+  })
+})
+

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { ProgressBarComponent } from './progress-bar.component'
 
 describe('ProgressBarComponent (5.10)', () => {
@@ -7,7 +8,8 @@ describe('ProgressBarComponent (5.10)', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProgressBarComponent]
+      imports: [ProgressBarComponent],
+      providers: [provideNoopAnimations()]
     }).compileComponents()
 
     fixture = TestBed.createComponent(ProgressBarComponent)

--- a/frontend/src/app/components/progress-bar/progress-bar.component.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.ts
@@ -1,0 +1,31 @@
+import { CommonModule } from '@angular/common'
+import { Component, Input } from '@angular/core'
+import { MatProgressBarModule } from '@angular/material/progress-bar'
+import type { TodoProgress } from '../../models/todo.interface'
+
+@Component({
+  selector: 'app-progress-bar',
+  standalone: true,
+  imports: [CommonModule, MatProgressBarModule],
+  templateUrl: './progress-bar.component.html',
+  styleUrl: './progress-bar.component.scss'
+})
+export class ProgressBarComponent {
+  @Input() progress: Pick<TodoProgress, 'completed' | 'total'> | null = null
+
+  get completed(): number {
+    const value = this.progress?.completed ?? 0
+    return Number.isFinite(value) ? Math.max(0, value) : 0
+  }
+
+  get total(): number {
+    const value = this.progress?.total ?? 0
+    return Number.isFinite(value) ? Math.max(0, value) : 0
+  }
+
+  get percentage(): number {
+    if (this.total <= 0) return 0
+    return Math.min(100, Math.round((this.completed / this.total) * 100))
+  }
+}
+


### PR DESCRIPTION
## 変更内容
Task 5.10（ProgressBar コンポーネント作成）を実装しました。

- `components/progress-bar` を新規追加（standalone）
- `@Input() progress: { completed, total }` を受けて進捗率を算出
- Angular Material `mat-progress-bar` で表示
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.10.1〜5.10.4 を `[x]` 更新

## テスト
- `docker compose run --rm frontend ng test --watch=false --include='**/progress-bar.component.spec.ts'`
- `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)