### PR TITLE
feat(backend): Task 8.2 multipartアップロード設定を追加

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,7 +29,7 @@
     },
     "node_modules/@fastify/accept-negotiator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
       "integrity": "sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==",
       "license": "MIT",
       "engines": {
@@ -55,7 +55,7 @@
     },
     "node_modules/@fastify/busboy": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/@fastify/busboy/-/busboy-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.2.1.tgz",
       "integrity": "sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==",
       "license": "MIT",
       "dependencies": {
@@ -107,7 +107,7 @@
     },
     "node_modules/@fastify/multipart": {
       "version": "7.7.3",
-      "resolved": "https://registry.npmmirror.com/@fastify/multipart/-/multipart-7.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-7.7.3.tgz",
       "integrity": "sha512-MG4Gd9FNEXc8qx0OgqoXM10EGO/dN/0iVQ8SrpFMU3d6F6KUfcqD2ZyoQhkm9LWrbiMgdHv5a43x78lASdn5GA==",
       "license": "MIT",
       "dependencies": {
@@ -124,7 +124,7 @@
     },
     "node_modules/@fastify/send": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/@fastify/send/-/send-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-2.1.0.tgz",
       "integrity": "sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==",
       "license": "MIT",
       "dependencies": {
@@ -152,7 +152,7 @@
     },
     "node_modules/@fastify/static": {
       "version": "6.12.0",
-      "resolved": "https://registry.npmmirror.com/@fastify/static/-/static-6.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-6.12.0.tgz",
       "integrity": "sha512-KK1B84E6QD/FcQWxDI2aiUCwHxMJBI1KeCUzm1BwYpPY1b742+jeKruGHP2uOluuM6OkBPI8CIANrXcCRtC2oQ==",
       "license": "MIT",
       "dependencies": {
@@ -166,7 +166,7 @@
     },
     "node_modules/@fastify/static/node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "license": "MIT",
       "dependencies": {
@@ -181,7 +181,7 @@
     },
     "node_modules/@fastify/swagger": {
       "version": "8.15.0",
-      "resolved": "https://registry.npmmirror.com/@fastify/swagger/-/swagger-8.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-8.15.0.tgz",
       "integrity": "sha512-zy+HEEKFqPMS2sFUsQU5X0MHplhKJvWeohBwTCkBAJA/GDYGLGUWQaETEhptiqxK7Hs0fQB9B4MDb3pbwIiCwA==",
       "license": "MIT",
       "dependencies": {
@@ -194,7 +194,7 @@
     },
     "node_modules/@fastify/swagger-ui": {
       "version": "1.10.2",
-      "resolved": "https://registry.npmmirror.com/@fastify/swagger-ui/-/swagger-ui-1.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-1.10.2.tgz",
       "integrity": "sha512-f2mRqtblm6eRAFQ3e8zSngxVNEtiYY7rISKQVjPA++ZsWc5WYlPVTb6Bx0G/zy0BIoucNqDr/Q2Vb/kTYkOq1A==",
       "license": "MIT",
       "dependencies": {
@@ -848,7 +848,7 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
       "dependencies": {
@@ -1107,7 +1107,7 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
@@ -1928,7 +1928,7 @@
     },
     "node_modules/json-schema-resolver": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/json-schema-resolver/-/json-schema-resolver-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-2.0.0.tgz",
       "integrity": "sha512-pJ4XLQP4Q9HTxl6RVDLJ8Cyh1uitSs0CzDBAz1uoJ4sRD/Bk7cFSXL1FUXDW3zJ7YnfliJx6eu8Jn283bpZ4Yg==",
       "license": "MIT",
       "dependencies": {
@@ -2166,7 +2166,7 @@
     },
     "node_modules/mime": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/mime/-/mime-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "license": "MIT",
       "bin": {
@@ -2519,7 +2519,7 @@
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
-      "resolved": "https://registry.npmmirror.com/openapi-types/-/openapi-types-12.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "license": "MIT"
     },
@@ -2818,7 +2818,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
       "engines": {
@@ -3267,7 +3267,7 @@
     },
     "node_modules/stream-wormhole": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/stream-wormhole/-/stream-wormhole-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-wormhole/-/stream-wormhole-1.1.0.tgz",
       "integrity": "sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==",
       "license": "MIT",
       "engines": {
@@ -3404,7 +3404,7 @@
     },
     "node_modules/text-decoding": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/text-decoding/-/text-decoding-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
       "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
       "license": "MIT"
     },
@@ -3545,7 +3545,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3705,7 +3705,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
@@ -3758,7 +3758,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "license": "MIT",
       "engines": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fastify/autoload": "^5.0.0",
         "@fastify/cors": "^9.0.1",
+        "@fastify/multipart": "^7.7.3",
         "@fastify/sensible": "^5.0.0",
         "bcrypt": "^5.1.1",
         "dotenv": "^16.4.5",
@@ -24,6 +25,15 @@
       },
       "devDependencies": {
         "sequelize-cli": "^6.6.2"
+      }
+    },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
+      "integrity": "sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@fastify/ajv-compiler": {
@@ -42,6 +52,18 @@
       "resolved": "https://registry.npmjs.org/@fastify/autoload/-/autoload-5.10.0.tgz",
       "integrity": "sha512-4A6s86qMbjcpWHmJL7cErtjIxOPuW8c67DLiuO8HoJQxuK97vaptoUnK5BTOwRg1ntYqfc3tjwerTTo5NQ3fEQ==",
       "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/@fastify/busboy/-/busboy-1.2.1.tgz",
+      "integrity": "sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "text-decoding": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@fastify/cors": {
       "version": "9.0.1",
@@ -83,6 +105,36 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "node_modules/@fastify/multipart": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmmirror.com/@fastify/multipart/-/multipart-7.7.3.tgz",
+      "integrity": "sha512-MG4Gd9FNEXc8qx0OgqoXM10EGO/dN/0iVQ8SrpFMU3d6F6KUfcqD2ZyoQhkm9LWrbiMgdHv5a43x78lASdn5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^1.0.0",
+        "@fastify/deepmerge": "^1.0.0",
+        "@fastify/error": "^3.0.0",
+        "@fastify/swagger": "^8.3.1",
+        "@fastify/swagger-ui": "^1.8.0",
+        "end-of-stream": "^1.4.4",
+        "fastify-plugin": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "stream-wormhole": "^1.1.0"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/@fastify/send/-/send-2.1.0.tgz",
+      "integrity": "sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.1",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "2.0.0",
+        "mime": "^3.0.0"
+      }
+    },
     "node_modules/@fastify/sensible": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@fastify/sensible/-/sensible-5.6.0.tgz",
@@ -96,6 +148,61 @@
         "http-errors": "^2.0.0",
         "type-is": "^1.6.18",
         "vary": "^1.1.2"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmmirror.com/@fastify/static/-/static-6.12.0.tgz",
+      "integrity": "sha512-KK1B84E6QD/FcQWxDI2aiUCwHxMJBI1KeCUzm1BwYpPY1b742+jeKruGHP2uOluuM6OkBPI8CIANrXcCRtC2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^1.0.0",
+        "@fastify/send": "^2.0.0",
+        "content-disposition": "^0.5.3",
+        "fastify-plugin": "^4.0.0",
+        "glob": "^8.0.1",
+        "p-limit": "^3.1.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fastify/swagger": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmmirror.com/@fastify/swagger/-/swagger-8.15.0.tgz",
+      "integrity": "sha512-zy+HEEKFqPMS2sFUsQU5X0MHplhKJvWeohBwTCkBAJA/GDYGLGUWQaETEhptiqxK7Hs0fQB9B4MDb3pbwIiCwA==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^4.0.0",
+        "json-schema-resolver": "^2.0.0",
+        "openapi-types": "^12.0.0",
+        "rfdc": "^1.3.0",
+        "yaml": "^2.2.2"
+      }
+    },
+    "node_modules/@fastify/swagger-ui": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmmirror.com/@fastify/swagger-ui/-/swagger-ui-1.10.2.tgz",
+      "integrity": "sha512-f2mRqtblm6eRAFQ3e8zSngxVNEtiYY7rISKQVjPA++ZsWc5WYlPVTb6Bx0G/zy0BIoucNqDr/Q2Vb/kTYkOq1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/static": "^6.0.0",
+        "fastify-plugin": "^4.0.0",
+        "openapi-types": "^12.0.2",
+        "rfdc": "^1.3.0",
+        "yaml": "^2.2.2"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -739,6 +846,18 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC"
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -985,6 +1104,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/esniff": {
       "version": "2.0.1",
