### PR TITLE
feat(backend): TodoControllerに繰り返し入力バリデーションを追加

### DIFF
--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -12,8 +12,72 @@ function parseTodoId(paramId) {
   return Number.isNaN(id) ? null : id;
 }
 
+function isDateOnly(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [yearText, monthText, dayText] = value.split('-');
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day
+  );
+}
+
+function validateRecurrencePayload(body, { requirePatternWhenRecurring = false } = {}) {
+  if (body == null || typeof body !== 'object') return null;
+
+  if (body.isRecurring !== undefined && typeof body.isRecurring !== 'boolean') {
+    return 'isRecurring must be boolean';
+  }
+
+  if (
+    body.recurrencePattern !== undefined &&
+    body.recurrencePattern !== null &&
+    !['daily', 'weekly', 'monthly'].includes(body.recurrencePattern)
+  ) {
+    return 'recurrencePattern must be one of daily, weekly, monthly';
+  }
+
+  if (
+    body.recurrenceInterval !== undefined &&
+    (!Number.isInteger(body.recurrenceInterval) || body.recurrenceInterval <= 0)
+  ) {
+    return 'recurrenceInterval must be a positive integer';
+  }
+
+  if (
+    body.recurrenceEndDate !== undefined &&
+    body.recurrenceEndDate !== null &&
+    !isDateOnly(body.recurrenceEndDate)
+  ) {
+    return 'recurrenceEndDate must be date format (YYYY-MM-DD)';
+  }
+
+  if (body.isRecurring === false) {
+    if (body.recurrencePattern !== undefined && body.recurrencePattern !== null) {
+      return 'recurrencePattern must be null when isRecurring is false';
+    }
+    if (body.recurrenceEndDate !== undefined && body.recurrenceEndDate !== null) {
+      return 'recurrenceEndDate must be null when isRecurring is false';
+    }
+  }
+
+  if (body.isRecurring === true && requirePatternWhenRecurring && body.recurrencePattern == null) {
+    return 'recurrencePattern is required when isRecurring is true';
+  }
+
+  return null;
+}
+
 async function createTodo(fastify, req, reply) {
   try {
+    const recurrenceError = validateRecurrencePayload(req.body, { requirePatternWhenRecurring: true });
+    if (recurrenceError) {
+      return reply.code(400).send({ error: recurrenceError });
+    }
     const userId = req.user.id;
     const todo = await todoService.createTodo(fastify, userId, req.body);
     reply.code(201).send(todo.toJSON());
@@ -125,6 +189,10 @@ async function updateTodo(fastify, req, reply) {
     const todoId = parseTodoId(req.params.id);
     if (todoId === null) {
       return reply.code(400).send({ error: 'Invalid todo id' });
+    }
+    const recurrenceError = validateRecurrencePayload(req.body);
+    if (recurrenceError) {
+      return reply.code(400).send({ error: recurrenceError });
     }
     const todo = await todoService.updateTodo(fastify, todoId, req.user.id, req.body);
     if (!todo) {

--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -60,6 +60,9 @@ function validateRecurrencePayload(body, { requirePatternWhenRecurring = false }
     if (body.recurrencePattern !== undefined && body.recurrencePattern !== null) {
       return 'recurrencePattern must be null when isRecurring is false';
     }
+    if (body.recurrenceInterval !== undefined && body.recurrenceInterval !== 1) {
+      return 'recurrenceInterval must be 1 when isRecurring is false';
+    }
     if (body.recurrenceEndDate !== undefined && body.recurrenceEndDate !== null) {
       return 'recurrenceEndDate must be null when isRecurring is false';
     }

--- a/backend/test/routes/todos.test.js
+++ b/backend/test/routes/todos.test.js
@@ -88,6 +88,87 @@ test('GET /api/v1/todos/search with empty q returns 400', async (t) => {
   assert.strictEqual(resMissing.statusCode, 400)
 })
 
+test('POST /api/v1/todos recurrence validation returns 400/201 as expected', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `recur-create-${suffix}`, email: `recur-create-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const cases = [
+    { payload: { title: 'ng1', isRecurring: 'true' }, status: 400 },
+    { payload: { title: 'ng2', isRecurring: true, recurrencePattern: 'yearly' }, status: 400 },
+    { payload: { title: 'ng3', isRecurring: true, recurrencePattern: 'daily', recurrenceInterval: 0 }, status: 400 },
+    { payload: { title: 'ng4', isRecurring: true, recurrencePattern: 'daily', recurrenceInterval: -1 }, status: 400 },
+    { payload: { title: 'ng5', isRecurring: true, recurrencePattern: 'daily', recurrenceInterval: 1.5 }, status: 400 },
+    { payload: { title: 'ng6', isRecurring: true, recurrencePattern: 'daily', recurrenceEndDate: '2026-13-01' }, status: 400 },
+    { payload: { title: 'ng7', isRecurring: true, recurrencePattern: 'daily', recurrenceEndDate: 'abc' }, status: 400 },
+    { payload: { title: 'ng8', isRecurring: false, recurrencePattern: 'daily' }, status: 400 },
+    { payload: { title: 'ng9', isRecurring: true }, status: 400 },
+    {
+      payload: {
+        title: 'ok1',
+        isRecurring: true,
+        recurrencePattern: 'weekly',
+        recurrenceInterval: 2,
+        recurrenceEndDate: '2026-12-31',
+      },
+      status: 201
+    },
+  ]
+
+  for (const c of cases) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/todos',
+      headers: { authorization: `Bearer ${token}` },
+      payload: c.payload
+    })
+    assert.strictEqual(res.statusCode, c.status)
+  }
+})
+
+test('PUT /api/v1/todos recurrence validation returns 400 as expected', async (t) => {
+  const app = await build(t)
+  const suffix = uniqueSuffix()
+  const user = { name: `recur-put-${suffix}`, email: `recur-put-${suffix}@test.local`, password: 'pass123' }
+  await app.inject({ method: 'POST', url: '/api/v1/register', payload: user })
+  const loginRes = await app.inject({ method: 'POST', url: '/api/v1/login', payload: { email: user.email, password: user.password } })
+  const token = JSON.parse(loginRes.payload).token
+
+  const created = await app.inject({
+    method: 'POST',
+    url: '/api/v1/todos',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { title: 'target todo' }
+  })
+  assert.strictEqual(created.statusCode, 201)
+  const todoId = JSON.parse(created.payload).id
+
+  const cases = [
+    { isRecurring: 'false' },
+    { recurrencePattern: 'yearly' },
+    { recurrenceInterval: 0 },
+    { recurrenceInterval: -1 },
+    { recurrenceInterval: 1.5 },
+    { recurrenceEndDate: '2026-13-01' },
+    { recurrenceEndDate: 'abc' },
+    { isRecurring: false, recurrencePattern: 'daily' },
+    { isRecurring: false, recurrenceInterval: 2 },
+  ]
+
+  for (const payload of cases) {
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/todos/${todoId}`,
+      headers: { authorization: `Bearer ${token}` },
+      payload
+    })
+    assert.strictEqual(res.statusCode, 400)
+  }
+})
+
 test('GET /api/v1/todos/search with auth returns matching todos', async (t) => {
   const app = await build(t)
   const suffix = uniqueSuffix()

--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -65,7 +65,7 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.5: TodoController 更新
 
-- [ ] 6.5.1: 繰り返しフィールドのバリデーション追加
+- [x] 6.5.1: 繰り返しフィールドのバリデーション追加
 
 ### Task 6.6: Todo ルート更新
 


### PR DESCRIPTION
## Summary
- Task 6.5.1 として `todoController` に繰り返しフィールド検証を追加
- `createTodo`/`updateTodo` で `isRecurring`、`recurrencePattern`、`recurrenceInterval`、`recurrenceEndDate` の形式/整合性を検証し、不正値は 400 応答
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.5.1 を完了済みに更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)