### PR TITLE
feat(frontend): 繰り返しTodo一覧ページを追加

### DIFF
--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -113,9 +113,9 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.13: RecurringTodoList ページ作成
 
-- [ ] 6.13.1: `ng generate component pages/recurring-todo-list-page` 実行
-- [ ] 6.13.2: 繰り返しタスク一覧表示
-- [ ] 6.13.3: ルーティング追加
+- [x] 6.13.1: `ng generate component pages/recurring-todo-list-page` 実行
+- [x] 6.13.2: 繰り返しタスク一覧表示
+- [x] 6.13.3: ルーティング追加
 
 ### Task 6.14: スタイリング
 

--- a/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/components/pages/dashboard/dashboard-routing.module.ts
@@ -15,6 +15,10 @@ export const DASHBOARD_ROUTES: Routes = [
         loadComponent: () => import('./todo/todo-page/todo-page.component')
       },
       {
+        path: 'todos/recurring',
+        loadComponent: () => import('./recurring-todo-list-page/recurring-todo-list-page.component')
+      },
+      {
         path: 'todos/:id',
         loadComponent: () => import('./todo/todo-detail-page/todo-detail-page.component')
       },

--- a/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.html
@@ -10,9 +10,13 @@
         [dragDisabled]="true"
         [selectedIds]="[]"
         (toggle)="onToggle($event)"
+        (edit)="onEdit($event)"
         (delete)="onDelete($event)"
         (archive)="onArchive($event)"
+        (share)="onShare($event)"
         (reminderToggled)="onReminderToggled($event)"
+        (tagRemoved)="onTagRemoved($event)"
+        (tagAdded)="onTagAdded($event)"
       />
     </app-card>
   </div>

--- a/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.html
@@ -1,0 +1,19 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="繰り返し Todo 一覧（{{ todos.length }} 件）">
+      <p class="text-muted small mb-3">繰り返し設定が有効な Todo のみ表示します。</p>
+
+      <app-todo-list
+        [todos]="todos"
+        [loading]="loading"
+        [error]="error"
+        [dragDisabled]="true"
+        [selectedIds]="[]"
+        (toggle)="onToggle($event)"
+        (delete)="onDelete($event)"
+        (archive)="onArchive($event)"
+        (reminderToggled)="onReminderToggled($event)"
+      />
+    </app-card>
+  </div>
+</div>

--- a/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.spec.ts
@@ -2,6 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { provideNoopAnimations } from '@angular/platform-browser/animations'
 import { of } from 'rxjs'
 import { TodoService } from '../../../../services/todo.service'
+import { ShareService } from '../../../../services/share.service'
+import { MatDialog } from '@angular/material/dialog'
+import { Router } from '@angular/router'
 import type { Todo } from '../../../../models/todo.interface'
 
 import RecurringTodoListPageComponent from './recurring-todo-list-page.component'
