### PR TITLE
feat(frontend): TodoDetailページを追加

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -121,10 +121,10 @@ GET /api/todos/:id/progress
 
 ### Task 5.13: TodoDetail ページ作成
 
-- [ ] 5.13.1: `ng generate component pages/todo-detail-page` 実行
-- [ ] 5.13.2: Todo 詳細表示実装
-- [ ] 5.13.3: SubtaskList 統合
-- [ ] 5.13.4: ルーティング追加
+- [x] 5.13.1: `ng generate component pages/todo-detail-page` 実行
+- [x] 5.13.2: Todo 詳細表示実装
+- [x] 5.13.3: SubtaskList 統合
+- [x] 5.13.4: ルーティング追加
 
 ### Task 5.14: スタイリング
 

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -15,6 +15,10 @@ export const DASHBOARD_ROUTES: Routes = [
         loadComponent: () => import('./todo/todo-page/todo-page.component')
       },
       {
+        path: 'todos/:id',
+        loadComponent: () => import('./todo/todo-detail-page/todo-detail-page.component')
+      },
+      {
         path: 'calendar',
         loadComponent: () => import('./calendar/calendar-page/calendar-page.component')
       },

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.html
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="col-12">
+    <div class="d-flex align-items-center justify-content-between mb-3">
+      <h2 class="h5 mb-0">Todo 詳細</h2>
+      <a routerLink="/dashboard/todos" class="btn btn-sm btn-outline-secondary">一覧へ戻る</a>
+    </div>
+
+    @if (loading) {
+      <p class="text-muted mb-0">読み込み中...</p>
+    } @else if (error) {
+      <p class="text-danger mb-0">{{ error }}</p>
+    } @else if (todo) {
+      <div class="card">
+        <div class="card-body">
+          <div class="d-flex flex-wrap align-items-center gap-2">
+            <h3 class="h6 mb-0">{{ todo.title }}</h3>
+            <span class="badge text-bg-secondary">{{ todo.priority }}</span>
+            @if (todo.completed) {
+              <span class="badge text-bg-success">完了</span>
+            }
+          </div>
+
+          @if (todo.description) {
+            <p class="text-muted mt-2 mb-3">{{ todo.description }}</p>
+          }
+
+          <div class="mb-3">
+            <app-progress-bar [progress]="{ completed: todo.progress?.completed ?? 0, total: todo.progress?.total ?? 0 }"></app-progress-bar>
+          </div>
+
+          <app-subtask-list [parentId]="todo.id" (subtasksUpdated)="onSubtasksUpdated($event)"></app-subtask-list>
+        </div>
+      </div>
+    }
+  </div>
+</div>
+

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.scss
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.scss
@@ -1,0 +1,4 @@
+.card {
+  border: 1px solid #dee2e6;
+}
+

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { ActivatedRoute, convertToParamMap } from '@angular/router'
+import { TodoService } from '../../../../../services/todo.service'
+import { NetworkStatusService } from '../../../../../services/network-status.service'
+import { OfflineStorageService } from '../../../../../services/offline-storage.service'
+import type { Todo } from '../../../../../models/todo.interface'
+import TodoDetailPageComponent from './todo-detail-page.component'
+
+describe('TodoDetailPageComponent (5.13)', () => {
+  let fixture: ComponentFixture<TodoDetailPageComponent>
+  let component: TodoDetailPageComponent
+  let httpMock: HttpTestingController
+
+  const todo: Todo = {
+    id: 1,
+    userId: 1,
+    title: 'Parent',
+    description: 'desc',
+    completed: false,
+    priority: 'medium',
+    dueDate: null,
+    sortOrder: 0,
+    projectId: null,
+    archived: false,
+    archivedAt: null,
+    reminderEnabled: false,
+    reminderSentAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  }
+
+  beforeEach(async () => {
+    const networkStatus = jasmine.createSpyObj('NetworkStatusService', [], { isOnline: true })
+    const offlineStorage = jasmine.createSpyObj('OfflineStorageService', ['getTodos', 'saveTodos'])
+    offlineStorage.saveTodos.and.returnValue(Promise.resolve())
+    offlineStorage.getTodos.and.returnValue(Promise.resolve([]))
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, TodoDetailPageComponent],
+      providers: [
+        TodoService,
+        { provide: NetworkStatusService, useValue: networkStatus },
+        { provide: OfflineStorageService, useValue: offlineStorage },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ id: '1' }) } }
+        }
+      ]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(TodoDetailPageComponent)
+    component = fixture.componentInstance
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should load todo detail by route id', () => {
+    fixture.detectChanges()
+    const req = httpMock.expectOne((r) => r.method === 'GET' && r.url.includes('/todos/1'))
+    req.flush(todo)
+    expect(component.todo?.title).toBe('Parent')
+  })
+
+  it('should update progress when subtasks updated', () => {
+    component.todo = todo
+    component.onSubtasksUpdated([
+      { ...todo, id: 11, parentId: 1, completed: true },
+      { ...todo, id: 12, parentId: 1, completed: false }
+    ])
+    expect(component.todo.progress).toEqual({ completed: 1, total: 2 })
+  })
+})
+

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { ActivatedRoute, convertToParamMap } from '@angular/router'
 import { TodoService } from '../../../../../services/todo.service'
 import { NetworkStatusService } from '../../../../../services/network-status.service'
