### PR TITLE
feat(backend): RecurrenceServiceを追加して繰り返し計算を実装

### DIFF
--- a/backend/services/recurrenceService.js
+++ b/backend/services/recurrenceService.js
@@ -1,9 +1,5 @@
 'use strict';
 
-module.exports = require('./recurrenceService');
-
-'use strict';
-
 function toDateOnlyString(date) {
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, '0');
@@ -89,13 +85,15 @@ function shouldCreateNext(todo) {
  * 実際の DB 保存は呼び出し側サービスに委譲する。
  */
 function createNextOccurrence(todo) {
-  if (!shouldCreateNext(todo)) return null;
+  if (!todo?.isRecurring) return null;
+  if (!todo.recurrencePattern) return null;
 
   const nextDueDate = calculateNextDueDate(
     todo.recurrencePattern,
     todo.recurrenceInterval,
     todo.dueDate ?? toDateOnlyString(new Date())
   );
+  if (todo.recurrenceEndDate && nextDueDate > todo.recurrenceEndDate) return null;
 
   return {
     userId: todo.userId,

--- a/backend/services/recurrenceService.js
+++ b/backend/services/recurrenceService.js
@@ -1,0 +1,127 @@
+'use strict';
+
+module.exports = require('./recurrenceService');
+
+'use strict';
+
+function toDateOnlyString(date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateOnly(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const [y, m, d] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  if (
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() + 1 !== m ||
+    date.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function addMonthsUtc(date, months) {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+
+  const targetMonth = month + months;
+  const targetYear = year + Math.floor(targetMonth / 12);
+  const monthInYear = ((targetMonth % 12) + 12) % 12;
+
+  const lastDayOfTargetMonth = new Date(Date.UTC(targetYear, monthInYear + 1, 0)).getUTCDate();
+  const safeDay = Math.min(day, lastDayOfTargetMonth);
+
+  return new Date(Date.UTC(targetYear, monthInYear, safeDay));
+}
+
+/**
+ * 繰り返し設定に基づいて次回期限日（DATEONLY）を計算する。
+ * dueDate がない場合は現在日付（UTC 基準）を起点にする。
+ */
+function calculateNextDueDate(pattern, interval, currentDate) {
+  const safeInterval = Number.isInteger(interval) && interval > 0 ? interval : 1;
+  const baseDate = parseDateOnly(currentDate) ?? new Date();
+  const base = new Date(Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate()));
+
+  if (pattern === 'daily') {
+    base.setUTCDate(base.getUTCDate() + safeInterval);
+    return toDateOnlyString(base);
+  }
+  if (pattern === 'weekly') {
+    base.setUTCDate(base.getUTCDate() + safeInterval * 7);
+    return toDateOnlyString(base);
+  }
+  if (pattern === 'monthly') {
+    return toDateOnlyString(addMonthsUtc(base, safeInterval));
+  }
+
+  throw new Error('不正な recurrencePattern です。');
+}
+
+/**
+ * 次回発生 Todo を生成すべきか判定する。
+ * recurrenceEndDate がある場合、次回期限日が終了日を超えると false。
+ */
+function shouldCreateNext(todo) {
+  if (!todo?.isRecurring) return false;
+  if (!todo.recurrencePattern) return false;
+
+  const nextDueDate = calculateNextDueDate(
+    todo.recurrencePattern,
+    todo.recurrenceInterval,
+    todo.dueDate ?? toDateOnlyString(new Date())
+  );
+
+  if (!todo.recurrenceEndDate) return true;
+  return nextDueDate <= todo.recurrenceEndDate;
+}
+
+/**
+ * 次回発生 Todo の作成用 payload を返す。
+ * 実際の DB 保存は呼び出し側サービスに委譲する。
+ */
+function createNextOccurrence(todo) {
+  if (!shouldCreateNext(todo)) return null;
+
+  const nextDueDate = calculateNextDueDate(
+    todo.recurrencePattern,
+    todo.recurrenceInterval,
+    todo.dueDate ?? toDateOnlyString(new Date())
+  );
+
+  return {
+    userId: todo.userId,
+    title: todo.title,
+    description: todo.description ?? null,
+    priority: todo.priority ?? 'medium',
+    dueDate: nextDueDate,
+    projectId: todo.projectId ?? null,
+    completed: false,
+    archived: false,
+    archivedAt: null,
+    reminderEnabled: todo.reminderEnabled ?? true,
+    reminderSentAt: null,
+    isRecurring: true,
+    recurrencePattern: todo.recurrencePattern,
+    recurrenceInterval: Number.isInteger(todo.recurrenceInterval) && todo.recurrenceInterval > 0
+      ? todo.recurrenceInterval
+      : 1,
+    recurrenceEndDate: todo.recurrenceEndDate ?? null,
+    originalTodoId: todo.originalTodoId ?? todo.id ?? null
+  };
+}
+
+module.exports = {
+  calculateNextDueDate,
+  shouldCreateNext,
+  createNextOccurrence
+};
+

--- a/backend/test/services/recurrenceService.test.js
+++ b/backend/test/services/recurrenceService.test.js
@@ -89,3 +89,17 @@ test('createNextOccurrence: 生成条件を満たさない場合は null', () =>
   assert.equal(createNextOccurrence(todo), null);
 });
 
+test('createNextOccurrence: 終了日を超える場合は null を返す', () => {
+  const todo = {
+    id: 40,
+    userId: 1,
+    title: '終了日超過',
+    isRecurring: true,
+    recurrencePattern: 'daily',
+    recurrenceInterval: 1,
+    dueDate: '2026-03-25',
+    recurrenceEndDate: '2026-03-25'
+  };
+  assert.equal(createNextOccurrence(todo), null);
+});
+

--- a/backend/test/services/recurrenceService.test.js
+++ b/backend/test/services/recurrenceService.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  calculateNextDueDate,
+  shouldCreateNext,
+  createNextOccurrence
+} = require('../../services/recurrenceService');
+
+test('calculateNextDueDate: daily/weekly/monthly を正しく計算する', () => {
+  assert.equal(calculateNextDueDate('daily', 1, '2026-03-25'), '2026-03-26');
+  assert.equal(calculateNextDueDate('weekly', 1, '2026-03-25'), '2026-04-01');
+  assert.equal(calculateNextDueDate('monthly', 1, '2026-01-31'), '2026-02-28');
+});
+
+test('calculateNextDueDate: interval > 1 を考慮する', () => {
+  assert.equal(calculateNextDueDate('daily', 3, '2026-03-25'), '2026-03-28');
+  assert.equal(calculateNextDueDate('weekly', 2, '2026-03-25'), '2026-04-08');
+  assert.equal(calculateNextDueDate('monthly', 2, '2026-01-31'), '2026-03-31');
+});
+
+test('calculateNextDueDate: 不正 pattern は例外を投げる', () => {
+  assert.throws(
+    () => calculateNextDueDate('yearly', 1, '2026-03-25'),
+    /不正な recurrencePattern/
+  );
+});
+
+test('shouldCreateNext: recurrenceEndDate を超える場合は false', () => {
+  const todo = {
+    id: 10,
+    isRecurring: true,
+    recurrencePattern: 'daily',
+    recurrenceInterval: 1,
+    dueDate: '2026-03-25',
+    recurrenceEndDate: '2026-03-25'
+  };
+  assert.equal(shouldCreateNext(todo), false);
+});
+
+test('shouldCreateNext: recurrenceEndDate 以内なら true', () => {
+  const todo = {
+    id: 11,
+    isRecurring: true,
+    recurrencePattern: 'weekly',
+    recurrenceInterval: 1,
+    dueDate: '2026-03-25',
+    recurrenceEndDate: '2026-04-10'
+  };
+  assert.equal(shouldCreateNext(todo), true);
+});
+
+test('createNextOccurrence: 次回 Todo 作成 payload を返す', () => {
+  const todo = {
+    id: 20,
+    userId: 7,
+    title: '定期タスク',
+    description: '毎日実行',
+    priority: 'high',
+    dueDate: '2026-03-25',
+    projectId: 3,
+    reminderEnabled: true,
+    isRecurring: true,
+    recurrencePattern: 'daily',
+    recurrenceInterval: 1,
+    recurrenceEndDate: '2026-12-31'
+  };
+
+  const next = createNextOccurrence(todo);
+
+  assert.equal(next.userId, 7);
+  assert.equal(next.title, '定期タスク');
+  assert.equal(next.completed, false);
+  assert.equal(next.archived, false);
+  assert.equal(next.reminderSentAt, null);
+  assert.equal(next.dueDate, '2026-03-26');
+  assert.equal(next.originalTodoId, 20);
+  assert.equal(next.isRecurring, true);
+});
+
+test('createNextOccurrence: 生成条件を満たさない場合は null', () => {
+  const todo = {
+    id: 30,
+    isRecurring: false,
+    recurrencePattern: 'daily',
+    recurrenceInterval: 1,
+    dueDate: '2026-03-25'
+  };
+  assert.equal(createNextOccurrence(todo), null);
+});
+

--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -52,10 +52,10 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.3: RecurrenceService 作成
 
-- [ ] 6.3.1: `backend/services/RecurrenceService.js` 作成
-- [ ] 6.3.2: `calculateNextDueDate(pattern, interval, currentDate)` 実装
-- [ ] 6.3.3: `createNextOccurrence(todo)` 実装
-- [ ] 6.3.4: `shouldCreateNext(todo)` 実装（終了日チェック）
+- [x] 6.3.1: `backend/services/RecurrenceService.js` 作成
+- [x] 6.3.2: `calculateNextDueDate(pattern, interval, currentDate)` 実装
+- [x] 6.3.3: `createNextOccurrence(todo)` 実装
+- [x] 6.3.4: `shouldCreateNext(todo)` 実装（終了日チェック）
 
 ### Task 6.4: TodoService に繰り返し機能追加
 
@@ -74,9 +74,9 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.7: Backend テスト
 
-- [ ] 6.7.1: RecurrenceService のテスト
-- [ ] 6.7.2: 次回 Todo 生成のテスト
-- [ ] 6.7.3: 繰り返し終了日のテスト
+- [x] 6.7.1: RecurrenceService のテスト
+- [x] 6.7.2: 次回 Todo 生成のテスト
+- [x] 6.7.3: 繰り返し終了日のテスト
 
 ---
 


### PR DESCRIPTION
## Summary
- Task 6.3 として `recurrenceService` を追加し、`calculateNextDueDate` / `shouldCreateNext` / `createNextOccurrence` を実装
- daily/weekly/monthly、interval、終了日境界、不正パターンを含むサービステストを追加
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.3 / 6.7 を完了済みに更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)