### PR TITLE
test(frontend): 添付機能の単体テストを追加

### DIFF
--- a/docs/TODO_FEATURE_08_ATTACHMENTS.md
+++ b/docs/TODO_FEATURE_08_ATTACHMENTS.md
@@ -145,9 +145,9 @@ DELETE /api/attachments/:id
 
 ### Task 8.15: Frontend テスト
 
-- [ ] 8.15.1: AttachmentService のテスト
-- [ ] 8.15.2: FileUpload コンポーネントテスト
-- [ ] 8.15.3: AttachmentList コンポーネントテスト
+- [x] 8.15.1: AttachmentService のテスト
+- [x] 8.15.2: FileUpload コンポーネントテスト
+- [x] 8.15.3: AttachmentList コンポーネントテスト
 
 ---
 

--- a/frontend/src/app/components/attachment-list/attachment-list.component.spec.ts
+++ b/frontend/src/app/components/attachment-list/attachment-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import type { Attachment } from '../../models/attachment.interface'
 import { AttachmentListComponent } from './attachment-list.component'
 import { AttachmentService } from '../../services/attachment.service'
@@ -75,5 +75,39 @@ describe('AttachmentListComponent', () => {
 
   it('未知の MIME タイプは汎用アイコンを返す', () => {
     expect(component.getFileIcon('application/octet-stream')).toBe('bi bi-file-earmark')
+  })
+
+  it('refreshToken の変更でも getAttachments を再取得する', () => {
+    component.ngOnChanges({
+      refreshToken: {
+        currentValue: 1,
+        previousValue: 0,
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    })
+
+    expect(attachmentServiceSpy.getAttachments).toHaveBeenCalled()
+  })
+
+  it('remove エラー時にエラーメッセージを設定する', () => {
+    const item: Attachment = {
+      id: 8,
+      todoId: 1,
+      fileName: 'a.pdf',
+      fileSize: 100,
+      mimeType: 'application/pdf',
+      fileUrl: '/uploads/1/a.pdf',
+      createdAt: '2026-01-01T00:00:00.000Z'
+    }
+    attachmentServiceSpy.deleteAttachment.and.returnValue(
+      throwError(() => ({ error: { error: '削除失敗' } }))
+    )
+    component.attachments = [item]
+
+    component.remove(item)
+
+    expect(component.errorMessage).toBe('削除失敗')
+    expect(component.deletingIds.has(item.id)).toBeFalse()
   })
 })

--- a/frontend/src/app/components/file-upload/file-upload.component.spec.ts
+++ b/frontend/src/app/components/file-upload/file-upload.component.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { of } from 'rxjs'
-import { HttpEventType } from '@angular/common/http'
+import { HttpEvent, HttpEventType, HttpResponse } from '@angular/common/http'
 import { FileUploadComponent } from './file-upload.component'
 import { AttachmentService } from '../../services/attachment.service'
+import type { Attachment } from '../../models/attachment.interface'
 
 describe('FileUploadComponent', () => {
   let component: FileUploadComponent
@@ -58,5 +59,29 @@ describe('FileUploadComponent', () => {
 
     expect(component.selectedFile).toBeNull()
     expect(component.errorMessage).toContain('許可されていないファイル形式')
+  })
+
+  it('アップロード成功時に uploaded を emit する', () => {
+    const responseBody: Attachment = {
+      id: 11,
+      todoId: 1,
+      fileName: 'ok.png',
+      fileSize: 10,
+      mimeType: 'image/png',
+      fileUrl: '/uploads/1/ok.png',
+      createdAt: '2026-01-01T00:00:00.000Z'
+    }
+    const progressEvent = { type: HttpEventType.UploadProgress, loaded: 5, total: 10 } as HttpEvent<Attachment>
+    const responseEvent = new HttpResponse<Attachment>({ body: responseBody })
+    attachmentServiceSpy.uploadAttachmentWithProgress.and.returnValue(of(progressEvent, responseEvent))
+    const emitSpy = spyOn(component.uploaded, 'emit')
+    component.selectedFile = new File(['dummy'], 'ok.png', { type: 'image/png' })
+
+    component.startUpload()
+
+    expect(component.uploadProgress).toBe(100)
+    expect(component.uploading).toBeFalse()
+    expect(component.selectedFile).toBeNull()
+    expect(emitSpy).toHaveBeenCalledWith(responseBody)
   })
 })

--- a/frontend/src/app/services/attachment.service.spec.ts
+++ b/frontend/src/app/services/attachment.service.spec.ts
@@ -1,0 +1,86 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { HttpEventType } from '@angular/common/http'
+import { environment } from '../../environments/environment'
+import { AttachmentService } from './attachment.service'
+import type { Attachment } from '../models/attachment.interface'
+
+describe('AttachmentService (8.15.1)', () => {
+  let service: AttachmentService
+  let httpMock: HttpTestingController
+  const apiUrl = environment.apiUrl
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AttachmentService]
+    })
+    service = TestBed.inject(AttachmentService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  it('getAttachments should GET /todos/:id/attachments', () => {
+    const todoId = 3
+    const mock: Attachment[] = []
+    service.getAttachments(todoId).subscribe((list) => expect(list).toEqual(mock))
+    const req = httpMock.expectOne(`${apiUrl}/todos/${todoId}/attachments`)
+    expect(req.request.method).toBe('GET')
+    req.flush(mock)
+  })
+
+  it('deleteAttachment should DELETE /attachments/:id', () => {
+    service.deleteAttachment(9).subscribe(() => undefined)
+    const req = httpMock.expectOne(`${apiUrl}/attachments/9`)
+    expect(req.request.method).toBe('DELETE')
+    req.flush(null, { status: 204, statusText: 'No Content' })
+  })
+
+  it('uploadAttachmentWithProgress should POST multipart as events', () => {
+    const file = new File(['dummy'], 'a.png', { type: 'image/png' })
+    const todoId = 8
+    service.uploadAttachmentWithProgress(todoId, file).subscribe()
+
+    const req = httpMock.expectOne(`${apiUrl}/todos/${todoId}/attachments`)
+    expect(req.request.method).toBe('POST')
+    expect(req.request.reportProgress).toBeTrue()
+    expect(req.request.responseType).toBe('json')
+    expect(req.request.body instanceof FormData).toBeTrue()
+    req.event({ type: HttpEventType.UploadProgress, loaded: 1, total: 1 })
+    req.flush({} as Attachment)
+  })
+
+  it('uploadAttachment should map response body', () => {
+    const file = new File(['dummy'], 'a.png', { type: 'image/png' })
+    const todoId = 2
+    const mock: Attachment = {
+      id: 1,
+      todoId,
+      fileName: 'a.png',
+      fileSize: 1,
+      mimeType: 'image/png',
+      fileUrl: '/uploads/1/a.png',
+      createdAt: '2026-01-01T00:00:00.000Z'
+    }
+
+    service.uploadAttachment(todoId, file).subscribe((res) => expect(res).toEqual(mock))
+    const req = httpMock.expectOne(`${apiUrl}/todos/${todoId}/attachments`)
+    req.flush(mock)
+  })
+
+  it('downloadAttachment should GET blob URL', () => {
+    const targetUrl = 'https://example.test/uploads/a.png'
+    service.downloadAttachment(targetUrl).subscribe()
+    const req = httpMock.expectOne(targetUrl)
+    expect(req.request.method).toBe('GET')
+    expect(req.request.responseType).toBe('blob')
+    req.flush(new Blob())
+  })
+})


### PR DESCRIPTION
## Summary
- `AttachmentService` の単体テストを新規作成し、upload/get/download/delete のHTTP呼び出しを検証しました。
- `FileUploadComponent` テストにアップロード成功時の `uploaded` emit 検証を追加しました。
- `AttachmentListComponent` テストに `refreshToken` 再取得と削除失敗時のエラーハンドリング検証を追加しました。
- `docs/TODO_FEATURE_08_ATTACHMENTS.md` の Task 8.15 を完了状態に更新しました。

## Test plan
- [x] `docker compose run --rm frontend ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include="src/app/services/attachment.service.spec.ts" --include="src/app/components/file-upload/file-upload.component.spec.ts" --include="src/app/components/attachment-list/attachment-list.component.spec.ts"`
- [x] `docker compose run --rm frontend ng build`

Made with [Cursor](https://cursor.com)