### PR TITLE
feat(backend): Task 8.5 AttachmentController を追加

### DIFF
--- a/backend/controllers/AttachmentController.js
+++ b/backend/controllers/AttachmentController.js
@@ -19,10 +19,14 @@ async function uploadAttachment(fastify, req, reply) {
     const file = await req.file()
     if (!file) return reply.code(400).send({ error: 'File is required' })
 
-    const isAllowedMimeType = typeof fastify.isAllowedAttachmentMimeType === 'function'
-      ? fastify.isAllowedAttachmentMimeType(file.mimetype)
-      : true
-    if (!isAllowedMimeType) {
+    if (typeof fastify.isAllowedAttachmentMimeType !== 'function') {
+      fastify.log.error('isAllowedAttachmentMimeType is not registered')
+      await file.toBuffer()
+      return reply.code(500).send({ error: 'Server configuration error' })
+    }
+
+    if (!fastify.isAllowedAttachmentMimeType(file.mimetype)) {
+      await file.toBuffer()
       return reply.code(400).send({ error: 'Unsupported mime type' })
     }
 
@@ -58,6 +62,7 @@ async function deleteAttachment(fastify, req, reply) {
     if (attachmentId === null) return reply.code(400).send({ error: 'Invalid attachment id' })
 
     const deleted = await attachmentService.deleteAttachment(fastify, attachmentId, req.user.id)
+    // false は「存在しない」と「権限なし」の両方を含む（存在秘匿のため区別しない）
     if (!deleted) return reply.code(404).send({ error: 'Not found' })
     return reply.code(204).send()
   } catch (error) {

--- a/backend/controllers/AttachmentController.js
+++ b/backend/controllers/AttachmentController.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const attachmentService = require('../services/AttachmentService')
+
+function parseId(value) {
+  const id = Number.parseInt(value, 10)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+function toPlainAttachment(attachment) {
+  return typeof attachment?.toJSON === 'function' ? attachment.toJSON() : attachment
+}
+
+async function uploadAttachment(fastify, req, reply) {
+  try {
+    const todoId = parseId(req.params.todoId)
+    if (todoId === null) return reply.code(400).send({ error: 'Invalid todo id' })
+
+    const file = await req.file()
+    if (!file) return reply.code(400).send({ error: 'File is required' })
+
+    const isAllowedMimeType = typeof fastify.isAllowedAttachmentMimeType === 'function'
+      ? fastify.isAllowedAttachmentMimeType(file.mimetype)
+      : true
+    if (!isAllowedMimeType) {
+      return reply.code(400).send({ error: 'Unsupported mime type' })
+    }
+
+    const created = await attachmentService.createAttachment(fastify, todoId, file, req.user.id)
+    if (!created) return reply.code(403).send({ error: 'Forbidden' })
+    return reply.code(201).send(toPlainAttachment(created))
+  } catch (error) {
+    if (error?.code === 'FST_REQ_FILE_TOO_LARGE') {
+      return reply.code(413).send({ error: 'File too large' })
+    }
+    fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, 'Failed to upload attachment')
+    return reply.code(500).send({ error: 'Failed to upload attachment' })
+  }
+}
+
+async function getAttachments(fastify, req, reply) {
+  try {
+    const todoId = parseId(req.params.todoId)
+    if (todoId === null) return reply.code(400).send({ error: 'Invalid todo id' })
+
+    const list = await attachmentService.getAttachmentsByTodoId(fastify, todoId, req.user.id)
+    if (list === null) return reply.code(403).send({ error: 'Forbidden' })
+    return reply.code(200).send(list.map(toPlainAttachment))
+  } catch (error) {
+    fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, 'Failed to get attachments')
+    return reply.code(500).send({ error: 'Failed to get attachments' })
+  }
+}
+
+async function deleteAttachment(fastify, req, reply) {
+  try {
+    const attachmentId = parseId(req.params.id)
+    if (attachmentId === null) return reply.code(400).send({ error: 'Invalid attachment id' })
+
+    const deleted = await attachmentService.deleteAttachment(fastify, attachmentId, req.user.id)
+    if (!deleted) return reply.code(404).send({ error: 'Not found' })
+    return reply.code(204).send()
+  } catch (error) {
+    fastify.log.error({ err: error, message: error?.message, stack: error?.stack }, 'Failed to delete attachment')
+    return reply.code(500).send({ error: 'Failed to delete attachment' })
+  }
+}
+
+module.exports = {
+  uploadAttachment,
+  getAttachments,
+  deleteAttachment
+}

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -72,11 +72,11 @@ DELETE /api/attachments/:id
 
 ### Task 8.5: AttachmentController 作成
 
-- [ ] 8.5.1: `backend/controllers/AttachmentController.js` 作成
-- [ ] 8.5.2: `uploadAttachment` ハンドラ実装
-- [ ] 8.5.3: `getAttachments` ハンドラ実装
-- [ ] 8.5.4: `deleteAttachment` ハンドラ実装
-- [ ] 8.5.5: ファイルバリデーション
+- [x] 8.5.1: `backend/controllers/AttachmentController.js` 作成
+- [x] 8.5.2: `uploadAttachment` ハンドラ実装
+- [x] 8.5.3: `getAttachments` ハンドラ実装
+- [x] 8.5.4: `deleteAttachment` ハンドラ実装
+- [x] 8.5.5: ファイルバリデーション
 
 ### Task 8.6: Attachment ルート作成
 


### PR DESCRIPTION
## Summary
- `backend/controllers/AttachmentController.js` を追加し、添付API向けハンドラを実装
- `uploadAttachment` で `todoId` 検証、multipart ファイル存在確認、MIME タイプ検証を実施
- `getAttachments` / `deleteAttachment` を実装し、AttachmentService に処理委譲
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.5.1〜8.5.5 を完了に更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)