### PR TITLE
feat(backend): 繰り返しTodoのDBカラムとモデルを追加

### DIFF
--- a/backend/migrations/20260326160000-add-recurrence-fields-to-todos.js
+++ b/backend/migrations/20260326160000-add-recurrence-fields-to-todos.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('todos', 'is_recurring', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+
+    await queryInterface.addColumn('todos', 'recurrence_pattern', {
+      type: Sequelize.ENUM('daily', 'weekly', 'monthly'),
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('todos', 'recurrence_interval', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    });
+
+    await queryInterface.addColumn('todos', 'recurrence_end_date', {
+      type: Sequelize.DATEONLY,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('todos', 'original_todo_id', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+
+    await queryInterface.addIndex('todos', ['is_recurring'], {
+      name: 'idx_todos_is_recurring',
+    });
+
+    await queryInterface.addIndex('todos', ['original_todo_id'], {
+      name: 'idx_todos_original_todo_id',
+    });
+
+    await queryInterface.addConstraint('todos', {
+      fields: ['original_todo_id'],
+      type: 'foreign key',
+      name: 'fk_todos_original_todo_id',
+      references: { table: 'todos', field: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeConstraint('todos', 'fk_todos_original_todo_id');
+    await queryInterface.removeIndex('todos', 'idx_todos_original_todo_id');
+    await queryInterface.removeIndex('todos', 'idx_todos_is_recurring');
+    await queryInterface.removeColumn('todos', 'original_todo_id');
+    await queryInterface.removeColumn('todos', 'recurrence_end_date');
+    await queryInterface.removeColumn('todos', 'recurrence_interval');
+    await queryInterface.removeColumn('todos', 'recurrence_pattern');
+    await queryInterface.removeColumn('todos', 'is_recurring');
+
+    await queryInterface.sequelize.query(
+      "DROP TYPE IF EXISTS `enum_todos_recurrence_pattern`;"
+    ).catch(() => {});
+  },
+};
+

--- a/backend/migrations/20260326160000-add-recurrence-fields-to-todos.js
+++ b/backend/migrations/20260326160000-add-recurrence-fields-to-todos.js
@@ -57,10 +57,6 @@ module.exports = {
     await queryInterface.removeColumn('todos', 'recurrence_interval');
     await queryInterface.removeColumn('todos', 'recurrence_pattern');
     await queryInterface.removeColumn('todos', 'is_recurring');
-
-    await queryInterface.sequelize.query(
-      "DROP TYPE IF EXISTS `enum_todos_recurrence_pattern`;"
-    ).catch(() => {});
   },
 };
 

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -89,12 +89,55 @@ module.exports = (sequelize) => {
         onUpdate: 'CASCADE',
         onDelete: 'CASCADE',
       },
+      isRecurring: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: 'is_recurring',
+      },
+      recurrencePattern: {
+        type: DataTypes.ENUM('daily', 'weekly', 'monthly'),
+        allowNull: true,
+        field: 'recurrence_pattern',
+      },
+      recurrenceInterval: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+        field: 'recurrence_interval',
+      },
+      recurrenceEndDate: {
+        type: DataTypes.DATEONLY,
+        allowNull: true,
+        field: 'recurrence_end_date',
+      },
+      originalTodoId: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        field: 'original_todo_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
     },
     {
       tableName: 'todos',
       timestamps: true,
       underscored: true,
       validate: {
+        recurrenceConsistency() {
+          if (!this.isRecurring) {
+            return;
+          }
+
+          if (!this.recurrencePattern) {
+            throw new Error('繰り返し設定には recurrencePattern が必要です。');
+          }
+
+          if (!Number.isInteger(this.recurrenceInterval) || this.recurrenceInterval < 1) {
+            throw new Error('recurrenceInterval は 1 以上の整数である必要があります。');
+          }
+        },
         async hasNoCircularParentReference() {
           if (!this.parentId || !this.id) {
             return;
@@ -143,6 +186,14 @@ module.exports = (sequelize) => {
     Todo.hasMany(models.Todo, {
       foreignKey: 'parentId',
       as: 'subtasks',
+    });
+    Todo.belongsTo(models.Todo, {
+      foreignKey: 'originalTodoId',
+      as: 'originalTodo',
+    });
+    Todo.hasMany(models.Todo, {
+      foreignKey: 'originalTodoId',
+      as: 'recurrences',
     });
     Todo.belongsToMany(models.Tag, {
       through: models.TodoTag,

--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -39,16 +39,16 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.1: 繰り返しカラム追加
 
-- [ ] 6.1.1: マイグレーション生成 `add-recurrence-fields-to-todos`
-- [ ] 6.1.2: isRecurring, recurrencePattern, recurrenceInterval, recurrenceEndDate, originalTodoId カラム追加
-- [ ] 6.1.3: インデックス追加
-- [ ] 6.1.4: 外部キー制約追加（originalTodoId）
-- [ ] 6.1.5: マイグレーション実行
+- [x] 6.1.1: マイグレーション生成 `add-recurrence-fields-to-todos`
+- [x] 6.1.2: isRecurring, recurrencePattern, recurrenceInterval, recurrenceEndDate, originalTodoId カラム追加
+- [x] 6.1.3: インデックス追加
+- [x] 6.1.4: 外部キー制約追加（originalTodoId）
+- [x] 6.1.5: マイグレーション実行
 
 ### Task 6.2: Todo モデル更新
 
-- [ ] 6.2.1: 繰り返しフィールド追加
-- [ ] 6.2.2: バリデーション実装
+- [x] 6.2.1: 繰り返しフィールド追加
+- [x] 6.2.2: バリデーション実装
 
 ### Task 6.3: RecurrenceService 作成
 


### PR DESCRIPTION
## 変更内容
Task 6.1 / 6.2（繰り返しカラム追加・Todoモデル更新）を実装しました。

- `add-recurrence-fields-to-todos` マイグレーションを追加
  - `is_recurring`, `recurrence_pattern`, `recurrence_interval`, `recurrence_end_date`, `original_todo_id`
  - インデックス: `is_recurring`, `original_todo_id`
  - 外部キー: `original_todo_id -> todos.id (ON UPDATE CASCADE, ON DELETE SET NULL)`
- `backend/models/todo.js` に繰り返しフィールドを追加
- `isRecurring` 有効時の整合性バリデーションを追加
  - `recurrencePattern` 必須
  - `recurrenceInterval >= 1` 必須
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.1.1〜6.1.5, 6.2.1〜6.2.2 を `[x]` 更新

## 検証
- `docker compose run --rm backend npx sequelize-cli db:migrate`
- `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)