@@ -10,17 +13,35 @@ describe('RecurringTodoListPageComponent', () => {
   let component: RecurringTodoListPageComponent
   let fixture: ComponentFixture<RecurringTodoListPageComponent>
   let todoService: jasmine.SpyObj<TodoService>
+  let shareService: jasmine.SpyObj<ShareService>
+  let router: jasmine.SpyObj<Router>
 
   beforeEach(async () => {
     const spy = jasmine.createSpyObj('TodoService', ['list', 'toggleComplete', 'archiveTodo', 'delete', 'toggleReminder'])
+    const shareSpy = jasmine.createSpyObj('ShareService', ['shareTodo'])
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate'])
+    const dialogSpy = jasmine.createSpyObj('MatDialog', ['open'])
     spy.list.and.returnValue(of([]))
+    shareSpy.shareTodo.and.returnValue(of(undefined))
+    routerSpy.navigate.and.resolveTo(true)
+    dialogSpy.open.and.returnValue({
+      afterClosed: () => of(undefined)
+    })
     await TestBed.configureTestingModule({
       imports: [RecurringTodoListPageComponent],
-      providers: [{ provide: TodoService, useValue: spy }, provideNoopAnimations()]
+      providers: [
+        { provide: TodoService, useValue: spy },
+        { provide: ShareService, useValue: shareSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: MatDialog, useValue: dialogSpy },
+        provideNoopAnimations()
+      ]
     })
     .compileComponents()
 
     todoService = TestBed.inject(TodoService) as jasmine.SpyObj<TodoService>
+    shareService = TestBed.inject(ShareService) as jasmine.SpyObj<ShareService>
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>
     fixture = TestBed.createComponent(RecurringTodoListPageComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
@@ -39,5 +60,20 @@ describe('RecurringTodoListPageComponent', () => {
     component.loadRecurringTodos()
     expect(component.todos.length).toBe(1)
     expect(component.todos[0].id).toBe(1)
+  })
+
+  it('should navigate to todo detail on edit', () => {
+    component.onEdit({ id: 10 } as Todo)
+    expect(router.navigate).toHaveBeenCalledWith(['/dashboard/todos', 10])
+  })
+
+  it('should call share service when dialog returns result', () => {
+    const dialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>
+    dialog.open.and.returnValue({
+      afterClosed: () => of({ sharedWithUserId: 2, permission: 'view' })
+    } as never)
+
+    component.onShare(11)
+    expect(shareService.shareTodo).toHaveBeenCalledWith(11, 2, 'view')
   })
 })

--- a/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { provideNoopAnimations } from '@angular/platform-browser/animations'
+import { of } from 'rxjs'
+import { TodoService } from '../../../../services/todo.service'
+import type { Todo } from '../../../../models/todo.interface'
+
+import RecurringTodoListPageComponent from './recurring-todo-list-page.component'
+
+describe('RecurringTodoListPageComponent', () => {
+  let component: RecurringTodoListPageComponent
+  let fixture: ComponentFixture<RecurringTodoListPageComponent>
+  let todoService: jasmine.SpyObj<TodoService>
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('TodoService', ['list', 'toggleComplete', 'archiveTodo', 'delete', 'toggleReminder'])
+    spy.list.and.returnValue(of([]))
+    await TestBed.configureTestingModule({
+      imports: [RecurringTodoListPageComponent],
+      providers: [{ provide: TodoService, useValue: spy }, provideNoopAnimations()]
+    })
+    .compileComponents()
+
+    todoService = TestBed.inject(TodoService) as jasmine.SpyObj<TodoService>
+    fixture = TestBed.createComponent(RecurringTodoListPageComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should filter and display recurring todos only', () => {
+    const list: Todo[] = [
+      { id: 1, userId: 1, title: 'A', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 0, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: '', updatedAt: '', isRecurring: true, recurrencePattern: null, recurrenceInterval: 1, recurrenceEndDate: null },
+      { id: 2, userId: 1, title: 'B', description: null, completed: false, priority: 'medium', dueDate: null, sortOrder: 1, projectId: null, archived: false, archivedAt: null, reminderEnabled: true, reminderSentAt: null, createdAt: '', updatedAt: '', isRecurring: false, recurrencePattern: null, recurrenceInterval: 1, recurrenceEndDate: null }
+    ]
+    todoService.list.and.returnValue(of(list))
+    component.loadRecurringTodos()
+    expect(component.todos.length).toBe(1)
+    expect(component.todos[0].id).toBe(1)
+  })
+})

--- a/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Subject, takeUntil } from 'rxjs'
+import { TodoService } from '../../../../services/todo.service'
+import { TodoListComponent } from '../todo/todo-list/todo-list.component'
+import { CardComponent } from '../../../../theme/shared/components/card/card.component'
+import type { ReminderToggleEvent } from '../todo/todo-item/todo-item.component'
+import type { Todo } from '../../../../models/todo.interface'
+
+@Component({
+  selector: 'app-recurring-todo-list-page',
+  standalone: true,
+  imports: [CommonModule, CardComponent, TodoListComponent],
+  templateUrl: './recurring-todo-list-page.component.html',
+  styleUrl: './recurring-todo-list-page.component.scss'
+})
+export default class RecurringTodoListPageComponent implements OnInit, OnDestroy {
+  todos: Todo[] = []
+  loading = false
+  error: string | null = null
+
+  private readonly destroy$ = new Subject<void>()
+
+  constructor(private todoService: TodoService) {}
+
+  ngOnInit(): void {
+    this.loadRecurringTodos()
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  loadRecurringTodos(): void {
+    this.loading = true
+    this.error = null
+    this.todoService
+      .list()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (list) => {
+          this.todos = list.filter((todo) => todo.isRecurring === true)
+          this.loading = false
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '取得に失敗しました'
+          this.loading = false
+        }
+      })
+  }
+
+  onToggle(id: number): void {
+    this.todoService
+      .toggleComplete(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadRecurringTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '更新に失敗しました'
+        }
+      })
+  }
+
+  onArchive(id: number): void {
+    this.todoService
+      .archiveTodo(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadRecurringTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'アーカイブに失敗しました'
+        }
+      })
+  }
+
+  onDelete(id: number): void {
+    if (!confirm('この Todo を削除しますか？')) return
+    this.todoService
+      .delete(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadRecurringTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '削除に失敗しました'
+        }
+      })
+  }
+
+  onReminderToggled(event: ReminderToggleEvent): void {
+    this.todoService
+      .toggleReminder(event.todoId, event.enabled)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (updated) => {
+          this.todos = this.todos.map((todo) => (todo.id === updated.id ? updated : todo))
+        },
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? '更新に失敗しました'
+        }
+      })
+  }
+}

