### PR TITLE
feat(backend): Attachmentモデルとattachmentsテーブルを追加

### DIFF
--- a/backend/migrations/20260327080000-create-attachments.js
+++ b/backend/migrations/20260327080000-create-attachments.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('attachments', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      todo_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      file_name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      file_size: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      mime_type: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      file_url: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+
+    await queryInterface.addIndex('attachments', ['todo_id']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('attachments');
+  },
+};
+

--- a/backend/models/attachment.js
+++ b/backend/models/attachment.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { DataTypes } = require('sequelize');
+
+/**
+ * Todo に紐づく添付ファイル（機能8）。
+ * 実ファイルの格納先は fileUrl で抽象化し、ローカル/S3 切替に備える。
+ */
+module.exports = (sequelize) => {
+  const Attachment = sequelize.define(
+    'Attachment',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      todoId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'todo_id',
+        references: { model: 'todos', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      fileName: {
+        type: DataTypes.STRING(255),
+        allowNull: false,
+        field: 'file_name',
+      },
+      fileSize: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'file_size',
+      },
+      mimeType: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
+        field: 'mime_type',
+      },
+      fileUrl: {
+        type: DataTypes.STRING(500),
+        allowNull: false,
+        field: 'file_url',
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at',
+      },
+    },
+    {
+      tableName: 'attachments',
+      underscored: true,
+      timestamps: true,
+      updatedAt: false,
+    }
+  );
+
+  Attachment.associate = function (models) {
+    Attachment.belongsTo(models.Todo, { foreignKey: 'todoId' });
+  };
+
+  return Attachment;
+};
+

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -9,6 +9,7 @@ const Project = require('./project')
 const TodoTemplate = require('./todoTemplate')
 const TodoShare = require('./todoShare')
 const Comment = require('./comment')
+const Attachment = require('./attachment')
 
 module.exports = fp(async function (fastify, opts) {
   const sequelize = fastify.sequelize
@@ -22,6 +23,7 @@ module.exports = fp(async function (fastify, opts) {
     TodoTemplate: TodoTemplate(sequelize),
     TodoShare: TodoShare(sequelize),
     Comment: Comment(sequelize),
+    Attachment: Attachment(sequelize),
   }
 
   Object.keys(models).forEach((name) => {

--- a/backend/models/todo.js
+++ b/backend/models/todo.js
@@ -203,6 +203,7 @@ module.exports = (sequelize) => {
     });
     Todo.hasMany(models.TodoShare, { foreignKey: 'todoId' });
     Todo.hasMany(models.Comment, { foreignKey: 'todoId' });
+    Todo.hasMany(models.Attachment, { foreignKey: 'todoId' });
   };
 
   return Todo;

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -38,14 +38,14 @@ DELETE /api/attachments/:id
 
 ### Task 8.1: Attachment モデル作成
 
-- [ ] 8.1.1: マイグレーション生成 `create-attachments`
-- [ ] 8.1.2: attachments テーブル定義
-- [ ] 8.1.3: インデックス追加（todoId）
-- [ ] 8.1.4: 外部キー制約追加
-- [ ] 8.1.5: `backend/models/Attachment.js` 作成
-- [ ] 8.1.6: Attachment モデル定義
-- [ ] 8.1.7: Todo との関連付け
-- [ ] 8.1.8: マイグレーション実行
+- [x] 8.1.1: マイグレーション生成 `create-attachments`
+- [x] 8.1.2: attachments テーブル定義
+- [x] 8.1.3: インデックス追加（todoId）
+- [x] 8.1.4: 外部キー制約追加
+- [x] 8.1.5: `backend/models/Attachment.js` 作成
+- [x] 8.1.6: Attachment モデル定義
+- [x] 8.1.7: Todo との関連付け
+- [x] 8.1.8: マイグレーション実行
 
 ### Task 8.2: ファイルアップロード設定
 


### PR DESCRIPTION
## Summary
- Task 8.1 として `attachments` テーブル作成マイグレーションを追加（todo_id FK・index 含む）
- `backend/models/attachment.js` を追加し、fileName/fileSize/mimeType/fileUrl を定義
- `models/index.js` と `Todo` モデルの association を更新し、Todo-attachment 関連を有効化
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の 8.1.1〜8.1.8 を完了済みに更新

## Test plan
- [x] `docker compose run --rm backend npx sequelize-cli db:migrate`
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)