### PR TITLE
feat(frontend): TodoFormにサブタスク作成モードを追加

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -116,8 +116,8 @@ GET /api/todos/:id/progress
 
 ### Task 5.12: TodoForm にサブタスク作成モード追加
 
-- [ ] 5.12.1: @Input() parentId?: number 追加
-- [ ] 5.12.2: サブタスク作成時の UI 調整
+- [x] 5.12.1: @Input() parentId?: number 追加
+- [x] 5.12.2: サブタスク作成時の UI 調整
 
 ### Task 5.13: TodoDetail ページ作成
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="form" (ngSubmit)="onSubmit()" class="todo-form">
-  @if (templates.length > 0 && !editingTodo) {
+  @if (templates.length > 0 && !editingTodo && !isSubtaskMode) {
     <div class="mb-2">
       <label for="todo-template" class="form-label">テンプレートから入力（任意）</label>
       <select
@@ -24,7 +24,7 @@
       type="text"
       class="form-control"
       formControlName="title"
-      placeholder="Todo のタイトル"
+      [placeholder]="isSubtaskMode ? 'サブタスクのタイトル' : 'Todo のタイトル'"
       maxlength="255"
     />
     @if (form.get('title')?.invalid && form.get('title')?.touched) {
@@ -42,7 +42,7 @@
     ></textarea>
   </div>
   <div class="row mb-2">
-    <div class="col-md-6">
+    <div class="col-md-6" [class.col-12]="isSubtaskMode">
       <label for="todo-priority" class="form-label">優先度</label>
       <select id="todo-priority" class="form-select" formControlName="priority">
         <option value="low">low</option>
@@ -50,7 +50,8 @@
         <option value="high">high</option>
       </select>
     </div>
-    <div class="col-md-6">
+    @if (!isSubtaskMode) {
+      <div class="col-md-6">
       <label for="todo-dueDate" class="form-label">期限</label>
       <input
         id="todo-dueDate"
@@ -58,9 +59,10 @@
         class="form-control"
         formControlName="dueDate"
       />
-    </div>
+      </div>
+    }
   </div>
-  @if (projects.length > 0) {
+  @if (projects.length > 0 && !isSubtaskMode) {
     <div class="mb-2">
       <label for="todo-project" class="form-label">プロジェクト</label>
       <select id="todo-project" class="form-select" formControlName="projectId">
@@ -73,7 +75,7 @@
   }
   <div class="d-flex gap-2">
     <button type="submit" class="btn btn-primary" [disabled]="form.invalid">
-      {{ editingTodo ? '更新' : '作成' }}
+      {{ editingTodo ? '更新' : (isSubtaskMode ? 'サブタスクを作成' : '作成') }}
     </button>
     @if (editingTodo) {
       <button type="button" class="btn btn-outline-secondary" (click)="onCancel()">キャンセル</button>

--- a/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { TodoFormComponent } from './todo-form.component'
+
+describe('TodoFormComponent (5.12)', () => {
+  let fixture: ComponentFixture<TodoFormComponent>
+  let component: TodoFormComponent
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TodoFormComponent, NoopAnimationsModule]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(TodoFormComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should enable subtask mode when parentId is set', () => {
+    component.parentId = 10
+    fixture.detectChanges()
+
+    expect(component.isSubtaskMode).toBeTrue()
+  })
+
+  it('should show subtask submit label in subtask mode', () => {
+    component.parentId = 10
+    fixture.detectChanges()
+
+    const el: HTMLElement = fixture.nativeElement
+    expect(el.textContent).toContain('サブタスクを作成')
+  })
+})
+

--- a/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-form/todo-form.component.ts
@@ -20,6 +20,7 @@ function noWhitespaceValidator(control: AbstractControl): ValidationErrors | nul
 })
 export class TodoFormComponent implements OnChanges {
   @Input() editingTodo: Todo | null = null
+  @Input() parentId?: number
   @Input() projects: Project[] = []
   @Input() templates: Template[] = []
   @Output() submitForm = new EventEmitter<TodoCreateUpdate>()
@@ -96,5 +97,9 @@ export class TodoFormComponent implements OnChanges {
       priority: template.priority,
     })
     el.value = ''
+  }
+
+  get isSubtaskMode(): boolean {
+    return !this.editingTodo && this.parentId != null
   }
 }


### PR DESCRIPTION
## 変更内容
Task 5.12（TodoForm にサブタスク作成モード追加）を実装しました。

- `TodoFormComponent` に `@Input() parentId?: number` を追加
- `isSubtaskMode` を導入し、サブタスク作成時の UI を調整
  - テンプレート選択を非表示
  - 期限入力を非表示
  - プロジェクト選択を非表示
  - タイトルプレースホルダー/送信ボタン文言をサブタスク向けに変更
- `todo-form.component.spec.ts` を追加
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.12.1〜5.12.2 を `[x]` 更新

## テスト
- `docker compose run --rm frontend ng test --watch=false --include='**/todo-form.component.spec.ts'`
- `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)