### PR TITLE
feat(backend): Task 8.6 添付ファイルAPIルートを追加

### DIFF
--- a/backend/routes/api/v1/attachments.js
+++ b/backend/routes/api/v1/attachments.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const {
+  uploadAttachment,
+  getAttachments,
+  deleteAttachment
+} = require('../../../controllers/AttachmentController')
+
+module.exports = async function attachmentRoutes(fastify) {
+  fastify.post('/todos/:todoId/attachments', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['todoId'],
+        properties: { todoId: { type: 'string', pattern: '^[0-9]+$' } }
+      }
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => uploadAttachment(fastify, request, reply)
+  })
+
+  fastify.get('/todos/:todoId/attachments', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['todoId'],
+        properties: { todoId: { type: 'string', pattern: '^[0-9]+$' } }
+      }
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => getAttachments(fastify, request, reply)
+  })
+
+  fastify.delete('/attachments/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string', pattern: '^[0-9]+$' } }
+      }
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (request, reply) => deleteAttachment(fastify, request, reply)
+  })
+}

--- a/backend/routes/api/v1/index.js
+++ b/backend/routes/api/v1/index.js
@@ -819,6 +819,7 @@ module.exports = async function (fastify, opts) {
     preHandler: [fastify.authenticate],
     handler: async (request, reply) => deleteShare(fastify, request, reply),
   });
+  fastify.register(require('./attachments'));
 
   /**
    * Analytics（JWT 必須）— 既存 API と同様に /api/v1 配下

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -80,11 +80,11 @@ DELETE /api/attachments/:id
 
 ### Task 8.6: Attachment ルート作成
 
-- [ ] 8.6.1: `backend/routes/api/attachments.js` 作成
-- [ ] 8.6.2: POST /api/todos/:todoId/attachments のルート定義
-- [ ] 8.6.3: GET /api/todos/:todoId/attachments のルート定義
-- [ ] 8.6.4: DELETE /api/attachments/:id のルート定義
-- [ ] 8.6.5: JWT 認証 preHandler 適用
+- [x] 8.6.1: `backend/routes/api/attachments.js` 作成
+- [x] 8.6.2: POST /api/todos/:todoId/attachments のルート定義
+- [x] 8.6.3: GET /api/todos/:todoId/attachments のルート定義
+- [x] 8.6.4: DELETE /api/attachments/:id のルート定義
+- [x] 8.6.5: JWT 認証 preHandler 適用
 
 ### Task 8.7: 静的ファイル配信設定
 


### PR DESCRIPTION
## Summary
- `backend/routes/api/v1/attachments.js` を追加し、添付APIルートを実装
- `POST /todos/:todoId/attachments` / `GET /todos/:todoId/attachments` / `DELETE /attachments/:id` を定義
- すべての添付ルートに `preHandler: [fastify.authenticate]` を適用
- `backend/routes/api/v1/index.js` から attachments ルートを登録
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.6.1〜8.6.5 を完了に更新

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)