### PR TITLE
feat(frontend): TodoDetailに添付ファイルUIを統合

### DIFF
--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -134,8 +134,8 @@ DELETE /api/attachments/:id
 
 ### Task 8.13: TodoDetail に添付ファイル機能追加
 
-- [ ] 8.13.1: FileUpload コンポーネント追加
-- [ ] 8.13.2: AttachmentList コンポーネント追加
+- [x] 8.13.1: FileUpload コンポーネント追加
+- [x] 8.13.2: AttachmentList コンポーネント追加
 
 ### Task 8.14: スタイリング
 

--- a/frontend/src/app/components/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.ts
@@ -14,6 +14,7 @@ import { environment } from '../../../environments/environment'
 })
 export class AttachmentListComponent implements OnChanges, OnDestroy {
   @Input() todoId!: number
+  @Input() refreshToken = 0
 
   attachments: Attachment[] = []
   loading = false
@@ -28,7 +29,7 @@ export class AttachmentListComponent implements OnChanges, OnDestroy {
   constructor(private attachmentService: AttachmentService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if ('todoId' in changes) {
+    if ('todoId' in changes || 'refreshToken' in changes) {
       this.loadAttachments()
     }
   }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.html
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.html
@@ -29,6 +29,18 @@
           </div>
 
           <app-subtask-list [parentId]="todo.id" (subtasksUpdated)="onSubtasksUpdated($event)"></app-subtask-list>
+
+          <hr class="my-4" />
+
+          <section class="mb-3">
+            <h4 class="h6 mb-2">添付ファイルを追加</h4>
+            <app-file-upload [todoId]="todo.id" (uploaded)="onAttachmentUploaded()"></app-file-upload>
+          </section>
+
+          <section>
+            <h4 class="h6 mb-2">添付ファイル一覧</h4>
+            <app-attachment-list [todoId]="todo.id" [refreshToken]="attachmentRefreshToken"></app-attachment-list>
+          </section>
         </div>
       </div>
     }

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts
@@ -75,5 +75,11 @@ describe('TodoDetailPageComponent (5.13)', () => {
     ])
     expect(component.todo.progress).toEqual({ completed: 1, total: 2 })
   })
+
+  it('should increase attachment refresh token when upload completes', () => {
+    expect(component.attachmentRefreshToken).toBe(0)
+    component.onAttachmentUploaded()
+    expect(component.attachmentRefreshToken).toBe(1)
+  })
 })
 

--- a/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.ts
+++ b/frontend/src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.ts
@@ -6,11 +6,20 @@ import type { Todo } from '../../../../../models/todo.interface'
 import { TodoService } from '../../../../../services/todo.service'
 import { ProgressBarComponent } from '../../../../progress-bar/progress-bar.component'
 import SubtaskListComponent from '../../../../subtask-list/subtask-list.component'
+import { FileUploadComponent } from '../../../../file-upload/file-upload.component'
+import { AttachmentListComponent } from '../../../../attachment-list/attachment-list.component'
 
 @Component({
   selector: 'app-todo-detail-page',
   standalone: true,
-  imports: [CommonModule, RouterLink, ProgressBarComponent, SubtaskListComponent],
+  imports: [
+    CommonModule,
+    RouterLink,
+    ProgressBarComponent,
+    SubtaskListComponent,
+    FileUploadComponent,
+    AttachmentListComponent
+  ],
   templateUrl: './todo-detail-page.component.html',
   styleUrl: './todo-detail-page.component.scss'
 })
@@ -18,6 +27,7 @@ export default class TodoDetailPageComponent implements OnInit, OnDestroy {
   todo: Todo | null = null
   loading = false
   error: string | null = null
+  attachmentRefreshToken = 0
   private destroy$ = new Subject<void>()
 
   constructor(
@@ -47,6 +57,10 @@ export default class TodoDetailPageComponent implements OnInit, OnDestroy {
       subtasks,
       progress: { completed, total: subtasks.length }
     }
+  }
+
+  onAttachmentUploaded(): void {
+    this.attachmentRefreshToken += 1
   }
 
   private loadTodo(id: number): void {


### PR DESCRIPTION
## Summary
- Todo詳細画面に `FileUpload` と `AttachmentList` を組み込み、添付追加と一覧確認を同一画面で完結できるようにしました。
- アップロード完了イベントで一覧を再読込するため、`AttachmentList` に `refreshToken` 入力を追加しました。
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.13 チェックを完了状態に更新しました。

## Test plan
- [x] `docker compose run --rm frontend ng build`
- [x] `docker compose run --rm frontend ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include="src/app/components/pages/dashboard/todo/todo-detail-page/todo-detail-page.component.spec.ts" --include="src/app/components/attachment-list/attachment-list.component.spec.ts"`

Made with [Cursor](https://cursor.com)