### PR TITLE
feat(frontend): Todo型に繰り返しフィールドを追加

### DIFF
--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -90,7 +90,7 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.9: Todo インターフェース更新
 
-- [ ] 6.9.1: Todo インターフェースに繰り返しフィールド追加
+- [x] 6.9.1: Todo インターフェースに繰り返しフィールド追加
 
 ### Task 6.10: RecurrenceForm コンポーネント作成
 

--- a/frontend/src/app/models/todo.interface.ts
+++ b/frontend/src/app/models/todo.interface.ts
@@ -1,4 +1,5 @@
 import type { Project } from './project.interface'
+import type { Recurrence } from './recurrence.interface'
 import type { Tag } from './tag.interface'
 
 /**
@@ -32,6 +33,11 @@ export interface Todo {
   archivedAt: string | null
   reminderEnabled: boolean
   reminderSentAt: string | null
+  isRecurring?: Recurrence['isRecurring']
+  recurrencePattern?: Recurrence['recurrencePattern']
+  recurrenceInterval?: Recurrence['recurrenceInterval']
+  recurrenceEndDate?: Recurrence['recurrenceEndDate']
+  originalTodoId?: number | null
   createdAt: string
   updatedAt: string
   Tags?: Tag[]
@@ -51,6 +57,10 @@ export interface TodoCreateUpdate {
   priority?: TodoPriority
   dueDate?: string | null
   projectId?: number | null
+  isRecurring?: Recurrence['isRecurring']
+  recurrencePattern?: Recurrence['recurrencePattern']
+  recurrenceInterval?: Recurrence['recurrenceInterval']
+  recurrenceEndDate?: Recurrence['recurrenceEndDate']
 }
 
 /**


### PR DESCRIPTION
## Summary
- Task 6.9 として `todo.interface.ts` に繰り返し関連フィールドを追加
- `Todo` には互換性維持のため任意プロパティとして `isRecurring` / `recurrencePattern` / `recurrenceInterval` / `recurrenceEndDate` / `originalTodoId` を追加
- `TodoCreateUpdate` にも繰り返し設定項目を追加し、フォーム送信DTOで利用できるようにした
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.9.1 を完了済みに更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)