### PR TITLE
feat(backend): Task 8.7 uploads静的配信を追加

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/cors": "^9.0.1",
         "@fastify/multipart": "^7.7.3",
         "@fastify/sensible": "^5.0.0",
+        "@fastify/static": "^6.12.0",
         "bcrypt": "^5.1.1",
         "dotenv": "^16.4.5",
         "fastify": "^4.26.1",
@@ -2219,11 +2220,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@fastify/cors": "^9.0.1",
     "@fastify/multipart": "^7.7.3",
     "@fastify/sensible": "^5.0.0",
+    "@fastify/static": "^6.12.0",
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",
     "fastify": "^4.26.1",

--- a/backend/plugins/static.js
+++ b/backend/plugins/static.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+const path = require('node:path')
+const fastifyStatic = require('@fastify/static')
+
+const DEFAULT_UPLOAD_DIR = path.join(__dirname, '..', 'uploads')
+
+function getUploadRootDir() {
+  const configured = process.env.ATTACHMENT_UPLOAD_DIR
+  if (configured && configured.trim().length > 0) {
+    return path.resolve(configured.trim())
+  }
+  return DEFAULT_UPLOAD_DIR
+}
+
+module.exports = fp(async function staticUploadPlugin(fastify) {
+  await fastify.register(fastifyStatic, {
+    root: getUploadRootDir(),
+    prefix: '/uploads/'
+  })
+})

--- a/backend/plugins/static.js
+++ b/backend/plugins/static.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fp = require('fastify-plugin')
 const path = require('node:path')
 const fastifyStatic = require('@fastify/static')
 
@@ -14,9 +13,11 @@ function getUploadRootDir() {
   return DEFAULT_UPLOAD_DIR
 }
 
-module.exports = fp(async function staticUploadPlugin(fastify) {
+module.exports = async function staticUploadPlugin(fastify) {
+  fastify.addHook('preHandler', fastify.authenticate)
+
   await fastify.register(fastifyStatic, {
     root: getUploadRootDir(),
     prefix: '/uploads/'
   })
-})
+}

--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -88,8 +88,8 @@ DELETE /api/attachments/:id
 
 ### Task 8.7: 静的ファイル配信設定
 
-- [ ] 8.7.1: `@fastify/static` インストール
-- [ ] 8.7.2: uploads ディレクトリの静的配信設定
+- [x] 8.7.1: `@fastify/static` インストール
+- [x] 8.7.2: uploads ディレクトリの静的配信設定
 
 ### Task 8.8: Backend テスト
 


### PR DESCRIPTION
## Summary
- `@fastify/static`（Fastify 4 互換）を backend 依存へ追加
- `backend/plugins/static.js` を追加し、`ATTACHMENT_UPLOAD_DIR`（未設定時は `backend/uploads`）を `/uploads/` で配信する設定を追加
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.7.1〜8.7.2 を完了に更新
- `package-lock.json` の resolved URL は公式 `registry.npmjs.org` に統一

## Test plan
- [x] `docker compose run --rm backend npm run test`

Made with [Cursor](https://cursor.com)