### PR TITLE
feat(frontend): RecurrenceFormコンポーネントを実装

### DIFF
--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -94,11 +94,11 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.10: RecurrenceForm コンポーネント作成
 
-- [ ] 6.10.1: `ng generate component components/recurrence-form` 実行
-- [ ] 6.10.2: 繰り返しパターン選択実装
-- [ ] 6.10.3: 繰り返し間隔入力実装
-- [ ] 6.10.4: 終了日入力実装
-- [ ] 6.10.5: @Output() recurrenceChanged 実装
+- [x] 6.10.1: `ng generate component components/recurrence-form` 実行
+- [x] 6.10.2: 繰り返しパターン選択実装
+- [x] 6.10.3: 繰り返し間隔入力実装
+- [x] 6.10.4: 終了日入力実装
+- [x] 6.10.5: @Output() recurrenceChanged 実装
 
 ### Task 6.11: TodoForm に繰り返し設定追加
 

--- a/frontend/src/app/components/recurrence-form/recurrence-form.component.html
+++ b/frontend/src/app/components/recurrence-form/recurrence-form.component.html
@@ -1,0 +1,45 @@
+<div class="recurrence-form" [formGroup]="form">
+  <div class="form-check form-switch mb-2">
+    <input
+      id="recurrence-enabled"
+      class="form-check-input"
+      type="checkbox"
+      formControlName="isRecurring"
+    />
+    <label class="form-check-label" for="recurrence-enabled">繰り返しを有効化</label>
+  </div>
+
+  @if (form.get('isRecurring')?.value === true) {
+    <div class="row g-2">
+      <div class="col-md-4">
+        <label for="recurrence-pattern" class="form-label">繰り返しパターン</label>
+        <select id="recurrence-pattern" class="form-select" formControlName="recurrencePattern">
+          @for (p of patterns; track p.value) {
+            <option [ngValue]="p.value">{{ p.label }}</option>
+          }
+        </select>
+      </div>
+
+      <div class="col-md-4">
+        <label for="recurrence-interval" class="form-label">間隔</label>
+        <input
+          id="recurrence-interval"
+          type="number"
+          class="form-control"
+          min="1"
+          formControlName="recurrenceInterval"
+        />
+      </div>
+
+      <div class="col-md-4">
+        <label for="recurrence-end-date" class="form-label">終了日（任意）</label>
+        <input
+          id="recurrence-end-date"
+          type="date"
+          class="form-control"
+          formControlName="recurrenceEndDate"
+        />
+      </div>
+    </div>
+  }
+</div>

--- a/frontend/src/app/components/recurrence-form/recurrence-form.component.spec.ts
+++ b/frontend/src/app/components/recurrence-form/recurrence-form.component.spec.ts
@@ -72,4 +72,22 @@ describe('RecurrenceFormComponent', () => {
       recurrenceEndDate: null
     })
   })
+
+  it('should initialize daily pattern when enabled with null pattern', () => {
+    const emitted: unknown[] = []
+    component.recurrenceChanged.subscribe((v) => emitted.push(v))
+
+    component.form.patchValue({
+      isRecurring: true,
+      recurrencePattern: null
+    })
+
+    const last = emitted[emitted.length - 1] as {
+      isRecurring: boolean
+      recurrencePattern: string | null
+    }
+    expect(last.isRecurring).toBe(true)
+    expect(last.recurrencePattern).toBe('daily')
+    expect(component.form.get('recurrencePattern')?.value).toBe(RecurrencePattern.Daily)
+  })
 })

--- a/frontend/src/app/components/recurrence-form/recurrence-form.component.spec.ts
+++ b/frontend/src/app/components/recurrence-form/recurrence-form.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { RecurrencePattern } from '../../models/recurrence.interface'
+
+import { RecurrenceFormComponent } from './recurrence-form.component'
+
+describe('RecurrenceFormComponent', () => {
+  let component: RecurrenceFormComponent
+  let fixture: ComponentFixture<RecurrenceFormComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RecurrenceFormComponent]
+    })
+    .compileComponents()
+
+    fixture = TestBed.createComponent(RecurrenceFormComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should emit normalized recurrence when enabled', () => {
+    const emitted: unknown[] = []
+    component.recurrenceChanged.subscribe((v) => emitted.push(v))
+
+    component.form.patchValue({
+      isRecurring: true,
+      recurrencePattern: RecurrencePattern.Weekly,
+      recurrenceInterval: 2,
+      recurrenceEndDate: '2026-12-31'
+    })
+
+    expect(emitted.length).toBeGreaterThan(0)
+    const last = emitted[emitted.length - 1] as {
+      isRecurring: boolean
+      recurrencePattern: string | null
+      recurrenceInterval: number
+      recurrenceEndDate: string | null
+    }
+    expect(last).toEqual({
+      isRecurring: true,
+      recurrencePattern: 'weekly',
+      recurrenceInterval: 2,
+      recurrenceEndDate: '2026-12-31'
+    })
+  })
+
+  it('should emit cleared recurrence when disabled', () => {
+    const emitted: unknown[] = []
+    component.recurrenceChanged.subscribe((v) => emitted.push(v))
+
+    component.form.patchValue({
+      isRecurring: false,
+      recurrencePattern: RecurrencePattern.Monthly,
+      recurrenceInterval: 3,
+      recurrenceEndDate: '2026-12-31'
+    })
+
+    const last = emitted[emitted.length - 1] as {
+      isRecurring: boolean
+      recurrencePattern: string | null
+      recurrenceInterval: number
+      recurrenceEndDate: string | null
+    }
+    expect(last).toEqual({
+      isRecurring: false,
+      recurrencePattern: null,
+      recurrenceInterval: 1,
+      recurrenceEndDate: null
+    })
+  })
+})

