### PR TITLE
feat(frontend): Task 8.9 Attachment インターフェースを追加

### DIFF
--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -103,8 +103,8 @@ DELETE /api/attachments/:id
 
 ### Task 8.9: Attachment インターフェース定義
 
-- [ ] 8.9.1: `frontend/src/app/models/attachment.interface.ts` 作成
-- [ ] 8.9.2: Attachment インターフェース定義
+- [x] 8.9.1: `frontend/src/app/models/attachment.interface.ts` 作成
+- [x] 8.9.2: Attachment インターフェース定義
 
 ### Task 8.10: AttachmentService 作成
 

--- a/frontend/src/app/models/attachment.interface.ts
+++ b/frontend/src/app/models/attachment.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * API から返却される Attachment 型（Feature 8）。
+ */
+export interface Attachment {
+  id: number
+  todoId: number
+  fileName: string
+  fileSize: number
+  mimeType: string
+  fileUrl: string
+  createdAt: string
+}


### PR DESCRIPTION
## Summary
- `frontend/src/app/models/attachment.interface.ts` を追加し、Attachment 型を定義
- `id`, `todoId`, `fileName`, `fileSize`, `mimeType`, `fileUrl`, `createdAt` を明示
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.9.1〜8.9.2 を完了に更新

## Test plan
- [x] `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)