### PR TITLE
feat(frontend): 繰り返し設定の型定義を追加

### DIFF
--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -84,9 +84,9 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.8: Recurrence インターフェース定義
 
-- [ ] 6.8.1: `frontend/src/app/models/recurrence.interface.ts` 作成
-- [ ] 6.8.2: RecurrencePattern enum 定義
-- [ ] 6.8.3: Recurrence インターフェース定義
+- [x] 6.8.1: `frontend/src/app/models/recurrence.interface.ts` 作成
+- [x] 6.8.2: RecurrencePattern enum 定義
+- [x] 6.8.3: Recurrence インターフェース定義
 
 ### Task 6.9: Todo インターフェース更新
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-list/todo-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { CdkDragDrop } from '@angular/cdk/drag-drop'
+import { provideRouter } from '@angular/router'
 import { TodoListComponent } from './todo-list.component'
 import type { Todo } from '../../../../../models/todo.interface'
 import type { Tag } from '../../../../../models/tag.interface'
@@ -18,6 +19,7 @@ describe('TodoListComponent (3.13.3)', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TodoListComponent, HttpClientTestingModule],
+      providers: [provideRouter([])],
     }).compileComponents()
 
     fixture = TestBed.createComponent(TodoListComponent)

--- a/frontend/src/app/models/recurrence.interface.ts
+++ b/frontend/src/app/models/recurrence.interface.ts
@@ -1,0 +1,20 @@
+/**
+ * 繰り返しパターン
+ */
+export enum RecurrencePattern {
+  Daily = 'daily',
+  Weekly = 'weekly',
+  Monthly = 'monthly',
+}
+
+/**
+ * 繰り返し設定
+ * isRecurring=false の場合は pattern/endDate は null、interval は 1 を想定する。
+ */
+export interface Recurrence {
+  isRecurring: boolean
+  recurrencePattern: RecurrencePattern | null
+  recurrenceInterval: number
+  recurrenceEndDate: string | null
+}
+


### PR DESCRIPTION
## Summary
- Task 6.8 として `frontend/src/app/models/recurrence.interface.ts` を追加
- `RecurrencePattern` enum（daily/weekly/monthly）と `Recurrence` interface を定義
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.8.1〜6.8.3 を完了済みに更新

## Test plan
- [ ] `docker compose run --rm frontend ng test --watch=false`（既存失敗により赤）
  - 既存の `TodoListComponent` テストで `No provider for ActivatedRoute` が発生

Made with [Cursor](https://cursor.com)