--- a/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/recurring-todo-list-page/recurring-todo-list-page.component.ts
@@ -1,11 +1,17 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { Subject, takeUntil } from 'rxjs'
+import { MatDialog } from '@angular/material/dialog'
+import { Router } from '@angular/router'
 import { TodoService } from '../../../../services/todo.service'
+import { ShareService } from '../../../../services/share.service'
 import { TodoListComponent } from '../todo/todo-list/todo-list.component'
 import { CardComponent } from '../../../../theme/shared/components/card/card.component'
 import type { ReminderToggleEvent } from '../todo/todo-item/todo-item.component'
 import type { Todo } from '../../../../models/todo.interface'
+import type { Tag } from '../../../../models/tag.interface'
+import type { SharePermission } from '../../../../models/share.interface'
+import { ShareDialogComponent } from '../todo/share-dialog/share-dialog.component'
 
 @Component({
   selector: 'app-recurring-todo-list-page',
@@ -21,7 +27,12 @@ export default class RecurringTodoListPageComponent implements OnInit, OnDestroy
 
   private readonly destroy$ = new Subject<void>()
 
-  constructor(private todoService: TodoService) {}
+  constructor(
+    private todoService: TodoService,
+    private shareService: ShareService,
+    private dialog: MatDialog,
+    private router: Router
+  ) {}
 
   ngOnInit(): void {
     this.loadRecurringTodos()
@@ -97,6 +108,57 @@ export default class RecurringTodoListPageComponent implements OnInit, OnDestroy
         },
         error: (err) => {
           this.error = err?.error?.message ?? err?.message ?? '更新に失敗しました'
+        }
+      })
+  }
+
+  onEdit(todo: Todo): void {
+    void this.router.navigate(['/dashboard/todos', todo.id])
+  }
+
+  onShare(todoId: number): void {
+    const ref = this.dialog.open(ShareDialogComponent, {
+      width: '420px',
+      data: { todoId }
+    })
+
+    type ShareDialogResult = { sharedWithUserId: number; permission: SharePermission }
+
+    ref.afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((result: ShareDialogResult | undefined) => {
+        if (!result) return
+        this.shareService.shareTodo(todoId, result.sharedWithUserId, result.permission)
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: () => {},
+            error: (err) => {
+              this.error = err?.error?.message ?? err?.message ?? '共有に失敗しました'
+            }
+          })
+      })
+  }
+
+  onTagRemoved(event: { todoId: number; tag: Tag }): void {
+    this.todoService
+      .removeTagFromTodo(event.todoId, event.tag.id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadRecurringTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'タグの削除に失敗しました'
+        }
+      })
+  }
+
+  onTagAdded(event: { todoId: number; tagId: number }): void {
+    this.todoService
+      .addTagToTodo(event.todoId, event.tagId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.loadRecurringTodos(),
+        error: (err) => {
+          this.error = err?.error?.message ?? err?.message ?? 'タグの追加に失敗しました'
         }
       })
   }

--- a/frontend/src/app/theme/layout/admin/navigation/navigation.ts
+++ b/frontend/src/app/theme/layout/admin/navigation/navigation.ts
@@ -45,6 +45,14 @@ const NavigationItems = [
         classes: 'nav-item'
       },
       {
+        id: 'recurring-todos',
+        title: '繰り返しTodo',
+        type: 'item',
+        url: '/dashboard/todos/recurring',
+        icon: 'feather icon-refresh-cw',
+        classes: 'nav-item'
+      },
+      {
         id: 'calendar',
         title: 'カレンダー',
         type: 'item',


### PR DESCRIPTION
## Summary
- Task 6.13 として `recurring-todo-list-page` を追加（ng generate 実行済み）
- Todo 一覧取得結果から `isRecurring === true` のみ表示する専用ページを実装
- `/dashboard/todos/recurring` ルートを追加し、サイドナビに「繰り返しTodo」を追加
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.13.1〜6.13.3 を完了済みに更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)