@@ -39,6 +40,7 @@ describe('TodoDetailPageComponent (5.13)', () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, TodoDetailPageComponent],
       providers: [
+        provideNoopAnimations(),
         TodoService,
         { provide: NetworkStatusService, useValue: networkStatus },
         { provide: OfflineStorageService, useValue: offlineStorage },

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.ts
@@ -1,0 +1,70 @@
+import { CommonModule } from '@angular/common'
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { ActivatedRoute, RouterLink } from '@angular/router'
+import { Subject, takeUntil } from 'rxjs'
+import type { Todo } from '../../../../../models/todo.interface'
+import { TodoService } from '../../../../../services/todo.service'
+import { ProgressBarComponent } from '../../../../progress-bar/progress-bar.component'
+import SubtaskListComponent from '../../../../subtask-list/subtask-list.component'
+
+@Component({
+  selector: 'app-todo-detail-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink, ProgressBarComponent, SubtaskListComponent],
+  templateUrl: './todo-detail-page.component.html',
+  styleUrl: './todo-detail-page.component.scss'
+})
+export default class TodoDetailPageComponent implements OnInit, OnDestroy {
+  todo: Todo | null = null
+  loading = false
+  error: string | null = null
+  private destroy$ = new Subject<void>()
+
+  constructor(
+    private route: ActivatedRoute,
+    private todoService: TodoService
+  ) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      this.error = '不正な Todo ID です'
+      return
+    }
+    this.loadTodo(id)
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  onSubtasksUpdated(subtasks: Todo[]): void {
+    if (!this.todo) return
+    const completed = subtasks.filter((t) => t.completed).length
+    this.todo = {
+      ...this.todo,
+      subtasks,
+      progress: { completed, total: subtasks.length }
+    }
+  }
+
+  private loadTodo(id: number): void {
+    this.loading = true
+    this.error = null
+    this.todoService
+      .getById(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (todo) => {
+          this.todo = todo
+          this.loading = false
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'Todo の取得に失敗しました'
+          this.loading = false
+        }
+      })
+  }
+}
+

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -8,7 +8,12 @@
     [attr.aria-label]="'完了: ' + todo.title"
   />
   <div class="flex-grow-1 min-width-0">
-    <span class="todo-title" [class.text-decoration-line-through]="todo.completed" [class.text-muted]="todo.completed">
+    <a
+      class="todo-title text-decoration-none"
+      [routerLink]="['/dashboard/todos', todo.id]"
+      [class.text-decoration-line-through]="todo.completed"
+      [class.text-muted]="todo.completed"
+    >
       @for (p of titleParts; track $index) {
         @if (p.match) {
           <mark class="todo-highlight">{{ p.text }}</mark>
@@ -16,7 +21,7 @@
           <span>{{ p.text }}</span>
         }
       }
-    </span>
+    </a>
     @if (todo.description) {
       <span class="d-block small text-muted">
         @for (p of descParts; track $index) {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.html
@@ -9,9 +9,10 @@
   />
   <div class="flex-grow-1 min-width-0">
     <a
-      class="todo-title text-decoration-none"
+      class="todo-title"
       [routerLink]="['/dashboard/todos', todo.id]"
       [class.text-decoration-line-through]="todo.completed"
+      [class.text-decoration-none]="!todo.completed"
       [class.text-muted]="todo.completed"
     >
       @for (p of titleParts; track $index) {

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { SimpleChange } from '@angular/core'
 import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { ActivatedRoute, convertToParamMap } from '@angular/router'
 import { TodoItemComponent } from './todo-item.component'
 import type { ReminderToggleEvent } from './todo-item.component'
 import type { Todo } from '../../../../../models/todo.interface'
@@ -32,7 +33,13 @@ describe('TodoItemComponent (2.12.2)', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TodoItemComponent, HttpClientTestingModule],
-      providers: [provideNoopAnimations()]
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ id: '1' }) } }
+        }
+      ]
     }).compileComponents()
 
     fixture = TestBed.createComponent(TodoItemComponent)

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { RouterLink } from '@angular/router'
 import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap'
 import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
@@ -18,6 +19,7 @@ export interface ReminderToggleEvent {
   standalone: true,
   imports: [
     CommonModule,
+    RouterLink,
     NgbDropdown,
     NgbDropdownToggle,
     NgbDropdownMenu,


### PR DESCRIPTION
## 変更内容
Task 5.13（TodoDetail ページ作成）を実装しました。

- `todo-detail-page` を新規追加し Todo 詳細を表示
- `SubtaskListComponent` と `ProgressBarComponent` を TodoDetail に統合
- `subtasksUpdated` 時にローカルの progress/subtasks を再計算
- ダッシュボードルーティングに `/dashboard/todos/:id` を追加
- `TodoItem` のタイトルから詳細ページへ遷移可能に変更
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.13.1〜5.13.4 を `[x]` 更新

## テスト
- `docker compose run --rm frontend ng test --watch=false --include='**/todo-detail-page.component.spec.ts'`
- `docker compose run --rm frontend ng test --watch=false --include='**/todo-item.component.spec.ts'`
- `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)