### PR TITLE
feat(frontend): Task 8.10 AttachmentService を追加

### DIFF
--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -108,11 +108,11 @@ DELETE /api/attachments/:id
 
 ### Task 8.10: AttachmentService 作成
 
-- [ ] 8.10.1: `frontend/src/app/services/attachment.service.ts` 作成
-- [ ] 8.10.2: `uploadAttachment(todoId: number, file: File): Observable<Attachment>` 実装
-- [ ] 8.10.3: `getAttachments(todoId: number): Observable<Attachment[]>` 実装
-- [ ] 8.10.4: `deleteAttachment(id: number): Observable<void>` 実装
-- [ ] 8.10.5: アップロード進捗の実装
+- [x] 8.10.1: `frontend/src/app/services/attachment.service.ts` 作成
+- [x] 8.10.2: `uploadAttachment(todoId: number, file: File): Observable<Attachment>` 実装
+- [x] 8.10.3: `getAttachments(todoId: number): Observable<Attachment[]>` 実装
+- [x] 8.10.4: `deleteAttachment(id: number): Observable<void>` 実装
+- [x] 8.10.5: アップロード進捗の実装
 
 ### Task 8.11: FileUpload コンポーネント作成
 

--- a/frontend/src/app/services/attachment.service.ts
+++ b/frontend/src/app/services/attachment.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core'
+import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http'
+import { Observable, filter, map } from 'rxjs'
+import { environment } from '../../environments/environment'
+import type { Attachment } from '../models/attachment.interface'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AttachmentService {
+  private apiUrl = environment.apiUrl
+
+  constructor(private http: HttpClient) {}
+
+  uploadAttachment(todoId: number, file: File): Observable<Attachment> {
+    return this.uploadAttachmentWithProgress(todoId, file).pipe(
+      filter((event) => event.type === HttpEventType.Response),
+      map((event) => event.body as Attachment)
+    )
+  }
+
+  uploadAttachmentWithProgress(todoId: number, file: File): Observable<HttpEvent<Attachment>> {
+    const formData = new FormData()
+    formData.append('file', file)
+
+    return this.http.post<Attachment>(`${this.apiUrl}/todos/${todoId}/attachments`, formData, {
+      reportProgress: true,
+      observe: 'events'
+    })
+  }
+
+  getAttachments(todoId: number): Observable<Attachment[]> {
+    return this.http.get<Attachment[]>(`${this.apiUrl}/todos/${todoId}/attachments`)
+  }
+
+  deleteAttachment(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/attachments/${id}`)
+  }
+}

--- a/frontend/src/app/services/attachment.service.ts
+++ b/frontend/src/app/services/attachment.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http'
+import { HttpClient, HttpEvent, HttpEventType, HttpResponse } from '@angular/common/http'
 import { Observable, filter, map } from 'rxjs'
 import { environment } from '../../environments/environment'
 import type { Attachment } from '../models/attachment.interface'
@@ -14,8 +14,13 @@ export class AttachmentService {
 
   uploadAttachment(todoId: number, file: File): Observable<Attachment> {
     return this.uploadAttachmentWithProgress(todoId, file).pipe(
-      filter((event) => event.type === HttpEventType.Response),
-      map((event) => event.body as Attachment)
+      filter((event): event is HttpResponse<Attachment> => event.type === HttpEventType.Response),
+      map((event) => {
+        if (!event.body) {
+          throw new Error('Attachment response body is empty')
+        }
+        return event.body
+      })
     )
   }
 


### PR DESCRIPTION
## Summary
- `frontend/src/app/services/attachment.service.ts` を追加
- `uploadAttachment(todoId, file)` / `getAttachments(todoId)` / `deleteAttachment(id)` を実装
- `uploadAttachmentWithProgress` を追加し、`HttpEvent` ベースでアップロード進捗を扱えるようにした
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.10.1〜8.10.5 を完了に更新

## Test plan
- [x] `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)