### PR TITLE
test(frontend): 繰り返しUIのテストケースを拡充

### DIFF
--- a/docs/TODO_FEATURE_06_RECURRING.md
+++ b/docs/TODO_FEATURE_06_RECURRING.md
@@ -124,8 +124,8 @@ PATCH /api/todos/:id/complete (繰り返しタスクの場合、次回生成)
 
 ### Task 6.15: Frontend テスト
 
-- [ ] 6.15.1: RecurrenceForm コンポーネントテスト
-- [ ] 6.15.2: 繰り返しタスク表示のテスト
+- [x] 6.15.1: RecurrenceForm コンポーネントテスト
+- [x] 6.15.2: 繰り返しタスク表示のテスト
 
 ---
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-item/todo-item.component.spec.ts
@@ -157,5 +157,24 @@ describe('TodoItemComponent (2.12.2)', () => {
     expect(component.recurrenceTooltip).toBe('毎週 / 2 回ごと（終了日: 2026-12-31）')
   })
 
+  it('should return empty recurrence tooltip for non-recurring todo', () => {
+    component.todo = {
+      ...mockTodo,
+      isRecurring: false
+    }
+    expect(component.recurrenceTooltip).toBe('')
+  })
+
+  it('should fallback recurrence tooltip when pattern is null', () => {
+    component.todo = {
+      ...mockTodo,
+      isRecurring: true,
+      recurrencePattern: null,
+      recurrenceInterval: 1,
+      recurrenceEndDate: null
+    }
+    expect(component.recurrenceTooltip).toBe('繰り返し / 1 回ごと')
+  })
+
 })
 

--- a/frontend/src/app/components/recurrence-form/recurrence-form.component.spec.ts
+++ b/frontend/src/app/components/recurrence-form/recurrence-form.component.spec.ts
@@ -90,4 +90,19 @@ describe('RecurrenceFormComponent', () => {
     expect(last.recurrencePattern).toBe('daily')
     expect(component.form.get('recurrencePattern')?.value).toBe(RecurrencePattern.Daily)
   })
+
+  it('should reflect @Input value on ngOnChanges', () => {
+    component.value = {
+      isRecurring: true,
+      recurrencePattern: RecurrencePattern.Monthly,
+      recurrenceInterval: 3,
+      recurrenceEndDate: '2026-06-30'
+    }
+    component.ngOnChanges()
+
+    expect(component.form.get('isRecurring')?.value).toBe(true)
+    expect(component.form.get('recurrencePattern')?.value).toBe(RecurrencePattern.Monthly)
+    expect(component.form.get('recurrenceInterval')?.value).toBe(3)
+    expect(component.form.get('recurrenceEndDate')?.value).toBe('2026-06-30')
+  })
 })


### PR DESCRIPTION
## Summary
- Task 6.15.1: `RecurrenceFormComponent` に `@Input` 値の `ngOnChanges` 反映テストを追加
- Task 6.15.2: `TodoItemComponent` に繰り返しツールチップの非繰り返し/null pattern ケースを追加
- `docs/TODO_FEATURE_06_RECURRING.md` の 6.15.1〜6.15.2 を完了済みに更新

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false`

Made with [Cursor](https://cursor.com)