### PR TITLE
feat(backend): Task 8.4 AttachmentService を追加

### DIFF
--- a/backend/services/AttachmentService.js
+++ b/backend/services/AttachmentService.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const storageService = require('./StorageService')
+const todoService = require('./todoService')
+const shareService = require('./shareService')
+
+async function canEditTodo(fastify, todo, userId) {
+  if (!todo) return false
+  if (todo.userId === userId) return true
+  return shareService.canEdit(fastify, todo.id, userId)
+}
+
+/**
+ * 添付ファイルを保存し、attachments テーブルにメタ情報を作成する。
+ * @param {object} fastify
+ * @param {number} todoId
+ * @param {object} fileData - @fastify/multipart の file オブジェクト
+ * @param {number} userId
+ * @returns {Promise<object|null>}
+ */
+async function createAttachment(fastify, todoId, fileData, userId) {
+  const todo = await todoService.getTodoById(fastify, todoId, userId)
+  if (!(await canEditTodo(fastify, todo, userId))) return null
+
+  const uploaded = await storageService.uploadFile(fileData, todoId)
+  try {
+    return await fastify.models.Attachment.create({
+      todoId: Number(todoId),
+      fileName: uploaded.originalFileName,
+      fileSize: uploaded.fileSize,
+      mimeType: uploaded.mimeType,
+      fileUrl: uploaded.fileUrl
+    })
+  } catch (error) {
+    await storageService.deleteFile(uploaded.fileUrl)
+    throw error
+  }
+}
+
+/**
+ * 指定 Todo の添付一覧を取得する（所有者または view/edit 共有先）。
+ * @param {object} fastify
+ * @param {number} todoId
+ * @param {number} userId
+ * @returns {Promise<object[]|null>}
+ */
+async function getAttachmentsByTodoId(fastify, todoId, userId) {
+  const todo = await todoService.getTodoById(fastify, todoId, userId)
+  if (!todo) return null
+
+  return fastify.models.Attachment.findAll({
+    where: { todoId: Number(todoId) },
+    order: [['createdAt', 'DESC']]
+  })
+}
+
+/**
+ * 添付ファイルを削除する（所有者または edit 共有先）。
+ * @param {object} fastify
+ * @param {number} attachmentId
+ * @param {number} userId
+ * @returns {Promise<boolean>}
+ */
+async function deleteAttachment(fastify, attachmentId, userId) {
+  const attachment = await fastify.models.Attachment.findByPk(attachmentId)
+  if (!attachment) return false
+
+  const todo = await todoService.getTodoById(fastify, attachment.todoId, userId)
+  if (!(await canEditTodo(fastify, todo, userId))) return false
+
+  await attachment.destroy()
+  try {
+    await storageService.deleteFile(attachment.fileUrl)
+  } catch (error) {
+    fastify.log?.warn(error, '添付ファイルの物理削除に失敗しました')
+  }
+  return true
+}
+
+module.exports = {
+  createAttachment,
+  getAttachmentsByTodoId,
+  deleteAttachment
+}

--- a/backend/test/services/attachmentService.test.js
+++ b/backend/test/services/attachmentService.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const attachmentService = require('../../services/AttachmentService')
+const storageService = require('../../services/StorageService')
+const todoService = require('../../services/todoService')
+const shareService = require('../../services/shareService')
+
+test('createAttachment: 所有者は添付を作成できる', async () => {
+  const uploadResult = {
+    originalFileName: 'image.png',
+    fileSize: 1234,
+    mimeType: 'image/png',
+    fileUrl: '/uploads/10/uuid.png'
+  }
+  const created = { id: 1, todoId: 10, fileName: 'image.png' }
+  const fastify = {
+    models: {
+      Attachment: {
+        create: async (payload) => ({ ...created, ...payload })
+      }
+    }
+  }
+
+  todoService.getTodoById = async () => ({ id: 10, userId: 1 })
+  storageService.uploadFile = async () => uploadResult
+
+  const result = await attachmentService.createAttachment(fastify, 10, { file: { pipe: () => {} } }, 1)
+  assert.strictEqual(result.todoId, 10)
+  assert.strictEqual(result.fileName, 'image.png')
+})
+
+test('getAttachmentsByTodoId: 閲覧不可なら null', async () => {
+  todoService.getTodoById = async () => null
+  const fastify = { models: { Attachment: { findAll: async () => [] } } }
+
+  const result = await attachmentService.getAttachmentsByTodoId(fastify, 10, 99)
+  assert.strictEqual(result, null)
+})
+
+test('deleteAttachment: edit 権限があれば削除できる', async () => {
+  let destroyed = false
+  const fastify = {
+    models: {
+      Attachment: {
+        findByPk: async () => ({
+          id: 5,
+          todoId: 10,
+          fileUrl: '/uploads/10/file.png',
+          destroy: async () => { destroyed = true }
+        })
+      }
+    },
+    log: { warn: () => {} }
+  }
+
+  todoService.getTodoById = async () => ({ id: 10, userId: 1 })
+  shareService.canEdit = async () => true
+  storageService.deleteFile = async () => true
+
+  const result = await attachmentService.deleteAttachment(fastify, 5, 2)
+  assert.strictEqual(result, true)
+  assert.strictEqual(destroyed, true)
+})

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -64,11 +64,11 @@ DELETE /api/attachments/:id
 
 ### Task 8.4: AttachmentService 作成
 
-- [ ] 8.4.1: `backend/services/AttachmentService.js` 作成
-- [ ] 8.4.2: `createAttachment(todoId, fileData)` 実装
-- [ ] 8.4.3: `getAttachmentsByTodoId(todoId, userId)` 実装
-- [ ] 8.4.4: `deleteAttachment(attachmentId, userId)` 実装
-- [ ] 8.4.5: StorageService 呼び出し
+- [x] 8.4.1: `backend/services/AttachmentService.js` 作成
+- [x] 8.4.2: `createAttachment(todoId, fileData)` 実装
+- [x] 8.4.3: `getAttachmentsByTodoId(todoId, userId)` 実装
+- [x] 8.4.4: `deleteAttachment(attachmentId, userId)` 実装
+- [x] 8.4.5: StorageService 呼び出し
 
 ### Task 8.5: AttachmentController 作成
 


### PR DESCRIPTION
## Summary
- `backend/services/AttachmentService.js` を追加し、添付の作成・一覧取得・削除を実装
- 作成/削除時に Todo のアクセス権限（所有者 or 共有 edit）を確認するようにした
- `StorageService` 連携で実ファイル保存/削除と DB レコード作成/削除を連動
- `backend/test/services/attachmentService.test.js` を追加し主要ロジックを検証
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.4.1〜8.4.5 を完了に更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)