### PR TITLE
feat(frontend): Task 8.11 FileUpload コンポーネントを追加

### DIFF
--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -116,12 +116,12 @@ DELETE /api/attachments/:id
 
 ### Task 8.11: FileUpload コンポーネント作成
 
-- [ ] 8.11.1: `ng generate component components/file-upload` 実行
-- [ ] 8.11.2: ファイル選択 UI 実装
-- [ ] 8.11.3: ドラッグ&ドロップ実装
-- [ ] 8.11.4: アップロード進捗バー表示
-- [ ] 8.11.5: @Input() todoId: number 実装
-- [ ] 8.11.6: @Output() uploaded 実装
+- [x] 8.11.1: `ng generate component components/file-upload` 実行
+- [x] 8.11.2: ファイル選択 UI 実装
+- [x] 8.11.3: ドラッグ&ドロップ実装
+- [x] 8.11.4: アップロード進捗バー表示
+- [x] 8.11.5: @Input() todoId: number 実装
+- [x] 8.11.6: @Output() uploaded 実装
 
 ### Task 8.12: AttachmentList コンポーネント作成
 

--- a/frontend/src/app/components/file-upload/file-upload.component.html
+++ b/frontend/src/app/components/file-upload/file-upload.component.html
@@ -1,0 +1,41 @@
+<div
+  class="file-upload"
+  [class.dragging]="isDragging"
+  (dragover)="onDragOver($event)"
+  (dragleave)="onDragLeave($event)"
+  (drop)="onDrop($event)"
+>
+  <p class="mb-2">ファイルをドラッグ&ドロップ、または選択してください</p>
+  <input
+    type="file"
+    class="form-control form-control-sm mb-2"
+    [disabled]="uploading"
+    (change)="onFileSelected($event)"
+    accept="image/jpeg,image/png,image/webp,application/pdf"
+  />
+
+  @if (selectedFile) {
+    <p class="small text-muted mb-2">
+      選択中: {{ selectedFile.name }} ({{ selectedFile.size }} bytes)
+    </p>
+  }
+
+  @if (uploading) {
+    <div class="progress mb-2" role="progressbar" [attr.aria-valuenow]="uploadProgress" aria-valuemin="0" aria-valuemax="100">
+      <div class="progress-bar" [style.width.%]="uploadProgress">{{ uploadProgress }}%</div>
+    </div>
+  }
+
+  @if (errorMessage) {
+    <p class="small text-danger mb-2">{{ errorMessage }}</p>
+  }
+
+  <button
+    type="button"
+    class="btn btn-primary btn-sm"
+    [disabled]="!selectedFile || uploading"
+    (click)="startUpload()"
+  >
+    アップロード
+  </button>
+</div>

--- a/frontend/src/app/components/file-upload/file-upload.component.scss
+++ b/frontend/src/app/components/file-upload/file-upload.component.scss
@@ -1,0 +1,11 @@
+.file-upload {
+  border: 2px dashed #ced4da;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background-color: #f8f9fa;
+}
+
+.file-upload.dragging {
+  border-color: #0d6efd;
+  background-color: #e7f1ff;
+}

