### PR TITLE
test(frontend): サブタスク関連テストを拡充

### DIFF
--- a/docs/TODO_FEATURE_05_SUBTASKS.md
+++ b/docs/TODO_FEATURE_05_SUBTASKS.md
@@ -134,9 +134,9 @@ GET /api/todos/:id/progress
 
 ### Task 5.15: Frontend テスト
 
-- [ ] 5.15.1: TodoService サブタスク機能のテスト
-- [ ] 5.15.2: SubtaskList コンポーネントテスト
-- [ ] 5.15.3: ProgressBar コンポーネントテスト
+- [x] 5.15.1: TodoService サブタスク機能のテスト
+- [x] 5.15.2: SubtaskList コンポーネントテスト
+- [x] 5.15.3: ProgressBar コンポーネントテスト
 
 ---
 

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -15,7 +15,7 @@ describe('ProgressBarComponent (5.10)', () => {
     fixture = TestBed.createComponent(ProgressBarComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
-})
+  })
 
   it('should create', () => {
     expect(component).toBeTruthy()
@@ -33,6 +33,22 @@ describe('ProgressBarComponent (5.10)', () => {
     fixture.detectChanges()
 
     expect(component.percentage).toBe(0)
+  })
+
+  it('should clamp negative values to zero', () => {
+    component.progress = { completed: -3, total: -10 }
+    fixture.detectChanges()
+
+    expect(component.completed).toBe(0)
+    expect(component.total).toBe(0)
+    expect(component.percentage).toBe(0)
+  })
+
+  it('should clamp percentage to 100 when completed exceeds total', () => {
+    component.progress = { completed: 10, total: 3 }
+    fixture.detectChanges()
+
+    expect(component.percentage).toBe(100)
   })
 })
 

--- a/frontend/src/app/components/subtask-list/subtask-list.component.spec.ts
+++ b/frontend/src/app/components/subtask-list/subtask-list.component.spec.ts
@@ -116,5 +116,34 @@ describe('SubtaskListComponent', () => {
     const patchReq = httpMock.expectOne((r) => r.method === 'PATCH')
     patchReq.flush(updated)
   })
+
+  it('should set error when loading subtasks fails', () => {
+    component.parentId = 1
+    component.ngOnChanges({
+      parentId: new SimpleChange(undefined, 1, true)
+    })
+
+    const req = httpMock.expectOne((r) => r.method === 'GET')
+    req.flush({ message: 'failed' }, { status: 500, statusText: 'Server Error' })
+
+    expect(component.error).toBe('failed')
+    expect(component.loading).toBeFalse()
+  })
+
+  it('should prevent duplicate create calls while creating', () => {
+    component.parentId = 1
+    component.ngOnChanges({
+      parentId: new SimpleChange(undefined, 1, true)
+    })
+    httpMock.expectOne((r) => r.method === 'GET').flush([])
+
+    component.onAddClick()
+    component.newTitle = 'new child'
+    component.creating = true
+    component.create()
+
+    expect(component.subtasks.length).toBe(0)
+    httpMock.expectNone((r) => r.method === 'POST')
+  })
 })
 

--- a/frontend/src/app/services/todo.service.spec.ts
+++ b/frontend/src/app/services/todo.service.spec.ts
@@ -222,6 +222,22 @@ describe('TodoService', () => {
       const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${todoId}/subtasks` && r.method === 'GET')
       req.flush(mockSubtasks)
     })
+
+    it('should propagate error from GET /todos/:id/subtasks', () => {
+      const todoId = 99
+      const message = 'not found'
+
+      service.getSubtasks(todoId).subscribe({
+        next: () => fail('expected error'),
+        error: (err) => {
+          expect(err.status).toBe(404)
+          expect(err.error?.message).toBe(message)
+        }
+      })
+
+      const req = httpMock.expectOne((r) => r.url === `${apiUrl}/todos/${todoId}/subtasks` && r.method === 'GET')
+      req.flush({ message }, { status: 404, statusText: 'Not Found' })
+    })
   })
 
   describe('subtasks (5.8.2)', () => {
@@ -237,6 +253,19 @@ describe('TodoService', () => {
       )
       expect(req.request.body).toEqual(payload)
       req.flush(created)
+    })
+
+    it('should send title payload as-is for createSubtask', () => {
+      const parentId = 3
+      const payload: CreateTodoDto = { title: ' child ' }
+
+      service.createSubtask(parentId, payload).subscribe()
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${apiUrl}/todos/${parentId}/subtasks` && r.method === 'POST'
+      )
+      expect(req.request.body).toEqual(payload)
+      req.flush({ ...mockTodo, id: 30, parentId, title: ' child ' })
     })
   })
 


### PR DESCRIPTION
## 変更内容
Task 5.15（Frontend テスト）を実装しました。

- `TodoService` のサブタスク系にエラー系/リクエスト内容検証を追加（5.15.1）
- `SubtaskListComponent` のエラー表示と二重送信ガードのテストを追加（5.15.2）
- `ProgressBarComponent` の境界値（負値・100%超過）テストを追加（5.15.3）
- `docs/TODO_FEATURE_05_SUBTASKS.md` の 5.15.1〜5.15.3 を `[x]` 更新

## テスト
- `docker compose run --rm frontend ng test --watch=false --include='**/todo.service.spec.ts'`
- `docker compose run --rm frontend ng test --watch=false --include='**/subtask-list.component.spec.ts'`
- `docker compose run --rm frontend ng test --watch=false --include='**/progress-bar.component.spec.ts'`
- `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)