--- a/frontend/src/app/components/recurrence-form/recurrence-form.component.ts
+++ b/frontend/src/app/components/recurrence-form/recurrence-form.component.ts
@@ -1,0 +1,65 @@
+import { CommonModule } from '@angular/common'
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core'
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms'
+import { RecurrencePattern, type Recurrence } from '../../models/recurrence.interface'
+
+@Component({
+  selector: 'app-recurrence-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './recurrence-form.component.html',
+  styleUrl: './recurrence-form.component.scss'
+})
+export class RecurrenceFormComponent implements OnChanges {
+  @Input() value: Recurrence = {
+    isRecurring: false,
+    recurrencePattern: null,
+    recurrenceInterval: 1,
+    recurrenceEndDate: null
+  }
+  @Output() recurrenceChanged = new EventEmitter<Recurrence>()
+
+  readonly patterns = [
+    { value: RecurrencePattern.Daily, label: '毎日' },
+    { value: RecurrencePattern.Weekly, label: '毎週' },
+    { value: RecurrencePattern.Monthly, label: '毎月' },
+  ]
+
+  readonly form = this.fb.group({
+    isRecurring: [false],
+    recurrencePattern: [null as RecurrencePattern | null],
+    recurrenceInterval: [1],
+    recurrenceEndDate: ['']
+  })
+
+  constructor(private fb: FormBuilder) {
+    this.form.valueChanges.subscribe(() => {
+      this.emitCurrentValue()
+    })
+  }
+
+  ngOnChanges(): void {
+    this.form.patchValue({
+      isRecurring: this.value?.isRecurring ?? false,
+      recurrencePattern: this.value?.recurrencePattern ?? null,
+      recurrenceInterval: this.value?.recurrenceInterval ?? 1,
+      recurrenceEndDate: this.value?.recurrenceEndDate ?? ''
+    }, { emitEvent: false })
+  }
+
+  private emitCurrentValue(): void {
+    const raw = this.form.getRawValue()
+    const recurring = raw.isRecurring === true
+
+    this.recurrenceChanged.emit({
+      isRecurring: recurring,
+      recurrencePattern: recurring ? (raw.recurrencePattern ?? RecurrencePattern.Daily) : null,
+      recurrenceInterval: recurring
+        ? Math.max(1, Number(raw.recurrenceInterval ?? 1))
+        : 1,
+      recurrenceEndDate: recurring
+        ? (raw.recurrenceEndDate?.trim() || null)
+        : null
+    })
+  }
+}

--- a/frontend/src/app/components/recurrence-form/recurrence-form.component.ts
+++ b/frontend/src/app/components/recurrence-form/recurrence-form.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common'
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core'
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output } from '@angular/core'
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms'
+import { Subject, takeUntil } from 'rxjs'
 import { RecurrencePattern, type Recurrence } from '../../models/recurrence.interface'
 
 @Component({
@@ -10,7 +11,8 @@ import { RecurrencePattern, type Recurrence } from '../../models/recurrence.inte
   templateUrl: './recurrence-form.component.html',
   styleUrl: './recurrence-form.component.scss'
 })
-export class RecurrenceFormComponent implements OnChanges {
+export class RecurrenceFormComponent implements OnChanges, OnDestroy {
+  private readonly destroy$ = new Subject<void>()
   @Input() value: Recurrence = {
     isRecurring: false,
     recurrencePattern: null,
@@ -33,9 +35,11 @@ export class RecurrenceFormComponent implements OnChanges {
   })
 
   constructor(private fb: FormBuilder) {
-    this.form.valueChanges.subscribe(() => {
-      this.emitCurrentValue()
-    })
+    this.form.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.emitCurrentValue()
+      })
   }
 
   ngOnChanges(): void {
@@ -51,15 +55,25 @@ export class RecurrenceFormComponent implements OnChanges {
     const raw = this.form.getRawValue()
     const recurring = raw.isRecurring === true
 
+    if (recurring && !raw.recurrencePattern) {
+      this.form.patchValue({ recurrencePattern: RecurrencePattern.Daily }, { emitEvent: false })
+    }
+    const patchedRaw = this.form.getRawValue()
+
     this.recurrenceChanged.emit({
       isRecurring: recurring,
-      recurrencePattern: recurring ? (raw.recurrencePattern ?? RecurrencePattern.Daily) : null,
+      recurrencePattern: recurring ? (patchedRaw.recurrencePattern ?? RecurrencePattern.Daily) : null,
       recurrenceInterval: recurring
-        ? Math.max(1, Number(raw.recurrenceInterval ?? 1))
+        ? Math.max(1, Number(patchedRaw.recurrenceInterval ?? 1))
         : 1,
       recurrenceEndDate: recurring
-        ? (raw.recurrenceEndDate?.trim() || null)
+        ? (patchedRaw.recurrenceEndDate?.trim() || null)
         : null
     })
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
   }
 }


### PR DESCRIPTION
## Summary
- Task 6.10 として `ng generate component components/recurrence-form` を実行し、standalone コンポーネントを追加
- 繰り返し有効化トグル、パターン選択、間隔入力、終了日入力を実装
- `@Output() recurrenceChanged` で親へ正規化済み `Recurrence` を通知するよう実装
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.10.1〜6.10.5 を完了済みに更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)