### PR TITLE
feat(frontend): Task 8.12 AttachmentList コンポーネントを追加

### DIFF
--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -125,12 +125,12 @@ DELETE /api/attachments/:id
 
 ### Task 8.12: AttachmentList コンポーネント作成
 
-- [ ] 8.12.1: `ng generate component components/attachment-list` 実行
-- [ ] 8.12.2: 添付ファイル一覧表示
-- [ ] 8.12.3: ファイルアイコン表示（MIME タイプ別）
-- [ ] 8.12.4: ダウンロードボタン実装
-- [ ] 8.12.5: 削除ボタン実装
-- [ ] 8.12.6: @Input() todoId: number 実装
+- [x] 8.12.1: `ng generate component components/attachment-list` 実行
+- [x] 8.12.2: 添付ファイル一覧表示
+- [x] 8.12.3: ファイルアイコン表示（MIME タイプ別）
+- [x] 8.12.4: ダウンロードボタン実装
+- [x] 8.12.5: 削除ボタン実装
+- [x] 8.12.6: @Input() todoId: number 実装
 
 ### Task 8.13: TodoDetail に添付ファイル機能追加
 

--- a/frontend/src/app/components/attachment-list/attachment-list.component.html
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.html
@@ -1,0 +1,46 @@
+<div class="attachment-list">
+  @if (loading) {
+    <p class="small text-muted mb-2">添付ファイルを読み込み中...</p>
+  }
+
+  @if (errorMessage) {
+    <p class="small text-danger mb-2">{{ errorMessage }}</p>
+  }
+
+  @if (!loading && attachments.length === 0) {
+    <p class="small text-muted mb-0">添付ファイルはありません。</p>
+  }
+
+  @if (attachments.length > 0) {
+    <ul class="list-group">
+      @for (attachment of attachments; track attachment.id) {
+        <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
+          <div class="d-flex align-items-center gap-2 text-break">
+            <i [class]="getFileIcon(attachment.mimeType)"></i>
+            <div>
+              <div class="fw-semibold">{{ attachment.fileName }}</div>
+              <small class="text-muted">{{ attachment.fileSize }} bytes</small>
+            </div>
+          </div>
+          <div class="d-flex gap-2">
+            <button
+              type="button"
+              class="btn btn-outline-secondary btn-sm"
+              (click)="download(attachment)"
+            >
+              ダウンロード
+            </button>
+            <button
+              type="button"
+              class="btn btn-outline-danger btn-sm"
+              [disabled]="deletingIds.has(attachment.id)"
+              (click)="remove(attachment)"
+            >
+              削除
+            </button>
+          </div>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/frontend/src/app/components/attachment-list/attachment-list.component.scss
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.scss
@@ -1,0 +1,10 @@
+.attachment-list {
+  .list-group-item {
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  i {
+    font-size: 1.1rem;
+  }
+}

--- a/frontend/src/app/components/attachment-list/attachment-list.component.spec.ts
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AttachmentListComponent } from './attachment-list.component';
+
+describe('AttachmentListComponent', () => {
+  let component: AttachmentListComponent;
+  let fixture: ComponentFixture<AttachmentListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AttachmentListComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AttachmentListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/attachment-list/attachment-list.component.spec.ts
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.spec.ts
@@ -1,23 +1,79 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { AttachmentListComponent } from './attachment-list.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { of } from 'rxjs'
+import type { Attachment } from '../../models/attachment.interface'
+import { AttachmentListComponent } from './attachment-list.component'
+import { AttachmentService } from '../../services/attachment.service'
 
 describe('AttachmentListComponent', () => {
-  let component: AttachmentListComponent;
-  let fixture: ComponentFixture<AttachmentListComponent>;
+  let component: AttachmentListComponent
+  let fixture: ComponentFixture<AttachmentListComponent>
+  let attachmentServiceSpy: jasmine.SpyObj<AttachmentService>
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AttachmentListComponent]
-    })
-    .compileComponents();
+    attachmentServiceSpy = jasmine.createSpyObj<AttachmentService>('AttachmentService', [
+      'getAttachments',
+      'deleteAttachment',
+      'downloadAttachment'
+    ])
+    attachmentServiceSpy.getAttachments.and.returnValue(of([]))
+    attachmentServiceSpy.deleteAttachment.and.returnValue(of(void 0))
+    attachmentServiceSpy.downloadAttachment.and.returnValue(of(new Blob()))
 
-    fixture = TestBed.createComponent(AttachmentListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    await TestBed.configureTestingModule({
+      imports: [AttachmentListComponent],
+      providers: [{ provide: AttachmentService, useValue: attachmentServiceSpy }]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(AttachmentListComponent)
+    component = fixture.componentInstance
+    component.todoId = 1
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+
+  it('todoId が有効なとき ngOnChanges で getAttachments を呼ぶ', () => {
+    component.todoId = 10
+    component.ngOnChanges({
+      todoId: {
+        currentValue: 10,
+        previousValue: 1,
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    })
+
+    expect(attachmentServiceSpy.getAttachments).toHaveBeenCalledWith(10)
+  })
+
+  it('添付が0件のとき空状態メッセージを表示する', () => {
+    component.loading = false
+    component.attachments = []
+    fixture.detectChanges()
+
+    expect(fixture.nativeElement.textContent).toContain('添付ファイルはありません。')
+  })
+
+  it('remove が deleteAttachment を呼ぶ', () => {
+    const item: Attachment = {
+      id: 7,
+      todoId: 1,
+      fileName: 'a.pdf',
+      fileSize: 100,
+      mimeType: 'application/pdf',
+      fileUrl: '/uploads/1/a.pdf',
+      createdAt: '2026-01-01T00:00:00.000Z'
+    }
+    component.attachments = [item]
+
+    component.remove(item)
+
+    expect(attachmentServiceSpy.deleteAttachment).toHaveBeenCalledWith(7)
+  })
+
+  it('未知の MIME タイプは汎用アイコンを返す', () => {
+    expect(component.getFileIcon('application/octet-stream')).toBe('bi bi-file-earmark')
+  })
+})

--- a/frontend/src/app/components/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.ts
@@ -1,0 +1,106 @@
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { HttpClient } from '@angular/common/http'
+import { Subscription } from 'rxjs'
+import { AttachmentService } from '../../services/attachment.service'
+import type { Attachment } from '../../models/attachment.interface'
+import { environment } from '../../../environments/environment'
+
+@Component({
+  selector: 'app-attachment-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './attachment-list.component.html',
+  styleUrl: './attachment-list.component.scss'
+})
+export class AttachmentListComponent implements OnChanges, OnDestroy {
+  @Input() todoId!: number
+
+  attachments: Attachment[] = []
+  loading = false
+  errorMessage = ''
+  deletingIds = new Set<number>()
+
+  private readonly apiOrigin = new URL(environment.apiUrl).origin
+  private listSub: Subscription | null = null
+  private downloadSub: Subscription | null = null
+
+  constructor(
+    private attachmentService: AttachmentService,
+    private http: HttpClient
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('todoId' in changes) {
+      this.loadAttachments()
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.listSub?.unsubscribe()
+    this.downloadSub?.unsubscribe()
+  }
+
+  getFileIcon(mimeType: string): string {
+    if (mimeType.startsWith('image/')) return 'bi bi-image'
+    if (mimeType === 'application/pdf') return 'bi bi-file-earmark-pdf'
+    return 'bi bi-file-earmark'
+  }
+
+  download(attachment: Attachment): void {
+    const fileUrl = this.resolveAbsoluteFileUrl(attachment.fileUrl)
+    this.downloadSub?.unsubscribe()
+    this.downloadSub = this.http.get(fileUrl, { responseType: 'blob' }).subscribe({
+      next: (blob) => {
+        const objectUrl = URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = objectUrl
+        link.download = attachment.fileName
+        link.click()
+        URL.revokeObjectURL(objectUrl)
+      },
+      error: (err) => {
+        this.errorMessage = err?.error?.error ?? 'ダウンロードに失敗しました。'
+      }
+    })
+  }
+
+  remove(attachment: Attachment): void {
+    if (this.deletingIds.has(attachment.id)) return
+    this.deletingIds.add(attachment.id)
+    this.attachmentService.deleteAttachment(attachment.id).subscribe({
+      next: () => {
+        this.attachments = this.attachments.filter((item) => item.id !== attachment.id)
+        this.deletingIds.delete(attachment.id)
+      },
+      error: (err) => {
+        this.errorMessage = err?.error?.error ?? '削除に失敗しました。'
+        this.deletingIds.delete(attachment.id)
+      }
+    })
+  }
+
+  private loadAttachments(): void {
+    if (!Number.isInteger(this.todoId) || this.todoId <= 0) return
+
+    this.loading = true
+    this.errorMessage = ''
+    this.listSub?.unsubscribe()
+    this.listSub = this.attachmentService.getAttachments(this.todoId).subscribe({
+      next: (list) => {
+        this.attachments = list
+        this.loading = false
+      },
+      error: (err) => {
+        this.errorMessage = err?.error?.error ?? '添付ファイル一覧の取得に失敗しました。'
+        this.loading = false
+      }
+    })
+  }
+
+  private resolveAbsoluteFileUrl(fileUrl: string): string {
+    if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) return fileUrl
+    if (fileUrl.startsWith('/')) return `${this.apiOrigin}${fileUrl}`
+    return `${this.apiOrigin}/${fileUrl}`
+  }
+}

--- a/frontend/src/app/components/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core'
 import { CommonModule } from '@angular/common'
-import { HttpClient } from '@angular/common/http'
 import { Subscription } from 'rxjs'
 import { AttachmentService } from '../../services/attachment.service'
 import type { Attachment } from '../../models/attachment.interface'
@@ -24,11 +23,9 @@ export class AttachmentListComponent implements OnChanges, OnDestroy {
   private readonly apiOrigin = new URL(environment.apiUrl).origin
   private listSub: Subscription | null = null
   private downloadSub: Subscription | null = null
+  private removeSub: Subscription | null = null
 
-  constructor(
-    private attachmentService: AttachmentService,
-    private http: HttpClient
-  ) {}
+  constructor(private attachmentService: AttachmentService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if ('todoId' in changes) {
@@ -39,6 +36,7 @@ export class AttachmentListComponent implements OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.listSub?.unsubscribe()
     this.downloadSub?.unsubscribe()
+    this.removeSub?.unsubscribe()
   }
 
   getFileIcon(mimeType: string): string {
@@ -50,7 +48,7 @@ export class AttachmentListComponent implements OnChanges, OnDestroy {
   download(attachment: Attachment): void {
     const fileUrl = this.resolveAbsoluteFileUrl(attachment.fileUrl)
     this.downloadSub?.unsubscribe()
-    this.downloadSub = this.http.get(fileUrl, { responseType: 'blob' }).subscribe({
+    this.downloadSub = this.attachmentService.downloadAttachment(fileUrl).subscribe({
       next: (blob) => {
         const objectUrl = URL.createObjectURL(blob)
         const link = document.createElement('a')
@@ -68,7 +66,8 @@ export class AttachmentListComponent implements OnChanges, OnDestroy {
   remove(attachment: Attachment): void {
     if (this.deletingIds.has(attachment.id)) return
     this.deletingIds.add(attachment.id)
-    this.attachmentService.deleteAttachment(attachment.id).subscribe({
+    this.removeSub?.unsubscribe()
+    this.removeSub = this.attachmentService.deleteAttachment(attachment.id).subscribe({
       next: () => {
         this.attachments = this.attachments.filter((item) => item.id !== attachment.id)
         this.deletingIds.delete(attachment.id)

--- a/frontend/src/app/services/attachment.service.ts
+++ b/frontend/src/app/services/attachment.service.ts
@@ -38,6 +38,10 @@ export class AttachmentService {
     return this.http.get<Attachment[]>(`${this.apiUrl}/todos/${todoId}/attachments`)
   }
 
+  downloadAttachment(fileUrl: string): Observable<Blob> {
+    return this.http.get(fileUrl, { responseType: 'blob' })
+  }
+
   deleteAttachment(id: number): Observable<void> {
     return this.http.delete<void>(`${this.apiUrl}/attachments/${id}`)
   }


### PR DESCRIPTION
## Summary
- `ng generate component components/attachment-list` を実行し、AttachmentList コンポーネントを追加
- `todoId` 入力で添付一覧を取得し、MIME別アイコンで表示
- ダウンロードボタンと削除ボタンを実装（削除中状態を管理）
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.12.1〜8.12.6 を完了に更新

## Test plan
- [x] `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)