@@ -1801,6 +1926,23 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "node_modules/json-schema-resolver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/json-schema-resolver/-/json-schema-resolver-2.0.0.tgz",
+      "integrity": "sha512-pJ4XLQP4Q9HTxl6RVDLJ8Cyh1uitSs0CzDBAz1uoJ4sRD/Bk7cFSXL1FUXDW3zJ7YnfliJx6eu8Jn283bpZ4Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "rfdc": "^1.1.4",
+        "uri-js": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2020,6 +2162,18 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -2363,6 +2517,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmmirror.com/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -2654,6 +2814,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/quick-format-unescaped": {
@@ -3096,6 +3265,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-wormhole": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/stream-wormhole/-/stream-wormhole-1.1.0.tgz",
+      "integrity": "sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3223,6 +3401,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/text-decoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/text-decoding/-/text-decoding-1.0.0.tgz",
+      "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
+      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",
@@ -3357,6 +3541,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -3510,6 +3703,21 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -3546,6 +3754,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@fastify/autoload": "^5.0.0",
     "@fastify/cors": "^9.0.1",
+    "@fastify/multipart": "^7.7.3",
     "@fastify/sensible": "^5.0.0",
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",

--- a/backend/plugins/multipart.js
+++ b/backend/plugins/multipart.js
@@ -1,41 +1,43 @@
-const fp = require('fastify-plugin');
-const multipart = require('@fastify/multipart');
+'use strict'
 