--- a/frontend/src/app/components/file-upload/file-upload.component.spec.ts
+++ b/frontend/src/app/components/file-upload/file-upload.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FileUploadComponent } from './file-upload.component';
+
+describe('FileUploadComponent', () => {
+  let component: FileUploadComponent;
+  let fixture: ComponentFixture<FileUploadComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FileUploadComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FileUploadComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/file-upload/file-upload.component.spec.ts
+++ b/frontend/src/app/components/file-upload/file-upload.component.spec.ts
@@ -1,23 +1,62 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { FileUploadComponent } from './file-upload.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { of } from 'rxjs'
+import { HttpEventType } from '@angular/common/http'
+import { FileUploadComponent } from './file-upload.component'
+import { AttachmentService } from '../../services/attachment.service'
 
 describe('FileUploadComponent', () => {
-  let component: FileUploadComponent;
-  let fixture: ComponentFixture<FileUploadComponent>;
+  let component: FileUploadComponent
+  let fixture: ComponentFixture<FileUploadComponent>
+  let attachmentServiceSpy: jasmine.SpyObj<AttachmentService>
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [FileUploadComponent]
-    })
-    .compileComponents();
+    attachmentServiceSpy = jasmine.createSpyObj<AttachmentService>('AttachmentService', ['uploadAttachmentWithProgress'])
+    attachmentServiceSpy.uploadAttachmentWithProgress.and.returnValue(of({ type: HttpEventType.Sent }))
 
-    fixture = TestBed.createComponent(FileUploadComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    await TestBed.configureTestingModule({
+      imports: [FileUploadComponent],
+      providers: [{ provide: AttachmentService, useValue: attachmentServiceSpy }]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(FileUploadComponent)
+    component = fixture.componentInstance
+    component.todoId = 1
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+
+  it('onDragOver / onDragLeave で dragging 状態を切り替える', () => {
+    const dragOverEvent = new DragEvent('dragover')
+    const dragLeaveEvent = new DragEvent('dragleave')
+
+    component.onDragOver(dragOverEvent)
+    expect(component.isDragging).toBeTrue()
+
+    component.onDragLeave(dragLeaveEvent)
+    expect(component.isDragging).toBeFalse()
+  })
+
+  it('不正な todoId では uploadAttachmentWithProgress を呼ばない', () => {
+    component.todoId = 0
+    component.selectedFile = new File(['dummy'], 'dummy.png', { type: 'image/png' })
+
+    component.startUpload()
+
+    expect(attachmentServiceSpy.uploadAttachmentWithProgress).not.toHaveBeenCalled()
+    expect(component.errorMessage).toContain('アップロード対象の Todo が不正です。')
+  })
+
+  it('非許可 MIME タイプを選択したときエラーを表示する', () => {
+    const file = new File(['dummy'], 'dummy.txt', { type: 'text/plain' })
+    const input = document.createElement('input')
+    const event = { target: { ...input, files: [file] } } as unknown as Event
+
+    component.onFileSelected(event)
+
+    expect(component.selectedFile).toBeNull()
+    expect(component.errorMessage).toContain('許可されていないファイル形式')
+  })
+})

--- a/frontend/src/app/components/file-upload/file-upload.component.ts
+++ b/frontend/src/app/components/file-upload/file-upload.component.ts
@@ -1,0 +1,99 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { HttpEventType } from '@angular/common/http'
+import { Subscription } from 'rxjs'
+import { AttachmentService } from '../../services/attachment.service'
+import type { Attachment } from '../../models/attachment.interface'
+
+@Component({
+  selector: 'app-file-upload',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './file-upload.component.html',
+  styleUrl: './file-upload.component.scss'
+})
+export class FileUploadComponent implements OnDestroy {
+  @Input() todoId!: number
+  @Output() uploaded = new EventEmitter<Attachment>()
+
+  selectedFile: File | null = null
+  isDragging = false
+  uploading = false
+  uploadProgress = 0
+  errorMessage = ''
+
+  private uploadSub: Subscription | null = null
+
+  constructor(private attachmentService: AttachmentService) {}
+
+  ngOnDestroy(): void {
+    this.uploadSub?.unsubscribe()
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement
+    const file = input.files?.[0] ?? null
+    this.handleSelectedFile(file)
+    input.value = ''
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault()
+    this.isDragging = true
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault()
+    this.isDragging = false
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault()
+    this.isDragging = false
+    const file = event.dataTransfer?.files?.[0] ?? null
+    this.handleSelectedFile(file)
+  }
+
+  startUpload(): void {
+    if (!this.selectedFile || this.uploading) return
+    if (!Number.isInteger(this.todoId) || this.todoId <= 0) {
+      this.errorMessage = 'アップロード対象の Todo が不正です。'
+      return
+    }
+
+    this.uploading = true
+    this.uploadProgress = 0
+    this.errorMessage = ''
+    this.uploadSub?.unsubscribe()
+    this.uploadSub = this.attachmentService
+      .uploadAttachmentWithProgress(this.todoId, this.selectedFile)
+      .subscribe({
+        next: (event) => {
+          if (event.type === HttpEventType.UploadProgress) {
+            const total = event.total ?? this.selectedFile?.size ?? 0
+            if (total > 0) {
+              this.uploadProgress = Math.round((event.loaded / total) * 100)
+            }
+            return
+          }
+          if (event.type === HttpEventType.Response && event.body) {
+            this.uploading = false
+            this.uploadProgress = 100
+            this.selectedFile = null
+            this.uploaded.emit(event.body)
+          }
+        },
+        error: (err) => {
+          this.uploading = false
+          this.uploadProgress = 0
+          this.errorMessage = err?.error?.error ?? 'ファイルのアップロードに失敗しました。'
+        }
+      })
+  }
+
+  private handleSelectedFile(file: File | null): void {
+    this.selectedFile = file
+    this.errorMessage = ''
+    this.uploadProgress = 0
+  }
+}

--- a/frontend/src/app/components/file-upload/file-upload.component.ts
+++ b/frontend/src/app/components/file-upload/file-upload.component.ts
@@ -13,6 +13,8 @@ import type { Attachment } from '../../models/attachment.interface'
   styleUrl: './file-upload.component.scss'
 })
 export class FileUploadComponent implements OnDestroy {
+  private readonly allowedMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf']
+
   @Input() todoId!: number
   @Output() uploaded = new EventEmitter<Attachment>()
 
@@ -92,6 +94,12 @@ export class FileUploadComponent implements OnDestroy {
   }
 
   private handleSelectedFile(file: File | null): void {
+    if (file && !this.allowedMimeTypes.includes(file.type)) {
+      this.selectedFile = null
+      this.errorMessage = '許可されていないファイル形式です（JPEG / PNG / WebP / PDF）。'
+      this.uploadProgress = 0
+      return
+    }
     this.selectedFile = file
     this.errorMessage = ''
     this.uploadProgress = 0


### PR DESCRIPTION
## Summary
- `ng generate component components/file-upload` を実行し、FileUpload コンポーネントを追加
- ファイル選択 UI、ドラッグ&ドロップ、アップロード進捗バー表示を実装
- `@Input() todoId` と `@Output() uploaded` を実装し、AttachmentService と連携
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.11.1〜8.11.6 を完了に更新

## Test plan
- [x] `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)