### PR TITLE
feat(backend): Task 8.3 StorageService を追加

### DIFF
--- a/backend/services/StorageService.js
+++ b/backend/services/StorageService.js
@@ -1,0 +1,118 @@
+'use strict'
+
+const fs = require('node:fs/promises')
+const fsSync = require('node:fs')
+const path = require('node:path')
+const { pipeline } = require('node:stream/promises')
+const { randomUUID } = require('node:crypto')
+
+const UPLOAD_URL_PREFIX = '/uploads'
+const DEFAULT_UPLOAD_DIR = path.join(__dirname, '..', 'uploads')
+
+function parseTodoId(todoId) {
+  const parsed = Number.parseInt(todoId, 10)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error('todoId must be a positive integer')
+  }
+  return parsed
+}
+
+function sanitizeFileName(fileName) {
+  const baseName = path.basename(String(fileName || ''))
+  const normalized = baseName.normalize('NFKC')
+  const sanitized = normalized
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .trim()
+
+  return sanitized.length > 0 ? sanitized : 'file'
+}
+
+function getUploadRootDir() {
+  const configured = process.env.ATTACHMENT_UPLOAD_DIR
+  if (configured && configured.trim().length > 0) {
+    return path.resolve(configured.trim())
+  }
+  return DEFAULT_UPLOAD_DIR
+}
+
+function toPublicFileUrl(todoId, uniqueFileName) {
+  return `${UPLOAD_URL_PREFIX}/${todoId}/${uniqueFileName}`
+}
+
+function resolvePathFromFileUrl(fileUrl) {
+  const uploadRoot = getUploadRootDir()
+  if (!fileUrl || typeof fileUrl !== 'string') return null
+
+  if (fileUrl.startsWith(UPLOAD_URL_PREFIX + '/')) {
+    const relativePart = fileUrl.slice(UPLOAD_URL_PREFIX.length + 1)
+    return path.resolve(uploadRoot, relativePart)
+  }
+
+  if (path.isAbsolute(fileUrl)) {
+    return path.resolve(fileUrl)
+  }
+
+  return path.resolve(uploadRoot, fileUrl)
+}
+
+function isUnderUploadRoot(targetPath) {
+  const uploadRoot = getUploadRootDir()
+  const normalizedRoot = path.resolve(uploadRoot) + path.sep
+  const normalizedTarget = path.resolve(targetPath)
+  return normalizedTarget.startsWith(normalizedRoot)
+}
+
+function generateUniqueFileName(originalFileName) {
+  const safeName = sanitizeFileName(originalFileName)
+  const ext = path.extname(safeName).toLowerCase()
+  return `${randomUUID()}${ext}`
+}
+
+async function uploadFile(file, todoId) {
+  const safeTodoId = parseTodoId(todoId)
+  if (!file || typeof file !== 'object' || typeof file.file?.pipe !== 'function') {
+    throw new Error('file stream is required')
+  }
+
+  const uploadRoot = getUploadRootDir()
+  const todoUploadDir = path.join(uploadRoot, String(safeTodoId))
+  const originalFileName = sanitizeFileName(file.filename)
+  const uniqueFileName = generateUniqueFileName(originalFileName)
+  const targetPath = path.join(todoUploadDir, uniqueFileName)
+
+  await fs.mkdir(todoUploadDir, { recursive: true })
+  await pipeline(file.file, fsSync.createWriteStream(targetPath))
+
+  const stat = await fs.stat(targetPath)
+  return {
+    originalFileName,
+    storedFileName: uniqueFileName,
+    fileSize: stat.size,
+    mimeType: file.mimetype || 'application/octet-stream',
+    fileUrl: toPublicFileUrl(safeTodoId, uniqueFileName)
+  }
+}
+
+async function deleteFile(fileUrl) {
+  const targetPath = resolvePathFromFileUrl(fileUrl)
+  if (!targetPath) return false
+  if (!isUnderUploadRoot(targetPath)) return false
+
+  try {
+    await fs.unlink(targetPath)
+    return true
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+module.exports = {
+  sanitizeFileName,
+  generateUniqueFileName,
+  uploadFile,
+  deleteFile
+}

--- a/backend/services/StorageService.js
+++ b/backend/services/StorageService.js
@@ -8,6 +8,7 @@ const { randomUUID } = require('node:crypto')
 
 const UPLOAD_URL_PREFIX = '/uploads'
 const DEFAULT_UPLOAD_DIR = path.join(__dirname, '..', 'uploads')
+const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.pdf'])
 
 function parseTodoId(todoId) {
   const parsed = Number.parseInt(todoId, 10)
@@ -68,9 +69,16 @@ function isUnderUploadRoot(targetPath) {
 function generateUniqueFileName(originalFileName) {
   const safeName = sanitizeFileName(originalFileName)
   const ext = path.extname(safeName).toLowerCase()
-  return `${randomUUID()}${ext}`
+  const safeExt = ALLOWED_EXTENSIONS.has(ext) ? ext : ''
+  return `${randomUUID()}${safeExt}`
 }
 
+/**
+ * @param {object} file - @fastify/multipart のファイルオブジェクト
+ * 呼び出し前に MIME タイプ検証を行うこと（StorageService は保存処理に専念する）。
+ * @param {number|string} todoId
+ * @returns {Promise<{originalFileName: string, storedFileName: string, fileSize: number, mimeType: string, fileUrl: string}>}
+ */
 async function uploadFile(file, todoId) {
   const safeTodoId = parseTodoId(todoId)
   if (!file || typeof file !== 'object' || typeof file.file?.pipe !== 'function') {

--- a/backend/test/services/storageService.test.js
+++ b/backend/test/services/storageService.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const storageService = require('../../services/StorageService')
+
+test('sanitizeFileName: 空文字は file にフォールバックする', () => {
+  assert.strictEqual(storageService.sanitizeFileName(''), 'file')
+})
+
+test('sanitizeFileName: 制御文字と危険文字を除去/置換する', () => {
+  const sanitized = storageService.sanitizeFileName('\u0000evil:/name?.png')
+  assert.strictEqual(sanitized, 'name_.png')
+})
+
+test('generateUniqueFileName: 許可拡張子は維持する', () => {
+  const generated = storageService.generateUniqueFileName('photo.JPG')
+  assert.match(generated, /^[0-9a-f-]{36}\.jpg$/)
+})
+
+test('generateUniqueFileName: 非許可拡張子は除去する', () => {
+  const generated = storageService.generateUniqueFileName('script.sh')
+  assert.match(generated, /^[0-9a-f-]{36}$/)
+})
+
+test('deleteFile: upload ルート外の絶対パスは削除せず false を返す', async () => {
+  const deleted = await storageService.deleteFile('/etc/passwd')
+  assert.strictEqual(deleted, false)
+})

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -55,12 +55,12 @@ DELETE /api/attachments/:id
 
 ### Task 8.3: StorageService 作成
 
-- [ ] 8.3.1: `backend/services/StorageService.js` 作成
-- [ ] 8.3.2: ローカルストレージ実装（開発用）
-- [ ] 8.3.3: `uploadFile(file, todoId)` 実装
-- [ ] 8.3.4: `deleteFile(fileUrl)` 実装
-- [ ] 8.3.5: ファイル名のサニタイズ処理
-- [ ] 8.3.6: ユニークファイル名生成（UUID）
+- [x] 8.3.1: `backend/services/StorageService.js` 作成
+- [x] 8.3.2: ローカルストレージ実装（開発用）
+- [x] 8.3.3: `uploadFile(file, todoId)` 実装
+- [x] 8.3.4: `deleteFile(fileUrl)` 実装
+- [x] 8.3.5: ファイル名のサニタイズ処理
+- [x] 8.3.6: ユニークファイル名生成（UUID）
 
 ### Task 8.4: AttachmentService 作成
 


### PR DESCRIPTION
## Summary
- `backend/services/StorageService.js` を追加し、添付ファイルのローカル保存/削除を実装
- ファイル名サニタイズ（制御文字・危険文字除去）と UUID ベースのユニーク名生成を追加
- `uploadFile(file, todoId)` で `todoId` 単位ディレクトリに保存し、`fileUrl` を返すようにした
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.3.1〜8.3.6 を完了に更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)