-const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const fp = require('fastify-plugin')
+const multipart = require('@fastify/multipart')
+
+const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_ALLOWED_MIME_TYPES = [
   'image/jpeg',
   'image/png',
   'image/webp',
   'application/pdf'
-];
+]
 
 function parsePositiveInt(value, fallback) {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
-  return parsed;
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback
+  return parsed
 }
 
 module.exports = fp(async function multipartPlugin(fastify) {
-  const maxFileSize = parsePositiveInt(process.env.ATTACHMENT_MAX_FILE_SIZE, DEFAULT_MAX_FILE_SIZE);
+  const maxFileSize = parsePositiveInt(process.env.ATTACHMENT_MAX_FILE_SIZE, DEFAULT_MAX_FILE_SIZE)
   const allowedMimeTypes = (process.env.ATTACHMENT_ALLOWED_MIME_TYPES || DEFAULT_ALLOWED_MIME_TYPES.join(','))
     .split(',')
     .map((v) => v.trim())
-    .filter((v) => v.length > 0);
+    .filter((v) => v.length > 0)
 
   await fastify.register(multipart, {
     limits: {
       files: 1,
       fileSize: maxFileSize
     }
-  });
+  })
 
   fastify.decorate('attachmentUploadConfig', {
     maxFileSize,
     allowedMimeTypes
-  });
+  })
 
   fastify.decorate('isAllowedAttachmentMimeType', (mimeType) => {
-    return allowedMimeTypes.includes(mimeType);
-  });
-});
+    return allowedMimeTypes.includes(mimeType)
+  })
+})
 

--- a/backend/plugins/multipart.js
+++ b/backend/plugins/multipart.js
@@ -1,0 +1,41 @@
+const fp = require('fastify-plugin');
+const multipart = require('@fastify/multipart');
+
+const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const DEFAULT_ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'application/pdf'
+];
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+module.exports = fp(async function multipartPlugin(fastify) {
+  const maxFileSize = parsePositiveInt(process.env.ATTACHMENT_MAX_FILE_SIZE, DEFAULT_MAX_FILE_SIZE);
+  const allowedMimeTypes = (process.env.ATTACHMENT_ALLOWED_MIME_TYPES || DEFAULT_ALLOWED_MIME_TYPES.join(','))
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+
+  await fastify.register(multipart, {
+    limits: {
+      files: 1,
+      fileSize: maxFileSize
+    }
+  });
+
+  fastify.decorate('attachmentUploadConfig', {
+    maxFileSize,
+    allowedMimeTypes
+  });
+
+  fastify.decorate('isAllowedAttachmentMimeType', (mimeType) => {
+    return allowedMimeTypes.includes(mimeType);
+  });
+});
+

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -49,9 +49,9 @@ DELETE /api/attachments/:id
 
 ### Task 8.2: ファイルアップロード設定
 
-- [ ] 8.2.1: `@fastify/multipart` インストール
-- [ ] 8.2.2: Fastify multipart プラグイン登録
-- [ ] 8.2.3: アップロード制限設定（ファイルサイズ、MIME タイプ）
+- [x] 8.2.1: `@fastify/multipart` インストール
+- [x] 8.2.2: Fastify multipart プラグイン登録
+- [x] 8.2.3: アップロード制限設定（ファイルサイズ、MIME タイプ）
 
 ### Task 8.3: StorageService 作成
 


### PR DESCRIPTION
## Summary
- `@fastify/multipart` を Fastify 4 互換版で導入し、アップロード基盤を追加
- `backend/plugins/multipart.js` を追加し、ファイルサイズ上限と許可MIMEタイプを環境変数で設定可能にした
- `attachmentUploadConfig` と `isAllowedAttachmentMimeType` を decorate し、後続タスクで再利用できるようにした
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.2.1〜8.2.3 を完了に更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)